### PR TITLE
Raise an error on topology change in multi-shard commands

### DIFF
--- a/src/fanout/cluster_map.rs
+++ b/src/fanout/cluster_map.rs
@@ -623,7 +623,10 @@ impl ClusterMap {
     /// when invoked without a real client context (e.g. from a background
     /// thread or the cluster-message callback). Parsing `CLUSTER NODES` lets us
     /// refresh the map safely from any context that holds the module lock.
-    pub fn create(ctx: &Context) -> Self {
+    /// Returns `None` when the `CLUSTER NODES` call fails to produce a usable
+    /// reply, so callers can distinguish a build failure from a successfully
+    /// built (possibly inconsistent) map and avoid clobbering a good map.
+    pub fn create(ctx: &Context) -> Option<Self> {
         let call_options = CallOptionsBuilder::new().errors_as_replies().build();
 
         log_notice("Calling CLUSTER NODES...");
@@ -632,13 +635,13 @@ impl ClusterMap {
 
         let Some(text) = reply_as_string(res) else {
             log_warning("CLUSTER NODES did not return a usable string reply");
-            return Self::default();
+            return None;
         };
 
         let my_node_id = *CURRENT_NODE_ID;
         debug_assert!(!my_node_id.is_empty(), "Current node id is empty");
 
-        Self::from_cluster_nodes(&text, &my_node_id)
+        Some(Self::from_cluster_nodes(&text, &my_node_id))
     }
 
     /// Build a ClusterMap from the raw text of a `CLUSTER NODES` reply.

--- a/src/fanout/cluster_map.rs
+++ b/src/fanout/cluster_map.rs
@@ -6,16 +6,15 @@ use range_set_blaze::{RangeMapBlaze, RangeSetBlaze, RangesIter};
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
-use std::ffi::c_char;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::hash::{DefaultHasher, Hash, Hasher};
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::{Arc, LazyLock, OnceLock};
 use valkey_module::logging::{log_notice, log_warning};
 use valkey_module::{
-    CallOptionResp, CallOptionsBuilder, CallReply, CallResult, Context, VALKEYMODULE_NODE_ID_LEN,
-    ValkeyError, ValkeyModule_GetMyClusterID,
+    CallOptionsBuilder, CallReply, CallResult, Context, VALKEYMODULE_NODE_ID_LEN,
+    ValkeyModule_GetMyClusterID,
 };
 
 // Constants
@@ -615,80 +614,175 @@ impl ClusterMap {
             .clone()
     }
 
-    /// Build a new ClusterMap by calling CLUSTER SLOTS through the provided API
-    /// implementation. Returns a ClusterMap on success, or a `ValkeyError`
-    /// describing why the map could not be built. Callers are expected to
-    /// handle the error gracefully (e.g. keep the previous, possibly stale map)
-    /// rather than crash the module thread.
-    pub fn create(ctx: &Context) -> Result<Self, ValkeyError> {
+    /// Build a new ClusterMap from `CLUSTER NODES`.
+    ///
+    /// `CLUSTER NODES` is used in preference to `CLUSTER SLOTS` because its reply
+    /// is generated from the node's own gossip view and does not consult the
+    /// calling client's connection. `CLUSTER SLOTS` resolves each node's
+    /// preferred endpoint against the current client, which crashes the server
+    /// when invoked without a real client context (e.g. from a background
+    /// thread or the cluster-message callback). Parsing `CLUSTER NODES` lets us
+    /// refresh the map safely from any context that holds the module lock.
+    pub fn create(ctx: &Context) -> Self {
+        let call_options = CallOptionsBuilder::new().errors_as_replies().build();
+
+        log_notice("Calling CLUSTER NODES...");
+
+        let res: CallResult = ctx.call_ext::<_, CallResult>("CLUSTER", &call_options, &["NODES"]);
+
+        let Some(text) = reply_as_string(res) else {
+            log_warning("CLUSTER NODES did not return a usable string reply");
+            return Self::default();
+        };
+
+        let my_node_id = *CURRENT_NODE_ID;
+        debug_assert!(!my_node_id.is_empty(), "Current node id is empty");
+
+        Self::from_cluster_nodes(&text, &my_node_id)
+    }
+
+    /// Build a ClusterMap from the raw text of a `CLUSTER NODES` reply.
+    ///
+    /// Pure and self-contained so it can be unit-tested without a running
+    /// server. Each line has the form:
+    /// `<id> <ip:port@cport[,aux...]> <flags> <master> <ping> <pong> <epoch> <link> <slot...>`
+    pub(super) fn from_cluster_nodes(text: &str, my_node_id: &NodeId) -> Self {
         let mut new_map = ClusterMap {
             is_consistent: true,
             ..Default::default()
         };
 
-        // Call CLUSTER NODES from Valkey Module API
-        let call_options = CallOptionsBuilder::new()
-            .resp(CallOptionResp::Resp3)
-            .errors_as_replies()
-            .build();
-
-        log_notice("Calling CLUSTER SLOTS...");
-
-        let res: CallResult = ctx.call_ext::<_, CallResult>("CLUSTER", &call_options, &["SLOTS"]);
-
-        let reply = match res {
-            Err(e) => {
-                return Err(ValkeyError::String(format!(
-                    "Error calling CLUSTER SLOTS: {e}"
-                )));
-            }
-            Ok(CallReply::Array(arr)) => arr,
-            _ => {
-                return Err(ValkeyError::Str("CLUSTER SLOTS did not return an array"));
-            }
-        };
-
-        let my_node_id = *CURRENT_NODE_ID;
-
-        if my_node_id.is_empty() {
-            return Err(ValkeyError::Str("Current node id is empty"));
-        }
-
-        let mut socket_addr_to_node_map: AHashMap<SocketAddress, NodeId> =
-            AHashMap::with_capacity(reply.len() / 2 + 1);
-        let mut shard_map: AHashMap<NodeId, ShardInfo> =
-            AHashMap::with_capacity(reply.len() / 2 + 1);
-        let mut slot_ranges_parsed = Vec::new();
-
-        for slot_range in reply.iter().flatten() {
-            if !new_map.process_slot_range(
-                slot_range,
-                &my_node_id,
-                &mut slot_ranges_parsed,
-                &mut shard_map,
-                &mut socket_addr_to_node_map,
-            ) {
-                // dropped range; continue
-                log_warning("cluster-map: dropping slot range..");
+        // Parse every line first so masters and replicas can be assembled in
+        // two passes regardless of the order they appear.
+        let mut records: Vec<ParsedNodeLine> = Vec::new();
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() {
                 continue;
             }
+            match parse_node_line(line, my_node_id) {
+                Some(rec) => records.push(rec),
+                None => {
+                    log_warning("cluster-map: dropping unparseable CLUSTER NODES line");
+                    new_map.is_consistent = false;
+                }
+            }
         }
 
-        let mut shard_set: BTreeSet<ShardInfo> = BTreeSet::new();
+        // Detect socket-address collisions across distinct node ids.
+        let mut socket_addr_to_node: AHashMap<SocketAddress, NodeId> =
+            AHashMap::with_capacity(records.len());
+        for rec in records.iter() {
+            let Some(addr) = rec.socket_address else {
+                continue;
+            };
+            match socket_addr_to_node.get(&addr) {
+                Some(existing) if *existing != rec.id => {
+                    let msg = format!("Socket address collision at {addr} for node {}", rec.id);
+                    log_warning(&msg);
+                    new_map.is_consistent = false;
+                }
+                Some(_) => {}
+                None => {
+                    socket_addr_to_node.insert(addr, rec.id);
+                }
+            }
+        }
 
-        // Fix shard id references on nodes (back-pointers)
-        for (_, shard) in shard_map.into_iter() {
-            let mut shard = shard;
+        let mut shard_map: AHashMap<NodeId, ShardInfo> = AHashMap::with_capacity(records.len());
+        let mut slot_ranges_parsed: Vec<SlotRangeInfo> = Vec::new();
+        // The shard id (master node id) whose primary or a replica is the local node.
+        let mut local_shard_id: Option<NodeId> = None;
+
+        // Pass 1: masters become shards.
+        for rec in records.iter() {
+            if !rec.is_master {
+                continue;
+            }
+            let Some(socket_address) = rec.socket_address else {
+                // A master with no usable address cannot serve; if it owns slots
+                // the map is not trustworthy.
+                if !rec.slot_ranges.is_empty() {
+                    new_map.is_consistent = false;
+                }
+                continue;
+            };
+
+            let primary = NodeInfo {
+                id: rec.id,
+                shard_id: rec.id,
+                socket_address,
+                role: NodeRole::Primary,
+                location: rec.location(),
+            };
+
+            let shard = shard_map.entry(rec.id).or_insert_with(|| ShardInfo {
+                id: rec.id,
+                ..Default::default()
+            });
+            shard.primary = Some(primary);
+            if rec.is_local {
+                shard.is_local = true;
+                local_shard_id = Some(rec.id);
+            }
+
+            for &(start, end) in rec.slot_ranges.iter() {
+                if start > end || end >= NUM_SLOTS {
+                    new_map.is_consistent = false;
+                    continue;
+                }
+                shard.owned_slots.insert_range(start, end);
+                slot_ranges_parsed.push(SlotRangeInfo {
+                    start_slot: start,
+                    end_slot: end,
+                    shard_id: rec.id,
+                });
+            }
+        }
+
+        // Pass 2: attach replicas to their master's shard.
+        for rec in records.iter() {
+            if rec.is_master || !rec.has_master {
+                continue;
+            }
+            let Some(socket_address) = rec.socket_address else {
+                continue;
+            };
+            let Some(shard) = shard_map.get_mut(&rec.master_id) else {
+                // Replica whose master is not (yet) known; view is inconsistent.
+                new_map.is_consistent = false;
+                continue;
+            };
+            shard.replicas.push(NodeInfo {
+                id: rec.id,
+                shard_id: shard.id,
+                socket_address,
+                role: NodeRole::Replica,
+                location: rec.location(),
+            });
+            if rec.is_local {
+                shard.is_local = true;
+                local_shard_id = Some(rec.master_id);
+            }
+        }
+
+        // The local node owns (serves) the slots of its shard.
+        if let Some(shard_id) = local_shard_id
+            && let Some(shard) = shard_map.get(&shard_id)
+        {
+            new_map.owned_slots.append(&shard.owned_slots);
+        }
+
+        // Finalize shards: back-pointers and per-shard fingerprints.
+        let mut shard_set: BTreeSet<ShardInfo> = BTreeSet::new();
+        for (_, mut shard) in shard_map.into_iter() {
             if let Some(primary) = shard.primary.as_mut() {
                 primary.shard_id = shard.id;
             }
             for replica in shard.replicas.iter_mut() {
                 replica.shard_id = shard.id;
             }
-
-            // compute fingerprint for each shard
             shard.slots_fingerprint = shard.owned_slots.calculate_fingerprint();
-
             shard_set.insert(shard);
         }
         new_map.shards = shard_set;
@@ -706,209 +800,12 @@ impl ClusterMap {
         let expiration_ms = CLUSTER_MAP_EXPIRATION_MS.load(std::sync::atomic::Ordering::Relaxed);
         new_map.expiration_ts = current_time_millis() + expiration_ms as i64;
 
-        Ok(new_map)
+        new_map
     }
 
     /// Convenience: is the cluster map expired?
     pub fn is_expired(&self) -> bool {
         current_time_millis() >= self.expiration_ts
-    }
-
-    /// Process a single slot range reply. On success, appends a SlotRangeInfo
-    /// to `slot_ranges` and updates internal structures such as owned_slots
-    /// and the shard map. Returns `true` on success and `false` if the slot range
-    /// should be skipped.
-    fn process_slot_range(
-        &mut self,
-        slot_range_reply: CallReply,
-        my_node_id: &NodeId,
-        slot_ranges: &mut Vec<SlotRangeInfo>,
-        shard_map: &mut AHashMap<NodeId, ShardInfo>,
-        socket_addr_to_node_map: &mut AHashMap<SocketAddress, NodeId>,
-    ) -> bool {
-        let slot_range_arr = match &slot_range_reply {
-            CallReply::Array(arr) => arr,
-            _ => {
-                log_warning("Invalid slot range reply type");
-                self.is_consistent = false;
-                return false;
-            }
-        };
-
-        assert!(
-            slot_range_arr.len() >= 3,
-            "CLUSTER SLOTS: Slot range reply too short. Expected at least 3 elements, got {}",
-            slot_range_arr.len()
-        );
-
-        // Parse start and end slots (elements 0 and 1)
-        let start = slot_range_arr
-            .get(0)
-            .and_then(reply_as_integer)
-            .expect("Invalid start slot reply while processing slot range")
-            as u16;
-
-        let end = slot_range_arr
-            .get(1)
-            .and_then(reply_as_integer)
-            .expect("Invalid end slot reply while processing slot range") as u16;
-
-        let is_shard_local = is_local_shard(&slot_range_reply, my_node_id);
-
-        // Parse primary node at index 2
-        let Some(Ok(primary_arr)) = slot_range_arr.get(2) else {
-            let msg = format!("Missing primary node info in slot range [{start}-{end}]");
-            log_warning(&msg);
-            self.is_consistent = false;
-            return false;
-        };
-
-        let Some(mut primary_node) =
-            self.parse_node_info(&primary_arr, my_node_id, true, socket_addr_to_node_map)
-        else {
-            let msg = format!("Dropping slot range [{start}-{end}] due to invalid primary node");
-            log_warning(&msg);
-            self.is_consistent = false;
-            return false;
-        };
-
-        // Parse replicas
-        let slot_len = slot_range_arr.len();
-        let mut replicas = Vec::with_capacity(slot_len - 3);
-        for j in 3..slot_len {
-            if let Some(Ok(replica_arr)) = slot_range_arr.get(j) {
-                match self.parse_node_info(&replica_arr, my_node_id, false, socket_addr_to_node_map)
-                {
-                    Some(replica) => replicas.push(replica),
-                    None => {
-                        let msg = format!("Skipping invalid replica in slot range [{start}-{end}]");
-                        log_warning(&msg);
-                        self.is_consistent = false;
-                        return false;
-                    }
-                }
-            }
-        }
-
-        // Mark owned slots if local
-        if is_shard_local {
-            assert!(end < NUM_SLOTS, "Invalid end slot number {end}");
-            self.owned_slots.insert_range(start, end);
-        }
-
-        let shard_id = primary_node.id;
-        let shard_entry = shard_map.entry(shard_id).or_insert_with(|| ShardInfo {
-            id: shard_id,
-            ..Default::default()
-        });
-
-        shard_entry.owned_slots.insert_range(start, end);
-
-        if let Some(primary) = &shard_entry.primary {
-            // Verify consistency for existing shard
-            if !is_existing_shard_consistent(shard_entry, primary, &replicas) {
-                log_warning("Inconsistency shard info found on existing slot ranges!");
-                self.is_consistent = false;
-            }
-        } else {
-            // Initialize new shard
-            primary_node.id = shard_id;
-            shard_entry.primary = Some(primary_node);
-            shard_entry.replicas = replicas;
-        }
-
-        slot_ranges.push(SlotRangeInfo {
-            start_slot: start,
-            end_slot: end,
-            shard_id,
-        });
-
-        true
-    }
-
-    /// Parse node info from the Valkey reply.
-    fn parse_node_info(
-        &mut self,
-        node_reply: &CallReply,
-        my_node_id: &NodeId,
-        is_primary: bool,
-        socket_addr_to_node_map: &mut AHashMap<SocketAddress, NodeId>,
-    ) -> Option<NodeInfo> {
-        // Expecting an array-like reply with 4 elements.
-        let arr = match node_reply {
-            CallReply::Array(arr) => arr,
-            _ => {
-                panic!("parse_node_info: Invalid node_reply: {node_reply:?}");
-            }
-        };
-        let len = arr.len();
-        assert_eq!(len, 4, "Invalid node reply length while parsing node info");
-
-        // element 0: primary endpoint (string)
-        let endpoint_reply = arr.get(0)?;
-        let endpoint = reply_as_string(endpoint_reply)?;
-        if endpoint.is_empty() || endpoint == "?" {
-            log_warning("Invalid node primary endpoint");
-            return None;
-        }
-
-        // element 1: port (integer)
-        let port = arr
-            .get(1)
-            .and_then(reply_as_integer)
-            .expect("Invalid port reply while parsing node info") as u16;
-
-        // element 2: node id (string)
-        let node_id = arr
-            .get(2)
-            .and_then(reply_as_node_id)
-            .expect("Invalid node reply while parsing node info");
-
-        let is_local_node = &node_id == my_node_id;
-
-        let primary_endpoint = endpoint
-            .parse::<IpAddr>()
-            .expect("Invalid node primary endpoint value");
-
-        let socket_address = SocketAddress {
-            primary_endpoint,
-            port,
-        };
-
-        // Check for duplicate socket addresses across different nodes
-        if let Some(existing) = socket_addr_to_node_map.get(&socket_address) {
-            if existing != &node_id {
-                let msg = format!(
-                    "Socket address collision between nodes {node_id} and {existing} at {socket_address}",
-                );
-                log_warning(&msg);
-                self.is_consistent = false;
-            }
-        } else {
-            socket_addr_to_node_map.insert(socket_address, node_id);
-        }
-
-        let location = if is_local_node {
-            NodeLocation::Local
-        } else {
-            NodeLocation::Remote
-        };
-
-        let role = if is_primary {
-            NodeRole::Primary
-        } else {
-            NodeRole::Replica
-        };
-
-        let node = NodeInfo {
-            id: node_id,
-            shard_id: NodeId::default(),
-            socket_address,
-            role,
-            location,
-        };
-
-        Some(node)
     }
 
     fn check_cluster_map_full(&self) -> bool {
@@ -963,80 +860,356 @@ impl ClusterMap {
     }
 }
 
-fn is_existing_shard_consistent(
-    existing_shard: &ShardInfo,
-    new_primary: &NodeInfo,
-    new_replicas: &[NodeInfo],
-) -> bool {
-    if let Some(existing_primary) = &existing_shard.primary {
-        if existing_primary.id != new_primary.id {
-            return false;
-        }
-        if existing_primary.socket_address != new_primary.socket_address {
-            return false;
-        }
-        if existing_primary.location != new_primary.location {
-            return false;
-        }
-    }
-    if existing_shard.replicas.len() != new_replicas.len() {
-        return false;
-    }
-    for (existing_replica, new_replica) in existing_shard.replicas.iter().zip(new_replicas.iter()) {
-        if existing_replica.id != new_replica.id {
-            return false;
-        }
-        if existing_replica.socket_address != new_replica.socket_address {
-            return false;
-        }
-    }
-    true
-}
-
 fn reply_as_string(call_reply: CallResult) -> Option<String> {
     match call_reply {
         Ok(CallReply::String(v)) => v.to_string(),
-        _ => None, // TODO: throw error?
-    }
-}
-
-fn reply_as_node_id(call_reply: CallResult) -> Option<NodeId> {
-    match reply_as_string(call_reply) {
-        Some(node_id) => {
-            let raw_id = node_id.as_ptr() as *const c_char;
-            let id: NodeId = NodeId::from_raw(raw_id);
-            Some(id)
-        }
-        None => None,
-    }
-}
-
-fn reply_as_integer(call_reply: CallResult) -> Option<i64> {
-    match call_reply {
-        Ok(CallReply::I64(v)) => Some(v.to_i64()),
+        Ok(CallReply::VerbatimString(v)) => v
+            .to_parts()
+            .map(|(_, bytes)| String::from_utf8_lossy(&bytes).into_owned()),
         _ => None,
     }
 }
 
-/// Returns true if any node listed for the slot range has the local node id.
-fn is_local_shard(slot_range_reply: &CallReply, my_node_id: &NodeId) -> bool {
-    let CallReply::Array(arr) = slot_range_reply else {
-        return false;
-    };
+/// A single parsed line of `CLUSTER NODES` output.
+struct ParsedNodeLine {
+    id: NodeId,
+    /// `None` when the node has no usable address (dropped for remote nodes).
+    socket_address: Option<SocketAddress>,
+    is_master: bool,
+    is_local: bool,
+    /// True when this replica has a resolvable master id.
+    has_master: bool,
+    master_id: NodeId,
+    /// Owned slot ranges (masters only); import/export markers are excluded.
+    slot_ranges: Vec<(u16, u16)>,
+}
 
-    // assumes index 2.. are nodes: 2=primary, 3..=replicas
-    let id_bytes = my_node_id.as_bytes();
-    for i in 2..arr.len() {
-        if let Some(Ok(CallReply::Array(node_arr))) = arr.get(i)
-            && let Some(Ok(CallReply::String(node_id_reply))) = node_arr.get(2)
-            && node_id_reply.as_bytes() == id_bytes
-        {
-            return true;
+impl ParsedNodeLine {
+    fn location(&self) -> NodeLocation {
+        if self.is_local {
+            NodeLocation::Local
+        } else {
+            NodeLocation::Remote
         }
     }
-    false
+}
+
+/// Parse one `CLUSTER NODES` line:
+/// `<id> <ip:port@cport[,aux]> <flags> <master> <ping> <pong> <epoch> <link> [slots...]`
+///
+/// Returns `None` when the line is too malformed to trust (too few fields,
+/// unparseable node id, or no single clear role).
+fn parse_node_line(line: &str, my_node_id: &NodeId) -> Option<ParsedNodeLine> {
+    let fields: Vec<&str> = line.split_ascii_whitespace().collect();
+    if fields.len() < 8 {
+        return None;
+    }
+
+    let id_field = fields[0];
+    if id_field.len() != VALKEYMODULE_NODE_ID_LEN as usize {
+        return None;
+    }
+    let id = NodeId::from_bytes(id_field.as_bytes());
+
+    let mut is_master = false;
+    let mut is_replica = false;
+    let mut is_myself = false;
+    let mut noaddr = false;
+    for flag in fields[2].split(',') {
+        match flag {
+            "master" => is_master = true,
+            "slave" | "replica" => is_replica = true,
+            "myself" => is_myself = true,
+            "noaddr" => noaddr = true,
+            _ => {}
+        }
+    }
+    // Exactly one role must be declared (rejects handshake/unknown lines).
+    if is_master == is_replica {
+        return None;
+    }
+    let is_local = is_myself || &id == my_node_id;
+
+    let socket_address = parse_node_address(fields[1], noaddr, is_local);
+
+    let master_field = fields[3];
+    let has_master = is_replica && master_field.len() == VALKEYMODULE_NODE_ID_LEN as usize;
+    let master_id = if has_master {
+        NodeId::from_bytes(master_field.as_bytes())
+    } else {
+        NodeId::default()
+    };
+
+    let mut slot_ranges = Vec::new();
+    if is_master {
+        for spec in &fields[8..] {
+            // Skip importing/migrating markers like "[12000-<-<id>]".
+            if spec.starts_with('[') {
+                continue;
+            }
+            if let Some((a, b)) = spec.split_once('-') {
+                if let (Ok(a), Ok(b)) = (a.parse::<u16>(), b.parse::<u16>()) {
+                    slot_ranges.push((a, b));
+                }
+            } else if let Ok(n) = spec.parse::<u16>() {
+                slot_ranges.push((n, n));
+            }
+        }
+    }
+
+    Some(ParsedNodeLine {
+        id,
+        socket_address,
+        is_master,
+        is_local,
+        has_master,
+        master_id,
+        slot_ranges,
+    })
+}
+
+/// Parse the `ip:port@cport[,aux...]` address field.
+///
+/// Returns `None` for a remote node with no usable address (it can't be
+/// targeted). The local node keeps a placeholder address instead, since a
+/// node never dials itself but must still appear in its own map.
+fn parse_node_address(field: &str, noaddr: bool, is_local: bool) -> Option<SocketAddress> {
+    // Drop the optional ",hostname"/aux fields, then the "@cport" bus suffix.
+    let addr = field.split(',').next().unwrap_or(field);
+    let host_port = addr.split('@').next().unwrap_or(addr);
+    // Split at the last ':' so IPv6 addresses (which contain ':') parse.
+    let (ip_str, port) = match host_port.rsplit_once(':') {
+        Some((ip, port)) => (ip, port.parse::<u16>().unwrap_or(0)),
+        None => (host_port, 0),
+    };
+
+    let local_placeholder = || {
+        is_local.then_some(SocketAddress {
+            primary_endpoint: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+            port,
+        })
+    };
+
+    if noaddr || ip_str.is_empty() {
+        return local_placeholder();
+    }
+    match ip_str.parse::<IpAddr>() {
+        Ok(primary_endpoint) => Some(SocketAddress {
+            primary_endpoint,
+            port,
+        }),
+        Err(_) => local_placeholder(),
+    }
 }
 
 // Unit tests
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+
+    // 40-char hex node ids.
+    const M1: &str = "1111111111111111111111111111111111111111";
+    const M2: &str = "2222222222222222222222222222222222222222";
+    const M3: &str = "3333333333333333333333333333333333333333";
+    const R1: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const R2: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const R3: &str = "cccccccccccccccccccccccccccccccccccccccc";
+
+    fn id(s: &str) -> NodeId {
+        NodeId::from_bytes(s.as_bytes())
+    }
+
+    /// A 3-master / 3-replica cluster, `myself` on master M1.
+    fn three_shard_nodes() -> String {
+        format!(
+            "\
+{M1} 127.0.0.1:7001@17001 myself,master - 0 0 1 connected 0-5460\n\
+{R1} 127.0.0.1:7101@17101 slave {M1} 0 0 1 connected\n\
+{M2} 127.0.0.1:7002@17002 master - 0 0 2 connected 5461-10922\n\
+{R2} 127.0.0.1:7102@17102 slave {M2} 0 0 2 connected\n\
+{M3} 127.0.0.1:7003@17003 master - 0 0 3 connected 10923-16383\n\
+{R3} 127.0.0.1:7103@17103 slave {M3} 0 0 3 connected\n"
+        )
+    }
+
+    #[test]
+    fn test_parse_three_shards() {
+        let map = ClusterMap::from_cluster_nodes(&three_shard_nodes(), &id(M1));
+
+        assert!(map.is_consistent);
+        assert_eq!(map.all_shards().len(), 3);
+
+        // M1 is local and owns 0-5460.
+        assert!(map.i_own_slot(0));
+        assert!(map.i_own_slot(5460));
+        assert!(!map.i_own_slot(5461));
+        assert_eq!(map.owned_slot_count(), 5461);
+
+        let shard1 = map.get_shard_by_id(M1).unwrap();
+        assert!(shard1.is_local);
+        assert_eq!(shard1.replicas.len(), 1);
+        assert_eq!(shard1.replicas[0].id, id(R1));
+        assert_eq!(shard1.primary.unwrap().location, NodeLocation::Local);
+
+        // Slot -> shard routing across shards.
+        assert_eq!(map.get_shard_by_slot(0).unwrap().id, id(M1));
+        assert_eq!(map.get_shard_by_slot(6000).unwrap().id, id(M2));
+        assert_eq!(map.get_shard_by_slot(16383).unwrap().id, id(M3));
+
+        // Replicas belong to their master and are marked remote.
+        let shard2 = map.get_shard_by_id(M2).unwrap();
+        assert_eq!(shard2.replicas[0].id, id(R2));
+        assert_eq!(shard2.replicas[0].location, NodeLocation::Remote);
+        assert_eq!(shard2.replicas[0].shard_id, id(M2));
+    }
+
+    #[test]
+    fn test_fingerprint_independent_of_line_order() {
+        let a = ClusterMap::from_cluster_nodes(&three_shard_nodes(), &id(M1));
+
+        // Same topology, lines shuffled and replicas listed before masters.
+        let shuffled = format!(
+            "\
+{R3} 127.0.0.1:7103@17103 slave {M3} 0 0 3 connected\n\
+{M2} 127.0.0.1:7002@17002 master - 0 0 2 connected 5461-10922\n\
+{R1} 127.0.0.1:7101@17101 slave {M1} 0 0 1 connected\n\
+{M3} 127.0.0.1:7003@17003 master - 0 0 3 connected 10923-16383\n\
+{R2} 127.0.0.1:7102@17102 slave {M2} 0 0 2 connected\n\
+{M1} 127.0.0.1:7001@17001 myself,master - 0 0 1 connected 0-5460\n"
+        );
+        let b = ClusterMap::from_cluster_nodes(&shuffled, &id(M1));
+
+        assert_eq!(a.cluster_slots_fingerprint(), b.cluster_slots_fingerprint());
+        assert!(a.cluster_slots_fingerprint() != 0);
+    }
+
+    #[test]
+    fn test_fingerprint_changes_when_slot_moves() {
+        let before = ClusterMap::from_cluster_nodes(&three_shard_nodes(), &id(M1));
+
+        // Move slot 12000 from M3 to M2 (M2 gains a single-slot range).
+        let after_text = format!(
+            "\
+{M1} 127.0.0.1:7001@17001 myself,master - 0 0 1 connected 0-5460\n\
+{M2} 127.0.0.1:7002@17002 master - 0 0 2 connected 5461-10922 12000\n\
+{M3} 127.0.0.1:7003@17003 master - 0 0 3 connected 10923-11999 12001-16383\n"
+        );
+        let after = ClusterMap::from_cluster_nodes(&after_text, &id(M1));
+
+        assert!(after.is_consistent);
+        assert_ne!(
+            before.cluster_slots_fingerprint(),
+            after.cluster_slots_fingerprint()
+        );
+        assert_eq!(after.get_shard_by_slot(12000).unwrap().id, id(M2));
+    }
+
+    #[test]
+    fn test_import_export_markers_are_ignored() {
+        // M3 is exporting 12000, M2 is importing it: neither has settled
+        // ownership yet, so the slot is uncovered and the map is not full.
+        let text = format!(
+            "\
+{M1} 127.0.0.1:7001@17001 myself,master - 0 0 1 connected 0-5460\n\
+{M2} 127.0.0.1:7002@17002 master - 0 0 2 connected 5461-10922 [12000-<-{M3}]\n\
+{M3} 127.0.0.1:7003@17003 master - 0 0 3 connected 10923-16383 [12000->-{M2}]\n"
+        );
+        let map = ClusterMap::from_cluster_nodes(&text, &id(M1));
+
+        // The bracketed markers contributed no slots to either shard.
+        assert_eq!(map.get_shard_by_id(M2).unwrap().owned_slots.len(), 5462);
+        assert_eq!(map.get_shard_by_id(M3).unwrap().owned_slots.len(), 5461);
+    }
+
+    #[test]
+    fn test_empty_ip_on_local_myself_line() {
+        // Early in cluster life the local node's own line can have an empty ip.
+        let text = format!(
+            "\
+{M1} :7001@17001 myself,master - 0 0 1 connected 0-16383\n"
+        );
+        let map = ClusterMap::from_cluster_nodes(&text, &id(M1));
+
+        let shard = map.get_shard_by_id(M1).unwrap();
+        let primary = shard.primary.unwrap();
+        assert!(primary.is_local());
+        // A local node's address is never dialed; a placeholder is fine.
+        assert_eq!(
+            primary.socket_address.primary_endpoint,
+            IpAddr::V4(Ipv4Addr::UNSPECIFIED)
+        );
+        assert!(map.is_consistent);
+    }
+
+    #[test]
+    fn test_ipv6_and_hostname_address() {
+        let line = format!("{M1} ::1:7001@17001,host.example.com master - 0 0 1 connected 0-16383");
+        let rec = parse_node_line(&line, &id(M2)).unwrap();
+        let addr = rec.socket_address.unwrap();
+        assert_eq!(addr.primary_endpoint, "::1".parse::<IpAddr>().unwrap());
+        assert_eq!(addr.port, 7001);
+        assert!(rec.is_master);
+        assert!(!rec.is_local);
+    }
+
+    #[test]
+    fn test_replica_before_master_line_ordering() {
+        // Replica line appears before its master; two-pass assembly must still
+        // attach it.
+        let text = format!(
+            "\
+{R1} 127.0.0.1:7101@17101 slave {M1} 0 0 1 connected\n\
+{M1} 127.0.0.1:7001@17001 myself,master - 0 0 1 connected 0-16383\n"
+        );
+        let map = ClusterMap::from_cluster_nodes(&text, &id(M1));
+        let shard = map.get_shard_by_id(M1).unwrap();
+        assert_eq!(shard.replicas.len(), 1);
+        assert_eq!(shard.replicas[0].id, id(R1));
+    }
+
+    #[test]
+    fn test_parse_node_line_rejects_malformed() {
+        // Too few fields.
+        assert!(parse_node_line("too short line here", &id(M1)).is_none());
+        // Node id of the wrong length.
+        assert!(
+            parse_node_line(
+                "short 127.0.0.1:7001@17001 master - 0 0 1 connected",
+                &id(M1)
+            )
+            .is_none()
+        );
+        // No clear role flag.
+        let line = format!("{M1} 127.0.0.1:7001@17001 handshake - 0 0 1 connected");
+        assert!(parse_node_line(&line, &id(M2)).is_none());
+    }
+
+    #[test]
+    fn test_replica_with_missing_master_marks_inconsistent() {
+        // M1 covers all slots (full, no gap → no logging), but R2 references a
+        // master that is absent from the reply.
+        let text = format!(
+            "\
+{M1} 127.0.0.1:7001@17001 myself,master - 0 0 1 connected 0-16383\n\
+{R2} 127.0.0.1:7102@17102 slave {M2} 0 0 2 connected\n"
+        );
+        let map = ClusterMap::from_cluster_nodes(&text, &id(M1));
+        assert!(!map.is_consistent);
+    }
+
+    #[test]
+    fn test_local_replica_owns_its_shard_slots() {
+        // Local node is a replica of M1; it "owns" (serves) M1's slots.
+        let text = format!(
+            "\
+{M1} 127.0.0.1:7001@17001 master - 0 0 1 connected 0-5460\n\
+{R1} 127.0.0.1:7101@17101 myself,slave {M1} 0 0 1 connected\n\
+{M2} 127.0.0.1:7002@17002 master - 0 0 2 connected 5461-16383\n"
+        );
+        let map = ClusterMap::from_cluster_nodes(&text, &id(R1));
+        assert!(map.i_own_slot(0));
+        assert!(map.i_own_slot(5460));
+        assert!(!map.i_own_slot(5461));
+        assert!(map.get_shard_by_id(M1).unwrap().is_local);
+    }
+}

--- a/src/fanout/cluster_rpc.rs
+++ b/src/fanout/cluster_rpc.rs
@@ -424,7 +424,7 @@ fn process_request_message(
         return;
     }
 
-    let mut dest = Vec::with_capacity(1024);
+    let mut dest = get_pooled_buffer(FANOUT_RPC_RESPONSE_BUFFER_SIZE);
     let _ = set_current_db(ctx, db);
 
     let res = handler(ctx, request_buf, &mut dest);

--- a/src/fanout/cluster_rpc.rs
+++ b/src/fanout/cluster_rpc.rs
@@ -1,4 +1,4 @@
-use super::fanout_error::{FanoutError, NO_CLUSTER_NODES_AVAILABLE};
+use super::fanout_error::{ErrorKind, FanoutError, NO_CLUSTER_NODES_AVAILABLE};
 use super::fanout_message::{
     FANOUT_MESSAGE_VERSION, FanoutMessage, FanoutMessageHeader, serialize_request_message,
 };
@@ -12,7 +12,10 @@ use crate::fanout::cluster_map::{CURRENT_NODE_ID, NodeId, NodeRole, SocketAddres
 use crate::fanout::fanout_command::FanoutResponseCallback;
 use crate::fanout::registry::{RequestHandlerCallback, get_fanout_request_handler};
 use crate::fanout::serialization::Serializable;
-use crate::fanout::{FanoutResult, NodeInfo};
+use crate::fanout::{
+    FanoutResult, NodeInfo, get_cluster_map, get_or_refresh_cluster_map, mark_cluster_map_stale,
+    refresh_cluster_map,
+};
 use ahash::HashSet;
 use core::time::Duration;
 use papaya::HashMap;
@@ -199,13 +202,22 @@ pub fn invoke_rpc<Request: Serializable>(
     name: &str,
     req: Request,
     targets: Arc<HashSet<NodeInfo>>,
+    cluster_fingerprint: u64,
     response_handler: FanoutResponseCallback,
     timeout: Duration,
 ) -> ValkeyResult<()> {
     let mut buf = get_pooled_buffer(FANOUT_RPC_BUFFER_SIZE);
     req.serialize(&mut buf);
 
-    send_cluster_request(ctx, &buf, targets, name, response_handler, Some(timeout))
+    send_cluster_request(
+        ctx,
+        &buf,
+        targets,
+        name,
+        cluster_fingerprint,
+        response_handler,
+        Some(timeout),
+    )
 }
 
 pub(super) fn send_cluster_request(
@@ -213,6 +225,7 @@ pub(super) fn send_cluster_request(
     request_buf: &[u8],
     targets: Arc<HashSet<NodeInfo>>,
     handler: &str,
+    cluster_fingerprint: u64,
     response_handler: FanoutResponseCallback,
     timeout: Option<Duration>,
 ) -> ValkeyResult<()> {
@@ -221,8 +234,8 @@ pub(super) fn send_cluster_request(
     let id = generate_id();
     let db = get_current_db(ctx);
 
-    let mut buf = get_pooled_buffer(FANOUT_RPC_BUFFER_SIZE);
-    serialize_request_message(&mut buf, id, db, handler, request_buf);
+    let mut buf = get_pooled_buffer(512);
+    serialize_request_message(&mut buf, id, db, handler, cluster_fingerprint, request_buf);
 
     let remote_targets: Vec<NodeInfo> = targets
         .iter()
@@ -280,8 +293,10 @@ fn send_message_internal(
     handler: &str,
     buf: &[u8],
 ) -> Status {
-    let mut dest = get_pooled_buffer(FANOUT_RPC_RESPONSE_BUFFER_SIZE);
-    serialize_request_message(&mut dest, request_id, db, handler, buf);
+    let mut dest = Vec::with_capacity(1024);
+    // Responses and errors don't carry a meaningful cluster-map fingerprint; the
+    // requester matches them by request id and reacts to the error kind. Send 0.
+    serialize_request_message(&mut dest, request_id, db, handler, 0, buf);
     send_cluster_message(ctx, sender_id, msg_type, &dest)
 }
 
@@ -352,6 +367,32 @@ fn alloc_db_if_needed(ctx: &Context, db: i32) {
     }
 }
 
+/// Checks the requester's cluster-map fingerprint against our own view of the
+/// cluster topology.
+///
+/// A fingerprint of `0` means the sender had no map when it built the request,
+/// so the check is skipped. Otherwise we compare against a fresh local map: if
+/// they disagree, our map may merely be stale, so we force a single refresh and
+/// re-compare before declaring a mismatch. Building the map issues
+/// `CLUSTER NODES` (not `CLUSTER SLOTS`), whose reply does not depend on a
+/// client, so this is safe on the worker thread that runs it.
+///
+/// Returns `true` when the topologies agree (request accepted).
+fn cluster_fingerprint_matches(ctx: &Context, expected: u64) -> bool {
+    if expected == 0 {
+        return true;
+    }
+
+    let local = get_or_refresh_cluster_map(ctx);
+    if local.cluster_slots_fingerprint() == expected {
+        return true;
+    }
+
+    // Our map might just be stale; force one refresh and re-check.
+    refresh_cluster_map(ctx);
+    get_cluster_map().cluster_slots_fingerprint() == expected
+}
+
 /// Processes a valid request by executing the command and sending back the response.
 fn process_request_message(
     ctx: &Context,
@@ -363,7 +404,27 @@ fn process_request_message(
     let request_id = header.request_id;
     let db = header.db;
 
-    let mut dest = get_pooled_buffer(FANOUT_RPC_RESPONSE_BUFFER_SIZE);
+    // Reject the request if the cluster topology changed between the requester
+    // generating it and us receiving it. This runs on the worker thread (not the
+    // cluster-message callback) so the potential `CLUSTER NODES` refresh stays
+    // off the main thread. The aggregate result would otherwise be built from
+    // inconsistent per-node views.
+    if !cluster_fingerprint_matches(ctx, header.cluster_fingerprint) {
+        let msg = format!(
+            "cluster rpc: rejecting request {request_id} from node {sender_id}: cluster-map fingerprint mismatch"
+        );
+        ctx.log_warning(&msg);
+        send_error_response(
+            ctx,
+            request_id,
+            db,
+            sender_id.raw_ptr(),
+            FanoutError::cluster_map_mismatch(),
+        );
+        return;
+    }
+
+    let mut dest = Vec::with_capacity(1024);
     let _ = set_current_db(ctx, db);
 
     let res = handler(ctx, request_buf, &mut dest);
@@ -458,6 +519,7 @@ extern "C" fn on_request_received(
         request_id: message.request_id,
         db: message.db,
         handler: std::mem::take(&mut message.handler),
+        cluster_fingerprint: message.cluster_fingerprint,
     };
 
     alloc_db_if_needed(&ctx, message.db);
@@ -523,7 +585,15 @@ extern "C" fn on_error_received(
         let _ = set_current_db(ctx, message.db);
 
         match FanoutError::deserialize(message.buf) {
-            Ok((error, _)) => request.handle_response(ctx, Err(error), sender_id),
+            Ok((error, _)) => {
+                // A peer rejected us because its view of the cluster topology
+                // differs from ours. Invalidate our local map so the next fanout
+                // rebuilds it before targeting nodes.
+                if error.kind == ErrorKind::ClusterMapMismatch {
+                    mark_cluster_map_stale();
+                }
+                request.handle_response(ctx, Err(error), sender_id)
+            }
             Err(_) => {
                 ctx.log_warning("Failed to deserialize error response");
                 let err = FanoutError::invalid_message();

--- a/src/fanout/cluster_rpc.rs
+++ b/src/fanout/cluster_rpc.rs
@@ -234,7 +234,7 @@ pub(super) fn send_cluster_request(
     let id = generate_id();
     let db = get_current_db(ctx);
 
-    let mut buf = get_pooled_buffer(512);
+    let mut buf = get_pooled_buffer(FANOUT_RPC_BUFFER_SIZE);
     serialize_request_message(&mut buf, id, db, handler, cluster_fingerprint, request_buf);
 
     let remote_targets: Vec<NodeInfo> = targets
@@ -293,11 +293,11 @@ fn send_message_internal(
     handler: &str,
     buf: &[u8],
 ) -> Status {
-    let mut dest = Vec::with_capacity(1024);
+    let mut dest = get_pooled_buffer(FANOUT_RPC_RESPONSE_BUFFER_SIZE);
     // Responses and errors don't carry a meaningful cluster-map fingerprint; the
     // requester matches them by request id and reacts to the error kind. Send 0.
     serialize_request_message(&mut dest, request_id, db, handler, 0, buf);
-    send_cluster_message(ctx, sender_id, msg_type, &dest)
+    send_cluster_message(ctx, sender_id, msg_type, dest.as_slice())
 }
 
 fn send_response_message(

--- a/src/fanout/fanout_client_command.rs
+++ b/src/fanout/fanout_client_command.rs
@@ -2,8 +2,9 @@ use crate::common::replies::ReplyContext;
 use crate::fanout::FanoutCommandResult;
 use crate::fanout::blocked_client::FanoutBlockedClient;
 use crate::fanout::serialization::Serializable;
-use crate::fanout::{FanoutCommand, FanoutResult, FanoutTargetMode, NodeInfo, get_fanout_targets};
-use ahash::HashSet;
+use crate::fanout::{
+    FanoutCommand, FanoutResult, FanoutTargetMode, FanoutTargets, NodeInfo, get_fanout_targets,
+};
 use std::sync::{Arc, Mutex};
 use valkey_module::{Context, Status, ValkeyResult, ValkeyValue};
 
@@ -17,9 +18,10 @@ pub trait FanoutClientCommand: Default + Send + 'static {
 
     fn name() -> &'static str;
 
-    /// Get the list of target nodes for the fanout operation.
+    /// Get the target nodes for the fanout operation, bound to the cluster-map
+    /// fingerprint of the snapshot they were selected from.
     /// By default, it retrieves a random replica per shard.
-    fn get_targets(&self, ctx: &Context) -> Arc<HashSet<NodeInfo>> {
+    fn get_targets(&self, ctx: &Context) -> FanoutTargets {
         get_fanout_targets(ctx, FanoutTargetMode::Random)
     }
 
@@ -83,9 +85,10 @@ impl<T: FanoutClientCommand> FanoutCommand for T {
         T::get_local_response(ctx, req)
     }
 
-    /// Get the list of target nodes for the fanout operation.
+    /// Get the target nodes for the fanout operation, bound to the cluster-map
+    /// fingerprint of the snapshot they were selected from.
     /// By default, it retrieves a random replica per shard.
-    fn get_targets(&self, ctx: &Context) -> Arc<HashSet<NodeInfo>> {
+    fn get_targets(&self, ctx: &Context) -> FanoutTargets {
         FanoutClientCommand::get_targets(self, ctx)
     }
 

--- a/src/fanout/fanout_command.rs
+++ b/src/fanout/fanout_command.rs
@@ -211,6 +211,13 @@ where
     }
 
     fn on_error(&mut self, error: FanoutError, target: &NodeInfo) {
+        // Once the fanout has completed, `self.operation` has been moved out via
+        // `mem::take` and replaced with `OP::default()`, which may not be a
+        // valid accumulator. Ignore any late-arriving callbacks so we never
+        // invoke the operation on that placeholder.
+        if self.lifecycle == FanoutLifecycleState::Completed {
+            return;
+        }
         self.activate();
         // Invoke the handler's error callback for custom error handling
         self.operation.on_error(error.clone(), target);
@@ -235,6 +242,11 @@ where
     }
 
     fn on_response(&mut self, resp: OP::Response, target: &NodeInfo) {
+        // See `on_error`: after completion `self.operation` is a `mem::take`
+        // placeholder, so drop late responses instead of accumulating into it.
+        if self.lifecycle == FanoutLifecycleState::Completed {
+            return;
+        }
         self.activate();
         if self.timed_out {
             // We already timed out; ignore responses but mark RPC as done.

--- a/src/fanout/fanout_command.rs
+++ b/src/fanout/fanout_command.rs
@@ -2,8 +2,7 @@ use super::cluster_rpc::{get_cluster_command_timeout, invoke_rpc};
 use super::fanout_error::{ErrorKind, FanoutError};
 use crate::common::threads::spawn;
 use crate::fanout::serialization::{Deserialized, Serializable};
-use crate::fanout::{FanoutResult, FanoutTargetMode, NodeInfo, get_fanout_targets};
-use ahash::HashSet;
+use crate::fanout::{FanoutResult, FanoutTargetMode, FanoutTargets, NodeInfo, get_fanout_targets};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use valkey_module::{Context, MODULE_CONTEXT, ValkeyResult};
@@ -33,9 +32,10 @@ pub trait FanoutCommand: Default + Send + 'static {
         get_cluster_command_timeout()
     }
 
-    /// Get the list of target nodes for the fanout operation.
+    /// Get the target nodes for the fanout operation, bound to the cluster-map
+    /// fingerprint of the snapshot they were selected from.
     /// By default, it retrieves a random replica per shard.
-    fn get_targets(&self, ctx: &Context) -> Arc<HashSet<NodeInfo>> {
+    fn get_targets(&self, ctx: &Context) -> FanoutTargets {
         get_fanout_targets(ctx, FanoutTargetMode::Random)
     }
 
@@ -93,7 +93,7 @@ pub trait FanoutCommand: Default + Send + 'static {
 pub fn exec_command<OP: FanoutCommand, F>(
     ctx: &Context,
     command: OP,
-    targets: Arc<HashSet<NodeInfo>>,
+    targets: FanoutTargets,
     timeout: Duration,
     f: F,
 ) -> FanoutResult
@@ -101,6 +101,11 @@ where
     F: FnOnce(OP, FanoutCommandResult) + Send + 'static,
 {
     let op = command;
+
+    let FanoutTargets {
+        nodes: targets,
+        cluster_fingerprint,
+    } = targets;
 
     let req = op.generate_request();
     let outstanding = targets.len();
@@ -147,6 +152,7 @@ where
         OP::name(),
         req,
         targets,
+        cluster_fingerprint,
         Box::new(response_handler),
         timeout,
     ) {
@@ -179,6 +185,10 @@ where
     outstanding: usize,
     timed_out: bool,
     error_count: usize,
+    /// When set, the fanout has been aborted fail-fast (e.g. a cluster-map
+    /// mismatch) and this exact error is returned to the client, bypassing the
+    /// per-shard error aggregation.
+    abort_error: Option<FanoutError>,
     callback: Option<F>,
 }
 
@@ -210,6 +220,14 @@ where
             // Zero out outstanding so that any late-arriving responses become
             // no-ops — rpc_done saturates at 0 and won't retrigger completion.
             self.outstanding = 0;
+            self.on_completion();
+            return;
+        }
+        // A cluster-map mismatch means the topology moved underneath us; the
+        // aggregate result is unreliable, so abort the whole fanout immediately
+        // and surface the mismatch error to the client.
+        if error.kind == ErrorKind::ClusterMapMismatch {
+            self.abort_error = Some(error);
             self.on_completion();
             return;
         }
@@ -259,7 +277,9 @@ where
             return;
         };
 
-        let result = if self.timed_out {
+        let result = if let Some(err) = self.abort_error.take() {
+            Err(err)
+        } else if self.timed_out {
             Err(FanoutError::timeout())
         } else if self.error_count > 0 {
             Err(self.operation.generate_error_reply())
@@ -310,6 +330,7 @@ where
                 lifecycle: FanoutLifecycleState::Pending,
                 error_count: 0,
                 timed_out: false,
+                abort_error: None,
                 callback: Some(f),
             }),
         }

--- a/src/fanout/fanout_error.rs
+++ b/src/fanout/fanout_error.rs
@@ -39,6 +39,12 @@ pub enum ErrorKind {
 
     Internal = 8,
 
+    /// The cluster topology changed between the sending of a request and its
+    /// receipt: the requester's cluster-map fingerprint did not match the
+    /// receiver's. The aggregate result would be inconsistent, so the fanout
+    /// fails fast, and the requester invalidates its cluster map.
+    ClusterMapMismatch = 9,
+
     Custom = 255,
 }
 
@@ -52,6 +58,8 @@ pub(super) const NODE_UNREACHABLE_ERROR: &str = "Cluster node unreachable";
 pub(super) const NO_CLUSTER_NODES_AVAILABLE: &str = "No cluster nodes available";
 pub(super) const INTERNAL_ERROR: &str = "Internal error";
 pub(super) const INVALID_MESSAGE_ERROR: &str = "Invalid cluster message";
+pub(super) const CLUSTER_MAP_MISMATCH_ERROR: &str =
+    "A multi-shard command failed because the cluster topology has changed";
 
 impl ErrorKind {
     pub fn as_str(&self) -> &'static str {
@@ -65,6 +73,7 @@ impl ErrorKind {
             Self::Timeout => TIMEOUT_ERROR,
             Self::NodeUnreachable => NODE_UNREACHABLE_ERROR,
             Self::Internal => INTERNAL_ERROR,
+            Self::ClusterMapMismatch => CLUSTER_MAP_MISMATCH_ERROR,
             Self::Custom => "Custom error",
         }
     }
@@ -93,6 +102,10 @@ impl FanoutError {
 
     pub fn invalid_message() -> Self {
         ErrorKind::InvalidMessage.into()
+    }
+
+    pub fn cluster_map_mismatch() -> Self {
+        ErrorKind::ClusterMapMismatch.into()
     }
 
     pub fn custom<S: Into<String>>(description: S) -> Self {
@@ -149,6 +162,7 @@ impl TryFrom<u8> for ErrorKind {
             6 => Ok(ErrorKind::Serialization),
             7 => Ok(ErrorKind::BadRequestId),
             8 => Ok(ErrorKind::Internal),
+            9 => Ok(ErrorKind::ClusterMapMismatch),
             255 => Ok(ErrorKind::Custom),
             _ => {
                 let msg = format!("Invalid error kind: {value}");
@@ -208,6 +222,7 @@ fn convert_from_string(err: &str) -> FanoutError {
         KEY_PERMISSIONS_ERROR => ErrorKind::KeyPermissions.into(),
         PERMISSIONS_ERROR => ErrorKind::Permissions.into(),
         INTERNAL_ERROR => ErrorKind::Internal.into(),
+        CLUSTER_MAP_MISMATCH_ERROR => ErrorKind::ClusterMapMismatch.into(),
         NODE_UNREACHABLE_ERROR => ErrorKind::NodeUnreachable.into(),
         UNKNOWN_MESSAGE_TYPE_ERROR => ErrorKind::UnknownMessageType.into(),
         SERIALIZATION_ERROR => FanoutError::serialization(String::new()),
@@ -325,6 +340,7 @@ mod tests {
             ErrorKind::Serialization,
             ErrorKind::BadRequestId,
             ErrorKind::Internal,
+            ErrorKind::ClusterMapMismatch,
             ErrorKind::Custom,
         ];
 
@@ -474,6 +490,7 @@ mod tests {
         assert_eq!(ErrorKind::Serialization as u8, 6);
         assert_eq!(ErrorKind::BadRequestId as u8, 7);
         assert_eq!(ErrorKind::Internal as u8, 8);
+        assert_eq!(ErrorKind::ClusterMapMismatch as u8, 9);
         assert_eq!(ErrorKind::Custom as u8, 255);
     }
 }

--- a/src/fanout/fanout_message.rs
+++ b/src/fanout/fanout_message.rs
@@ -29,26 +29,15 @@ pub(super) struct FanoutMessageHeader {
 
 impl FanoutMessageHeader {
     pub fn serialize(&self, buf: &mut Vec<u8>) {
-        // Start with the marker
-        write_marker(buf);
-
-        // version is stored as a little-endian u16
-        write_u16_le(buf, self.version);
-
-        // Encode request_id as uvarint
-        write_uvarint(buf, self.request_id);
-
-        // Encode db as signed varint
-        write_signed_varint(buf, self.db as i64);
-
-        // Encode handler as a string
-        write_byte_slice(buf, self.handler.as_bytes());
-
-        // Cluster-map fingerprint, fixed 8-byte little-endian.
-        write_u64_le(buf, self.cluster_fingerprint);
-
-        // Reserved for future use (e.g., for larger payloads, we may compress the data)
-        write_u16_le(buf, self.reserved);
+        write_message_header(
+            buf,
+            self.version,
+            self.request_id,
+            self.db,
+            &self.handler,
+            self.cluster_fingerprint,
+            self.reserved,
+        );
     }
 
     /// Deserializes a MessageHeader from the beginning of the buffer.
@@ -95,19 +84,36 @@ impl FanoutMessageHeader {
 /// Write a message header directly to `buf` without constructing a [`FanoutMessageHeader`].
 /// This avoids an unnecessary `String` allocation for the handler name in the outgoing
 /// (serialization) path, where the handler is always available as a borrowed `&str`.
+///
+/// The wire layout here must stay in lockstep with [`FanoutMessageHeader::deserialize`].
 fn write_message_header(
     buf: &mut Vec<u8>,
     version: u16,
     request_id: u64,
     db: i32,
     handler: &str,
+    cluster_fingerprint: u64,
     reserved: u16,
 ) {
+    // Start with the marker
     write_marker(buf);
+
+    // version is stored as a little-endian u16
     write_u16_le(buf, version);
+
+    // Encode request_id as uvarint
     write_uvarint(buf, request_id);
+
+    // Encode db as signed varint
     write_signed_varint(buf, db as i64);
+
+    // Encode handler as a string
     write_byte_slice(buf, handler.as_bytes());
+
+    // Cluster-map fingerprint, fixed 8-byte little-endian.
+    write_u64_le(buf, cluster_fingerprint);
+
+    // Reserved for future use (e.g., for larger payloads, we may compress the data)
     write_u16_le(buf, reserved);
 }
 
@@ -212,15 +218,15 @@ pub(super) fn serialize_request_message(
     cluster_fingerprint: u64,
     serialized_request: &[u8],
 ) {
-    let header = FanoutMessageHeader {
-        version: FANOUT_MESSAGE_VERSION,
+    write_message_header(
+        dest,
+        FANOUT_MESSAGE_VERSION,
         request_id,
         db,
-        handler: handler.to_string(),
+        handler,
         cluster_fingerprint,
-        reserved: 0,
-    };
-    header.serialize(dest);
+        0,
+    );
     dest.extend_from_slice(serialized_request);
 }
 

--- a/src/fanout/fanout_message.rs
+++ b/src/fanout/fanout_message.rs
@@ -1,7 +1,7 @@
 use super::fanout_error::INVALID_MESSAGE_ERROR;
 use crate::common::encoding::{
-    try_read_signed_varint, try_read_string, try_read_uvarint, write_byte_slice,
-    write_signed_varint, write_uvarint,
+    try_read_signed_varint, try_read_string, try_read_u64_le, try_read_uvarint, write_byte_slice,
+    write_signed_varint, write_u64_le, write_uvarint,
 };
 use crate::fanout::{FanoutError, FanoutResult};
 
@@ -21,18 +21,33 @@ pub(super) struct FanoutMessageHeader {
     pub handler: String,
     /// Reserved for future use (e.g., for larger payloads, we may compress the data)
     pub reserved: u16,
+    /// Hash of the sender's cluster map (hash of all shard fingerprints) at the
+    /// time the request was generated. `0` means "no fingerprint", which
+    /// disables the receiver-side topology check.
+    pub cluster_fingerprint: u64,
 }
 
 impl FanoutMessageHeader {
     pub fn serialize(&self, buf: &mut Vec<u8>) {
-        write_message_header(
-            buf,
-            self.version,
-            self.request_id,
-            self.db,
-            &self.handler,
-            self.reserved,
-        );
+        // Start with the marker
+        write_marker(buf);
+
+        // version is stored as a little-endian u16
+        write_u16_le(buf, self.version);
+
+        // Encode request_id as uvarint
+        write_uvarint(buf, self.request_id);
+
+        // Encode db as signed varint
+        write_signed_varint(buf, self.db as i64);
+
+        // Encode handler as a string
+        write_byte_slice(buf, self.handler.as_bytes());
+
+        write_u16_le(buf, self.reserved);
+
+        // Cluster-map fingerprint, fixed 8-byte little-endian.
+        write_u64_le(buf, self.cluster_fingerprint);
     }
 
     /// Deserializes a MessageHeader from the beginning of the buffer.
@@ -58,6 +73,10 @@ impl FanoutMessageHeader {
         // Read reserved as a little-endian u16
         let reserved = read_u16_le(&mut buf)?;
 
+        // Cluster-map fingerprint, fixed 8-byte little-endian.
+        let cluster_fingerprint = try_read_u64_le(&mut buf)
+            .map_err(|_| FanoutError::serialization(INVALID_MESSAGE_ERROR))?;
+
         Ok((
             FanoutMessageHeader {
                 version,
@@ -65,6 +84,7 @@ impl FanoutMessageHeader {
                 handler,
                 db,
                 reserved,
+                cluster_fingerprint,
             },
             buf,
         ))
@@ -144,6 +164,8 @@ pub(super) struct FanoutMessage<'a> {
     pub handler: String,
     /// The database to use for this request.
     pub db: i32,
+    /// Sender's cluster-map fingerprint (0 if unavailable / v1 sender).
+    pub cluster_fingerprint: u64,
 }
 
 impl<'a> FanoutMessage<'a> {
@@ -167,6 +189,7 @@ impl<'a> FanoutMessage<'a> {
             request_id,
             db,
             handler,
+            cluster_fingerprint,
             ..
         } = header;
 
@@ -175,6 +198,7 @@ impl<'a> FanoutMessage<'a> {
             request_id,
             handler,
             db,
+            cluster_fingerprint,
         })
     }
 }
@@ -184,9 +208,18 @@ pub(super) fn serialize_request_message(
     request_id: u64,
     db: i32,
     handler: &str,
+    cluster_fingerprint: u64,
     serialized_request: &[u8],
 ) {
-    write_message_header(dest, FANOUT_MESSAGE_VERSION, request_id, db, handler, 0);
+    let header = FanoutMessageHeader {
+        version: FANOUT_MESSAGE_VERSION,
+        request_id,
+        db,
+        handler: handler.to_string(),
+        reserved: 0,
+        cluster_fingerprint,
+    };
+    header.serialize(dest);
     dest.extend_from_slice(serialized_request);
 }
 
@@ -203,6 +236,7 @@ mod tests {
             db: 0,
             handler: "test_handler".to_string(),
             reserved: 0,
+            cluster_fingerprint: 0xABCD_1234_5678_9F00,
         };
 
         let mut buf = Vec::new();
@@ -215,6 +249,10 @@ mod tests {
         assert_eq!(deserialized_header.db, 0);
         assert_eq!(deserialized_header.reserved, 0);
         assert_eq!(deserialized_header.handler, "test_handler");
+        assert_eq!(
+            deserialized_header.cluster_fingerprint,
+            0xABCD_1234_5678_9F00
+        );
         assert_eq!(remaining_buf.len(), 0);
     }
 
@@ -226,6 +264,7 @@ mod tests {
             db: -15,
             handler: "negative_db_handler".to_string(),
             reserved: 42,
+            cluster_fingerprint: u64::MAX,
         };
 
         let mut buf = Vec::new();
@@ -238,6 +277,7 @@ mod tests {
         assert_eq!(deserialized_header.db, -15);
         assert_eq!(deserialized_header.reserved, 42);
         assert_eq!(deserialized_header.handler, "negative_db_handler");
+        assert_eq!(deserialized_header.cluster_fingerprint, u64::MAX);
         assert_eq!(remaining_buf.len(), 0);
     }
 
@@ -249,6 +289,7 @@ mod tests {
             db: 5,
             handler: "handler_with_extra".to_string(),
             reserved: 1,
+            cluster_fingerprint: 7,
         };
 
         let mut buf = Vec::new();
@@ -430,7 +471,7 @@ mod tests {
         let mut buf = Vec::new();
         let request_data = b"test_request_data";
 
-        serialize_request_message(&mut buf, 123, 5, "handler", request_data);
+        serialize_request_message(&mut buf, 123, 5, "handler", 0xDEAD_BEEF, request_data);
 
         // Verify we can deserialize the header
         let (header, remaining) = FanoutMessageHeader::deserialize(&buf).unwrap();
@@ -440,6 +481,7 @@ mod tests {
         assert_eq!(header.db, 5);
         assert_eq!(header.reserved, 0);
         assert_eq!(header.handler, "handler");
+        assert_eq!(header.cluster_fingerprint, 0xDEAD_BEEF);
         assert_eq!(remaining, request_data);
     }
 
@@ -448,13 +490,14 @@ mod tests {
         let mut buf = Vec::new();
         let request_data = b"test_payload";
 
-        serialize_request_message(&mut buf, 456, -3, "test_handler", request_data);
+        serialize_request_message(&mut buf, 456, -3, "test_handler", 99, request_data);
 
         let request_message = FanoutMessage::new(&buf).unwrap();
 
         assert_eq!(request_message.request_id, 456);
         assert_eq!(request_message.db, -3);
         assert_eq!(request_message.handler, "test_handler");
+        assert_eq!(request_message.cluster_fingerprint, 99);
         assert_eq!(request_message.buf, request_data);
     }
 
@@ -469,23 +512,24 @@ mod tests {
     #[test]
     fn test_cluster_message_header_roundtrip_property_based() {
         // Property-based test: any valid ClusterMessageHeader should roundtrip,
-        // including various handler strings.
+        // including various handler strings and fingerprints.
         let test_cases = vec![
-            (0, 0, i32::MIN, 0, ""),
-            (1, 1, -1, 1, "handler1"),
-            (u16::MAX, u64::MAX, i32::MAX, u16::MAX, "h"),
-            (42, 1234567890, 0, 999, "property_based_test"),
-            (100, 555, -42, 200, "with_special_字符"),
-            (2, 3, 4, 5, "another_handler"),
+            (0, i32::MIN, 0, "", 0u64),
+            (1, -1, 1, "handler1", 1),
+            (u64::MAX, i32::MAX, u16::MAX, "h", u64::MAX),
+            (1234567890, 0, 999, "property_based_test", 0xABCD),
+            (555, -42, 200, "with_special_字符", 0x0102_0304_0506_0708),
+            (3, 4, 5, "another_handler", 42),
         ];
 
-        for (version, request_id, db, reserved, handler) in test_cases {
+        for (request_id, db, reserved, handler, cluster_fingerprint) in test_cases {
             let original_header = FanoutMessageHeader {
-                version,
+                version: FANOUT_MESSAGE_VERSION,
                 request_id,
                 db,
                 handler: handler.to_string(),
                 reserved,
+                cluster_fingerprint,
             };
 
             let mut buf = Vec::new();
@@ -499,6 +543,10 @@ mod tests {
             assert_eq!(deserialized_header.db, original_header.db);
             assert_eq!(deserialized_header.reserved, original_header.reserved);
             assert_eq!(deserialized_header.handler, original_header.handler);
+            assert_eq!(
+                deserialized_header.cluster_fingerprint,
+                original_header.cluster_fingerprint
+            );
             assert_eq!(remaining_buf.len(), 0);
         }
     }

--- a/src/fanout/fanout_message.rs
+++ b/src/fanout/fanout_message.rs
@@ -19,12 +19,12 @@ pub(super) struct FanoutMessageHeader {
     pub db: i32,
     /// The name of the handler to process this message.
     pub handler: String,
-    /// Reserved for future use (e.g., for larger payloads, we may compress the data)
-    pub reserved: u16,
     /// Hash of the sender's cluster map (hash of all shard fingerprints) at the
     /// time the request was generated. `0` means "no fingerprint", which
     /// disables the receiver-side topology check.
     pub cluster_fingerprint: u64,
+    /// Reserved for future use (e.g., for larger payloads, we may compress the data)
+    pub reserved: u16,
 }
 
 impl FanoutMessageHeader {
@@ -44,10 +44,11 @@ impl FanoutMessageHeader {
         // Encode handler as a string
         write_byte_slice(buf, self.handler.as_bytes());
 
-        write_u16_le(buf, self.reserved);
-
         // Cluster-map fingerprint, fixed 8-byte little-endian.
         write_u64_le(buf, self.cluster_fingerprint);
+
+        // Reserved for future use (e.g., for larger payloads, we may compress the data)
+        write_u16_le(buf, self.reserved);
     }
 
     /// Deserializes a MessageHeader from the beginning of the buffer.
@@ -70,12 +71,12 @@ impl FanoutMessageHeader {
         let handler = try_read_string(&mut buf)
             .map_err(|_| FanoutError::serialization(INVALID_MESSAGE_ERROR))?;
 
-        // Read reserved as a little-endian u16
-        let reserved = read_u16_le(&mut buf)?;
-
         // Cluster-map fingerprint, fixed 8-byte little-endian.
         let cluster_fingerprint = try_read_u64_le(&mut buf)
             .map_err(|_| FanoutError::serialization(INVALID_MESSAGE_ERROR))?;
+
+        // Read reserved as a little-endian u16
+        let reserved = read_u16_le(&mut buf)?;
 
         Ok((
             FanoutMessageHeader {
@@ -83,8 +84,8 @@ impl FanoutMessageHeader {
                 request_id,
                 handler,
                 db,
-                reserved,
                 cluster_fingerprint,
+                reserved,
             },
             buf,
         ))
@@ -216,8 +217,8 @@ pub(super) fn serialize_request_message(
         request_id,
         db,
         handler: handler.to_string(),
-        reserved: 0,
         cluster_fingerprint,
+        reserved: 0,
     };
     header.serialize(dest);
     dest.extend_from_slice(serialized_request);
@@ -235,8 +236,8 @@ mod tests {
             request_id: 12345,
             db: 0,
             handler: "test_handler".to_string(),
-            reserved: 0,
             cluster_fingerprint: 0xABCD_1234_5678_9F00,
+            reserved: 0,
         };
 
         let mut buf = Vec::new();
@@ -247,8 +248,8 @@ mod tests {
         assert_eq!(deserialized_header.version, FANOUT_MESSAGE_VERSION);
         assert_eq!(deserialized_header.request_id, 12345);
         assert_eq!(deserialized_header.db, 0);
-        assert_eq!(deserialized_header.reserved, 0);
         assert_eq!(deserialized_header.handler, "test_handler");
+        assert_eq!(deserialized_header.reserved, 0);
         assert_eq!(
             deserialized_header.cluster_fingerprint,
             0xABCD_1234_5678_9F00
@@ -263,8 +264,8 @@ mod tests {
             request_id: u64::MAX,
             db: -15,
             handler: "negative_db_handler".to_string(),
-            reserved: 42,
             cluster_fingerprint: u64::MAX,
+            reserved: 42,
         };
 
         let mut buf = Vec::new();
@@ -275,9 +276,9 @@ mod tests {
         assert_eq!(deserialized_header.version, FANOUT_MESSAGE_VERSION);
         assert_eq!(deserialized_header.request_id, u64::MAX);
         assert_eq!(deserialized_header.db, -15);
-        assert_eq!(deserialized_header.reserved, 42);
         assert_eq!(deserialized_header.handler, "negative_db_handler");
         assert_eq!(deserialized_header.cluster_fingerprint, u64::MAX);
+        assert_eq!(deserialized_header.reserved, 42);
         assert_eq!(remaining_buf.len(), 0);
     }
 
@@ -288,8 +289,8 @@ mod tests {
             request_id: 999,
             db: 5,
             handler: "handler_with_extra".to_string(),
-            reserved: 1,
             cluster_fingerprint: 7,
+            reserved: 1,
         };
 
         let mut buf = Vec::new();

--- a/src/fanout/mod.rs
+++ b/src/fanout/mod.rs
@@ -67,8 +67,8 @@ pub fn get_fanout_targets(ctx: &Context, mode: FanoutTargetMode) -> FanoutTarget
     let current_map = CLUSTER_MAP.load();
     // Check if we need to refresh. A stale flag is set when a peer rejected one
     // of our requests due to a topology mismatch.
-    let needs_refresh =
-        !current_map.is_consistent || current_map.is_expired() || take_cluster_map_stale();
+    let stale = take_cluster_map_stale();
+    let needs_refresh = !current_map.is_consistent || current_map.is_expired() || stale;
     if !needs_refresh {
         return FanoutTargets {
             nodes: current_map.get_targets(mode),
@@ -91,17 +91,25 @@ pub fn get_fanout_targets(ctx: &Context, mode: FanoutTargetMode) -> FanoutTarget
 // warning is logged so subsequent calls will retry the refresh.
 pub fn refresh_cluster_map(ctx: &Context) {
     ctx.log_notice("Refreshing cluster map...");
-    let new_map = ClusterMap::create(ctx);
-    update_cluster_map(new_map);
-    ctx.log_notice("Cluster map refreshed");
+    match ClusterMap::create(ctx) {
+        Some(new_map) => {
+            update_cluster_map(new_map);
+            ctx.log_notice("Cluster map refreshed");
+        }
+        None => {
+            ctx.log_warning(
+                "Failed to build cluster map; keeping the previous map and retrying later",
+            );
+        }
+    }
 }
 
 pub fn get_or_refresh_cluster_map(ctx: &Context) -> Arc<ClusterMap> {
     let current_map = get_cluster_map();
+    let stale = take_cluster_map_stale();
 
     // Check if we need to refresh
-    let needs_refresh =
-        !current_map.is_consistent || current_map.is_expired() || take_cluster_map_stale();
+    let needs_refresh = !current_map.is_consistent || current_map.is_expired() || stale;
 
     if needs_refresh {
         drop(current_map);

--- a/src/fanout/mod.rs
+++ b/src/fanout/mod.rs
@@ -11,6 +11,7 @@ mod utils;
 
 use ahash::HashSet;
 use arc_swap::{ArcSwap, Guard};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
 use valkey_module::Context;
 
@@ -30,51 +31,77 @@ pub(crate) fn init_fanout(ctx: &Context) {
 static CLUSTER_MAP: LazyLock<ArcSwap<ClusterMap>> =
     LazyLock::new(|| ArcSwap::from_pointee(ClusterMap::default()));
 
+/// Set when a peer rejects one of our requests with a cluster-map mismatch.
+/// The next target-selection or map access treats the local map as needing a
+/// refresh, so the following fanout is built from up-to-date topology.
+static CLUSTER_MAP_STALE: AtomicBool = AtomicBool::new(false);
+
+/// The set of target nodes for a fanout, together with the cluster-map
+/// fingerprint of the *same* snapshot the targets were chosen from. Keeping them
+/// together avoids a race where the map is swapped between target selection and
+/// sending, which would pair a fresh target list with a stale fingerprint.
+#[derive(Clone)]
+pub struct FanoutTargets {
+    pub nodes: Arc<HashSet<NodeInfo>>,
+    pub cluster_fingerprint: u64,
+}
+
 pub fn get_cluster_map() -> Guard<Arc<ClusterMap>> {
     CLUSTER_MAP.load()
+}
+
+/// Mark the local cluster map as stale so it is rebuilt on next use.
+pub fn mark_cluster_map_stale() {
+    CLUSTER_MAP_STALE.store(true, Ordering::Release);
+}
+
+fn take_cluster_map_stale() -> bool {
+    CLUSTER_MAP_STALE.swap(false, Ordering::AcqRel)
 }
 
 fn update_cluster_map(map: ClusterMap) {
     CLUSTER_MAP.swap(Arc::new(map));
 }
 
-pub fn get_fanout_targets(ctx: &Context, mode: FanoutTargetMode) -> Arc<HashSet<NodeInfo>> {
+pub fn get_fanout_targets(ctx: &Context, mode: FanoutTargetMode) -> FanoutTargets {
     let current_map = CLUSTER_MAP.load();
-    // Check if we need to refresh
-    let needs_refresh = !current_map.is_consistent || current_map.is_expired();
+    // Check if we need to refresh. A stale flag is set when a peer rejected one
+    // of our requests due to a topology mismatch.
+    let needs_refresh =
+        !current_map.is_consistent || current_map.is_expired() || take_cluster_map_stale();
     if !needs_refresh {
-        return current_map.get_targets(mode);
+        return FanoutTargets {
+            nodes: current_map.get_targets(mode),
+            cluster_fingerprint: current_map.cluster_slots_fingerprint(),
+        };
     }
     // Possibly race condition, but only if called concurrently, which is possible but very unlikely.
     // In any case, the worst that can happen is that we refresh more than once.
     refresh_cluster_map(ctx);
-    CLUSTER_MAP.load().get_targets(mode)
+    // Load the refreshed map once so targets and fingerprint come from the same snapshot.
+    let map = CLUSTER_MAP.load();
+    FanoutTargets {
+        nodes: map.get_targets(mode),
+        cluster_fingerprint: map.cluster_slots_fingerprint(),
+    }
 }
 
 // Refresh the cluster map by creating a new one from the current cluster state.
-// If building the new map fails (e.g. CLUSTER SLOTS returns an error), the
-// previous map is kept in place and a warning is logged so subsequent calls
-// will retry the refresh.
+// If building the new map fails, the previous map is kept in place and a
+// warning is logged so subsequent calls will retry the refresh.
 pub fn refresh_cluster_map(ctx: &Context) {
     ctx.log_notice("Refreshing cluster map...");
-    match ClusterMap::create(ctx) {
-        Ok(new_map) => {
-            update_cluster_map(new_map);
-            ctx.log_notice("Cluster map refreshed");
-        }
-        Err(e) => {
-            ctx.log_warning(&format!(
-                "Failed to refresh cluster map, keeping previous map: {e}"
-            ));
-        }
-    }
+    let new_map = ClusterMap::create(ctx);
+    update_cluster_map(new_map);
+    ctx.log_notice("Cluster map refreshed");
 }
 
 pub fn get_or_refresh_cluster_map(ctx: &Context) -> Arc<ClusterMap> {
     let current_map = get_cluster_map();
 
     // Check if we need to refresh
-    let needs_refresh = !current_map.is_consistent || current_map.is_expired();
+    let needs_refresh =
+        !current_map.is_consistent || current_map.is_expired() || take_cluster_map_stale();
 
     if needs_refresh {
         drop(current_map);

--- a/tests/test_ts_cluster_fingerprint_cme.py
+++ b/tests/test_ts_cluster_fingerprint_cme.py
@@ -1,0 +1,203 @@
+"""
+Integration tests for the cluster-map fingerprint validation feature.
+
+Every fanout request carries the sender's cluster-map fingerprint (a hash of all
+shard slot fingerprints). The receiving node compares it against its own view of
+the cluster topology and rejects the request with a "cluster topology changed"
+error when they disagree, so that a topology change between request and response
+cannot produce an inconsistent aggregated result.
+
+A node builds/refreshes its cluster map from CLUSTER NODES (whose reply does not
+depend on a client), so a receiver can refresh to ground truth on the fanout
+worker thread and validate authoritatively — including forcing a refresh when
+its own map might merely be stale. These tests cover:
+
+1. Happy path: in a stable cluster, fingerprints computed independently on every
+   node agree, so cross-shard fanout succeeds (receivers refresh on demand) and
+   no node rejects a request.
+2. Rejection + recovery: a requester holding a stale cluster map is rejected
+   once the topology changes, then succeeds after refreshing.
+"""
+
+import time
+
+import pytest
+from valkey import ResponseError, Valkey, ValkeyCluster
+from valkeytestframework.util.waiters import *
+from valkeytestframework.conftest import resource_port_tracker
+from valkey_timeseries_test_case import ValkeyTimeSeriesClusterTestCase
+
+# Hash tags {1}/{2}/{3} spread these keys across the three primary shards.
+CPU1 = b"fp:cpu1:{1}"
+CPU2 = b"fp:cpu2:{2}"
+CPU3 = b"fp:cpu3:{3}"
+
+CONFIG_EXPIRATION = "ts.ts-cluster-map-expiration-ms"
+LONG_EXPIRATION = 600_000  # 10 minutes: a warmed cache stays valid for the test.
+
+# Slot 12000 lives in the third shard's range for an even 3-way split of the
+# 16384 slots ( [10923, 16383] ), and none of the hash-tagged keys above map to
+# it, so it is safe to reassign.
+MIGRATED_SLOT = 12000
+
+MISMATCH_LOG_MARKER = "cluster topology has changed"
+
+
+class TestClusterFingerprint(ValkeyTimeSeriesClusterTestCase):
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    def _set_expiration(self, client: Valkey, millis: int):
+        client.execute_command("CONFIG", "SET", CONFIG_EXPIRATION, str(millis))
+
+    def _node_id(self, client: Valkey) -> str:
+        return client.execute_command("CLUSTER", "MYID").decode()
+
+    def _warm_cluster_map(self, client: Valkey):
+        """Force `client`'s node to build and cache its cluster map by running a
+        fanout command. The result is irrelevant; the map is refreshed as a side
+        effect of target selection."""
+        try:
+            client.execute_command("TS.QUERYINDEX", "name=__warm__")
+        except ResponseError:
+            pass
+
+    def _slot_owner_id(self, client: Valkey, slot: int):
+        """Return the primary node id that owns `slot`, per this node's view.
+
+        Parses raw CLUSTER NODES output to avoid depending on client-side
+        parsing of CLUSTER SLOTS."""
+        raw = client.execute_command("CLUSTER", "NODES")
+        if isinstance(raw, bytes):
+            raw = raw.decode()
+        for line in raw.splitlines():
+            fields = line.split()
+            if len(fields) < 8 or "master" not in fields[2]:
+                continue
+            node_id = fields[0]
+            for spec in fields[8:]:
+                if spec.startswith("["):  # importing/migrating placeholder
+                    continue
+                if "-" in spec:
+                    start, end = spec.split("-")
+                    if int(start) <= slot <= int(end):
+                        return node_id
+                elif int(spec) == slot:
+                    return node_id
+        return None
+
+    def _wait_until(self, predicate, timeout=25, interval=0.2, msg=""):
+        deadline = time.time() + timeout
+        last_exc = None
+        while time.time() < deadline:
+            try:
+                if predicate():
+                    return
+            except Exception as e:  # noqa: BLE001 - polling; remember last error
+                last_exc = e
+            time.sleep(interval)
+        raise AssertionError(f"Timeout waiting for: {msg} (last error: {last_exc})")
+
+    def _any_node_log_contains(self, marker: str) -> bool:
+        return any(rg.primary.does_logfile_contains(marker) for rg in self.replication_groups)
+
+    # ── tests ────────────────────────────────────────────────────────────────
+
+    def test_fanout_consistent_across_stable_cluster(self):
+        """In a stable cluster, cross-shard fanout succeeds and no node rejects a
+        request for a fingerprint mismatch.
+
+        Receivers here start with no cached map and must refresh to ground truth
+        on the very first request; the fanout succeeding proves both that the
+        refresh works from the receive path and that fingerprints computed
+        independently on different nodes agree."""
+        cluster: ValkeyCluster = self.new_cluster_client()
+        client = self.new_client_for_primary(0)
+
+        cluster.execute_command("TS.CREATE", CPU1, "LABELS", "name", "cpu")
+        cluster.execute_command("TS.CREATE", CPU2, "LABELS", "name", "cpu")
+        cluster.execute_command("TS.CREATE", CPU3, "LABELS", "name", "cpu")
+
+        # No warming: the first fanout forces every receiver to build its map.
+        for _ in range(5):
+            result = client.execute_command("TS.QUERYINDEX", "name=cpu")
+            assert sorted(result) == sorted([CPU1, CPU2, CPU3])
+
+        # And it works regardless of which node originates the fanout.
+        for i in range(self.CLUSTER_SIZE):
+            result = self.new_client_for_primary(i).execute_command("TS.QUERYINDEX", "name=cpu")
+            assert sorted(result) == sorted([CPU1, CPU2, CPU3])
+
+        assert not self._any_node_log_contains(MISMATCH_LOG_MARKER), (
+            "a stable cluster must not produce fingerprint-mismatch rejections"
+        )
+
+    def test_fanout_rejected_on_topology_change_then_recovers(self):
+        """A requester holding a stale cluster map is rejected once the topology
+        changes, and recovers on retry after refreshing.
+
+        Node 0 (the requester) is pinned to the pre-change map with a long
+        expiration and warmed before the change. Receivers 1 and 2 never cache
+        (expiration 0), so they always validate against current ground truth.
+        After migrating an empty slot between the receivers, node 0 still sends
+        the old fingerprint and is rejected; the rejection marks its map stale,
+        so the retry rebuilds and succeeds."""
+        node0 = self.new_client_for_primary(0)
+        node1 = self.new_client_for_primary(1)
+        node2 = self.new_client_for_primary(2)
+
+        # Requester pins its (soon to be stale) map; receivers always refresh.
+        self._set_expiration(node0, LONG_EXPIRATION)
+        self._set_expiration(node1, 0)
+        self._set_expiration(node2, 0)
+
+        node1_id = self._node_id(node1)
+        node2_id = self._node_id(node2)
+
+        self._wait_until(
+            lambda: self._slot_owner_id(node2, MIGRATED_SLOT) == node2_id,
+            msg="node2 initially owns the slot to migrate",
+        )
+
+        # Pin node 0's cache to the pre-change fingerprint.
+        self._warm_cluster_map(node0)
+
+        # Migrate the (empty) slot from node 2 to node 1 using the canonical
+        # empty-slot handoff, bumping node 1's config epoch and gossiping the new
+        # ownership. This changes both shards' slot fingerprints, hence the
+        # cluster-level fingerprint.
+        try:
+            node2.execute_command("CLUSTER", "SETSLOT", MIGRATED_SLOT, "MIGRATING", node1_id)
+            node1.execute_command("CLUSTER", "SETSLOT", MIGRATED_SLOT, "IMPORTING", node2_id)
+            node1.execute_command("CLUSTER", "SETSLOT", MIGRATED_SLOT, "NODE", node1_id)
+            node2.execute_command("CLUSTER", "SETSLOT", MIGRATED_SLOT, "NODE", node1_id)
+        except ResponseError as e:
+            pytest.skip(f"slot migration unsupported in this environment: {e}")
+
+        # Wait until the receivers observe the new ownership, so their refresh
+        # yields the new fingerprint.
+        self._wait_until(
+            lambda: self._slot_owner_id(node1, MIGRATED_SLOT) == node1_id
+            and self._slot_owner_id(node2, MIGRATED_SLOT) == node1_id,
+            msg="receivers observe the migrated slot ownership",
+        )
+
+        # Node 0 still holds the pre-change map (long expiration, not yet marked
+        # stale), so this fanout carries the stale fingerprint and is rejected.
+        with pytest.raises(ResponseError, match=r"(?i)topology( has)? changed"):
+            node0.execute_command("TS.QUERYINDEX", "name=cpu")
+
+        self._wait_until(
+            lambda: self._any_node_log_contains(MISMATCH_LOG_MARKER),
+            msg="a receiver logs the fingerprint-mismatch rejection",
+        )
+
+        # The rejection marked node 0's map stale; once its own view converges,
+        # the retry rebuilds the map and the fanout succeeds.
+        self._wait_until(
+            lambda: self._slot_owner_id(node0, MIGRATED_SLOT) == node1_id,
+            msg="node0's own view converges on the new ownership",
+        )
+        self._wait_until(
+            lambda: node0.execute_command("TS.QUERYINDEX", "name=cpu") == [],
+            msg="node0 recovers after refreshing its cluster map",
+        )


### PR DESCRIPTION
This pull request introduces a robust mechanism to detect and handle cluster topology changes during multi-shard (fanout) operations, ensuring consistency and correctness when the cluster map changes between request dispatch and processing. The main improvement is the introduction of a "cluster-map fingerprint" that is attached to each fanout request, validated by each node, and used to fail fast and invalidate stale cluster maps if a mismatch is detected. This prevents inconsistent aggregate results and improves error handling.

The most important changes are:

**Cluster Map Fingerprint Handling:**
* Added a `cluster_fingerprint` field to fanout request messages, which represents the sender's view of the cluster topology at the time of request generation. The fingerprint is included in all relevant APIs and message serialization (`src/fanout/cluster_rpc.rs`, `src/fanout/fanout_command.rs`, `src/fanout/fanout_client_command.rs`, `src/fanout/fanout_message.rs`). [[1]](diffhunk://#diff-1c1a81bb3ab1e654e4bd019e0512499324d25afe0de7afdb624a22e78ce5c78fR205-R228) [[2]](diffhunk://#diff-1c1a81bb3ab1e654e4bd019e0512499324d25afe0de7afdb624a22e78ce5c78fL224-R238) [[3]](diffhunk://#diff-1105b822c6608c8cde24aaafcd5044e23c20e27fa00b345c20ebf4e19968095cL96-R96) [[4]](diffhunk://#diff-1105b822c6608c8cde24aaafcd5044e23c20e27fa00b345c20ebf4e19968095cR105-R109) [[5]](diffhunk://#diff-29a53930c89acab0d1b4e36d78bf2560581e748863a2d323b7d90ca2b4ca509fL20-R24) [[6]](diffhunk://#diff-29a53930c89acab0d1b4e36d78bf2560581e748863a2d323b7d90ca2b4ca509fL86-R91) [[7]](diffhunk://#diff-576d3454cb35fc06783154cbe572a25609936e71d198310044688f496628e2b9L3-R4)
* Implemented logic on the receiving node to check the incoming request's `cluster_fingerprint` against its own current and refreshed cluster map, rejecting the request with a specific error if a mismatch is detected (`cluster_fingerprint_matches`, `process_request_message`). [[1]](diffhunk://#diff-1c1a81bb3ab1e654e4bd019e0512499324d25afe0de7afdb624a22e78ce5c78fR370-R395) [[2]](diffhunk://#diff-1c1a81bb3ab1e654e4bd019e0512499324d25afe0de7afdb624a22e78ce5c78fL366-R427)

**Error Handling and Propagation:**
* Introduced a new error kind, `ClusterMapMismatch`, with error propagation and handling throughout the fanout stack. If a mismatch is detected, the request is rejected, the client aborts the entire fanout operation, and the local map is marked stale for refresh (`src/fanout/fanout_error.rs`, `on_error_received`, error handling in fanout aggregation). [[1]](diffhunk://#diff-eeb3b9e6af2000668c88251539361ecf8706787ae1974d1100b9f2ffee86f229R42-R47) [[2]](diffhunk://#diff-eeb3b9e6af2000668c88251539361ecf8706787ae1974d1100b9f2ffee86f229R61-R62) [[3]](diffhunk://#diff-eeb3b9e6af2000668c88251539361ecf8706787ae1974d1100b9f2ffee86f229R76) [[4]](diffhunk://#diff-eeb3b9e6af2000668c88251539361ecf8706787ae1974d1100b9f2ffee86f229R107-R110) [[5]](diffhunk://#diff-eeb3b9e6af2000668c88251539361ecf8706787ae1974d1100b9f2ffee86f229R165) [[6]](diffhunk://#diff-eeb3b9e6af2000668c88251539361ecf8706787ae1974d1100b9f2ffee86f229R225) [[7]](diffhunk://#diff-eeb3b9e6af2000668c88251539361ecf8706787ae1974d1100b9f2ffee86f229R343) [[8]](diffhunk://#diff-eeb3b9e6af2000668c88251539361ecf8706787ae1974d1100b9f2ffee86f229R493) [[9]](diffhunk://#diff-1c1a81bb3ab1e654e4bd019e0512499324d25afe0de7afdb624a22e78ce5c78fL526-R596) [[10]](diffhunk://#diff-1105b822c6608c8cde24aaafcd5044e23c20e27fa00b345c20ebf4e19968095cR188-R191) [[11]](diffhunk://#diff-1105b822c6608c8cde24aaafcd5044e23c20e27fa00b345c20ebf4e19968095cR226-R233) [[12]](diffhunk://#diff-1105b822c6608c8cde24aaafcd5044e23c20e27fa00b345c20ebf4e19968095cL262-R282)

**API and Type Updates:**
* Refactored the fanout target selection API to return a new `FanoutTargets` struct (containing both the node set and the cluster-map fingerprint), replacing the previous use of `Arc<HashSet<NodeInfo>>` throughout the codebase. [[1]](diffhunk://#diff-29a53930c89acab0d1b4e36d78bf2560581e748863a2d323b7d90ca2b4ca509fL5-R7) [[2]](diffhunk://#diff-1105b822c6608c8cde24aaafcd5044e23c20e27fa00b345c20ebf4e19968095cL5-R5) [[3]](diffhunk://#diff-1105b822c6608c8cde24aaafcd5044e23c20e27fa00b345c20ebf4e19968095cL36-R38)

**Serialization Updates:**
* Updated serialization and deserialization routines to include the cluster fingerprint in all relevant message types (`serialize_request_message`, `try_read_u64_le`, `write_u64_le`). [[1]](diffhunk://#diff-576d3454cb35fc06783154cbe572a25609936e71d198310044688f496628e2b9L3-R4) [[2]](diffhunk://#diff-1c1a81bb3ab1e654e4bd019e0512499324d25afe0de7afdb624a22e78ce5c78fL224-R238) [[3]](diffhunk://#diff-1c1a81bb3ab1e654e4bd019e0512499324d25afe0de7afdb624a22e78ce5c78fL283-R299) [[4]](diffhunk://#diff-1c1a81bb3ab1e654e4bd019e0512499324d25afe0de7afdb624a22e78ce5c78fR522)

**Fail-fast and Consistency Improvements:**
* The fanout operation now aborts immediately and returns a specific error to the client if any node detects a cluster-map mismatch, preventing inconsistent aggregate results. The local cluster map is invalidated and refreshed on such errors. [[1]](diffhunk://#diff-1105b822c6608c8cde24aaafcd5044e23c20e27fa00b345c20ebf4e19968095cR226-R233) [[2]](diffhunk://#diff-1105b822c6608c8cde24aaafcd5044e23c20e27fa00b345c20ebf4e19968095cL262-R282) [[3]](diffhunk://#diff-1c1a81bb3ab1e654e4bd019e0512499324d25afe0de7afdb624a22e78ce5c78fL526-R596)

These changes collectively ensure that multi-shard operations are consistent and reliable, even in the presence of dynamic cluster topology changes.