### PR TITLE
[SECURITY] Bound regex sizes and ensure at least one positive label matcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,16 +38,35 @@ High-level architecture (big picture)
     - `["TS.ADD", commands::ts_add_cmd, "write deny-oom", 1, 1, 1, "write timeseries"]`
 - Time-series core lives under `src/series` (storage, encoding, background tasks, indexes). Index/init helpers:
   `init_croaring_allocator()` and `init_background_tasks()` are invoked from `src/lib.rs`.
+  - `src/series/chunks/` implements five encoding formats: **Gorilla** (default), **PCO**, **TsXOR**, **Uncompressed**,
+    **XOR2**. The default is controlled by `DEFAULT_CHUNK_ENCODING` in `src/config.rs`.
+  - ACL filtering per series: `src/series/acl.rs`.
 - Cross-node fanout / clustering patterns: `src/fanout` and `src/commands/*_fanout_command.rs` use protobuf (
   `src/commands/fanout.*.proto`) and explicit fanout registration (`register_fanout_operations`) to implement
   cluster-wide queries.
+- Outlier detection: `src/analysis/outliers/` — multiple algorithms (ESD, CUSUM, EWMA, IQR, MAD, modified z-score, RCF
+  variants) exposed via the `TS.OUTLIERS` command.
+- Aggregation: `src/aggregators/` — aggregation handlers and iterators used by range queries.
+- Supporting subsystems (all referenced from `src/lib.rs`):
+  - `src/common/` — shared utilities: encoding, logging, thread pool, RDB helpers, string interning.
+  - `src/labels/` — `Label` type, label filter evaluation, regex helpers.
+  - `src/parser/` — Prometheus-compatible filter syntax, metric name, timestamp, and duration parsing.
+  - `src/iterators/` — sample and row iterators consumed by range and multi-range queries.
+  - `src/join/` — ASOF join logic backing `TS.JOIN`.
 
 Project-specific conventions and patterns
 
 - All Valkey commands are declared in the `valkey_module!` macro in `src/lib.rs`; change there to add/remove commands.
 - Command files follow `ts_<command>.rs` naming and export `ts_<command>_cmd` functions (see `src/commands/mod.rs`).
 - Fanout pattern: synchronous local implementation + `*_fanout_command.rs` files which marshal/unmarshal protobuf
-  messages for cluster aggregation.
+  messages for cluster aggregation. Seven operations are currently registered (see `register_fanout_operations` in
+  `src/commands/mod.rs`): `LabelStatsFanoutCommand`, `CardFanoutCommand`, `LabelSearchFanoutCommand`,
+  `MDelFanoutCommand`, `MGetFanoutCommand`, `MRangeFanoutCommand`, `QueryIndexFanoutCommand`.
+- Initialization sequence (inside `initialize()` in `src/lib.rs`): `init_croaring_allocator` → `register_config` →
+  `init_fanout` + `register_fanout_operations` (cluster only) → `register_server_events` → `init_thread_pool` →
+  `init_background_tasks`.
+- Minimum supported Valkey server version: `[8, 0, 0]` (enforced in `preload()` via
+  `config::TIMESERIES_MIN_SUPPORTED_VERSION`).
 
 - Allocator in tests: tests compile with `enable-system-alloc` feature in unit runs (see `build.sh`), and the crate
   switches allocators under `#[cfg(test)]`.
@@ -69,15 +88,27 @@ Where to look first (key files & directories)
 - `src/commands/` — implementations and command parsing utilities (`command_parser.rs`).
 - `src/series/` — core storage, encodings, indexes, background tasks.
 - `src/fanout/` — cluster communication primitives.
+- `src/analysis/` — outlier detection algorithms (`src/analysis/outliers/`).
+- `src/aggregators/` — aggregation handlers for range queries.
+- `src/common/` — shared utilities (encoding, logging, thread pool, RDB, string interning).
+- `src/labels/` — label types and filter evaluation.
+- `src/parser/` — filter syntax, metric name, timestamp, and duration parsers.
+- `src/iterators/` — sample and row iterators.
+- `src/join/` — ASOF join for TS.JOIN.
+- `src/tests/` — synthetic data generators (mackey_glass, rand) for unit tests.
 - `build.sh` — canonical developer flow for formatting, linting, building, and running tests.
 - `README.md` and `docs/commands/` — human-facing command descriptions and examples.
+- `docs/topics/` — deep-dive topics: `filter-syntax.md`, `label-discovery.md`, `filter-dos-audit.md`.
 
 Quick tips for code changes
 
 - Add new commands: create `src/commands/ts_<name>.rs`, add function `ts_<name>_cmd`, then register in `valkey_module!`
-  in `src/lib.rs`.
+  in `src/lib.rs`. Currently registered commands: TS.CREATE, TS.ALTER, TS.ADD, TS.ADDBULK, TS.GET, TS.MGET, TS.MADD,
+  TS.DEL, TS.DECRBY, TS.INCRBY, TS.JOIN, TS.MDEL, TS.MRANGE, TS.MREVRANGE, TS.RANGE, TS.REVRANGE, TS.INFO,
+  TS.QUERYINDEX, TS.CARD, TS.LABELNAMES, TS.LABELVALUES, TS.METRICNAMES, TS.LABELSTATS, TS.CREATERULE,
+  TS.DELETERULE, TS.OUTLIERS, TS._DEBUG (hidden admin command, no user-facing docs needed).
 - Documentation: When adding or modifying commands, remember to update the human-facing docs in `docs/commands/` and the
-  supported list in `README.md`.
+  supported list in `README.md`. TS._DEBUG is intentionally undocumented.
 - When making cluster changes, search for `*_fanout_command.rs` to copy the fanout pattern and add protobuf messages in
   `src/commands/fanout.*.proto`.
 
@@ -88,4 +119,4 @@ Limitations of this document
 
 If you need more context, inspect:
 
-- `build.sh`, `Cargo.toml`, `src/lib.rs`, `src/commands/*`, `src/series/*`, and `tests/`.
+- `build.sh`, `Cargo.toml`, `src/lib.rs`, `src/commands/*`, `src/series/*`, `src/analysis/*`, and `tests/`.

--- a/src/commands/command_parser.rs
+++ b/src/commands/command_parser.rs
@@ -748,6 +748,24 @@ pub(crate) fn parse_ignore_options(args: &mut CommandArgIterator) -> ValkeyResul
     Ok((ignore_max_timediff, ignore_max_val_diff))
 }
 
+/// Rejects a filter set that has nothing to intersect against but the whole keyspace.
+///
+/// Commands take their filters as a list of selectors that are ANDed together, so boundedness
+/// is a property of the list, not of any single selector: `TS.QUERYINDEX n=1 i!=a` is bounded
+/// by `n=1` even though `i!=a` alone is not. One bounded selector anywhere in the list is
+/// therefore enough. This mirrors RedisTimeSeries, whose `FILTER` list is conjunctive and
+/// requires at least one positive matcher across the whole list.
+///
+/// Must be called by every command that assembles a complete filter set — validating a single
+/// selector as it is parsed would reject legitimate multi-argument queries.
+pub fn validate_selector_list(selectors: &[SeriesSelector]) -> ValkeyResult<()> {
+    if selectors.iter().any(SeriesSelector::is_bounded) {
+        Ok(())
+    } else {
+        Err(ValkeyError::Str(error_consts::UNBOUNDED_SERIES_FILTERS))
+    }
+}
+
 pub fn parse_series_selector_list(
     args: &mut CommandArgIterator,
     stop_tokens: &[CommandArgToken],
@@ -772,6 +790,8 @@ pub fn parse_series_selector_list(
     if matchers.is_empty() {
         return Err(ValkeyError::Str(error_consts::MISSING_FILTER));
     }
+
+    validate_selector_list(&matchers)?;
 
     Ok(matchers)
 }
@@ -1203,6 +1223,8 @@ pub(super) fn parse_query_index_command_args(
     if matchers.is_empty() {
         return Err(ValkeyError::Str(error_consts::MISSING_FILTER));
     }
+
+    validate_selector_list(&matchers)?;
 
     Ok(MatchFilterOptions {
         date_range,

--- a/src/commands/command_parser.rs
+++ b/src/commands/command_parser.rs
@@ -766,11 +766,7 @@ pub fn parse_series_selector_list(
             return Err(ValkeyError::Str(error_consts::INVALID_SERIES_SELECTOR));
         }
 
-        if let Ok(selector) = parse_series_selector(arg) {
-            matchers.push(selector);
-        } else {
-            return Err(ValkeyError::Str(error_consts::INVALID_SERIES_SELECTOR));
-        }
+        matchers.push(parse_series_selector(arg)?);
     }
 
     if matchers.is_empty() {

--- a/src/commands/label_search_utils.rs
+++ b/src/commands/label_search_utils.rs
@@ -1,4 +1,4 @@
-use crate::commands::command_parser::parse_filter_by_range_options;
+use crate::commands::command_parser::{parse_filter_by_range_options, validate_selector_list};
 use crate::commands::fanout::LabelSearchType;
 use crate::commands::ts_label_search_fanout_command::LabelSearchFanoutCommand;
 use crate::common::SortDir;
@@ -250,6 +250,7 @@ pub(super) fn parse_label_name_search_args(
                 if filter_count == parsed.series_filter.matchers.len() {
                     return Err(ValkeyError::Str(error_consts::MISSING_FILTER));
                 }
+                validate_selector_list(&parsed.series_filter.matchers)?;
             }
             LabelNameSearchToken::FilterByRange => {
                 let filter = parse_filter_by_range_options(&mut args)?;

--- a/src/error_consts.rs
+++ b/src/error_consts.rs
@@ -38,6 +38,8 @@ pub const INVALID_OR_MISSING_METRIC_NAME: &str = "TSDB: invalid or missing metri
 pub const METRIC_ALREADY_SET: &str = "TSDB: metric already set";
 pub const INVALID_NUMBER: &str = "TSDB: invalid number";
 pub const INVALID_SERIES_SELECTOR: &str = "TSDB: series selector is invalid";
+pub const UNBOUNDED_SERIES_FILTERS: &str =
+    "TSDB: filters must contain at least one matcher that does not match the empty string";
 pub const INVALID_STEP_DURATION: &str = "TSDB: invalid step duration";
 pub const INVALID_TIMESTAMP: &str = "TSDB: invalid timestamp.";
 pub const UNKNOWN_AGGREGATION_TYPE: &str = "TSDB: unknown aggregation type";

--- a/src/labels/filters.rs
+++ b/src/labels/filters.rs
@@ -893,6 +893,13 @@ impl From<Vec<LabelFilter>> for FilterList {
 /// OrFiltersList is a small vector of FilterList, used for OR combinations of AND filters.
 pub type OrFiltersList = SmallVec<[FilterList; 2]>;
 
+/// See [`SeriesSelector::is_bounded`]. An empty group matches every series, so it is unbounded.
+fn filter_group_is_bounded(filters: &FilterList) -> bool {
+    filters
+        .iter()
+        .any(|f| !f.is_negative_matcher() && !f.matches_empty())
+}
+
 #[derive(Debug, Clone, Hash, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 pub enum SeriesSelector {
@@ -907,6 +914,23 @@ impl SeriesSelector {
 
     pub fn with_filters(matchers: Vec<LabelFilter>) -> Self {
         SeriesSelector::And(matchers.into())
+    }
+
+    /// True if this selector on its own restricts the search to a bounded set of series,
+    /// rather than requiring a full keyspace scan.
+    ///
+    /// A filter group is bounded when it holds at least one matcher that cannot be satisfied
+    /// by a missing label — i.e. one that is neither negative (`l!=v`, `l!~re`) nor
+    /// empty-matching (`l=""`, `l=~".*"`). `Or` branches are unioned, so an `Or` selector is
+    /// bounded only when *every* branch is; `And` filters are intersected, so one bounded
+    /// matcher anywhere in the group suffices.
+    pub fn is_bounded(&self) -> bool {
+        match self {
+            SeriesSelector::And(filters) => filter_group_is_bounded(filters),
+            SeriesSelector::Or(groups) => {
+                !groups.is_empty() && groups.iter().all(filter_group_is_bounded)
+            }
+        }
     }
 
     pub fn len(&self) -> usize {

--- a/src/labels/regex.rs
+++ b/src/labels/regex.rs
@@ -3,6 +3,8 @@ use regex::{Regex, RegexBuilder};
 
 /// Sets the approximate size limit, in bytes, of the compiled regex.
 const REGEX_SIZE_LIMIT: usize = 16 * 1024;
+/// Sets the approximate size limit, in bytes, of the cache used by the lazy DFA at match time.
+const DFA_SIZE_LIMIT: usize = 16 * 1024;
 
 /// remove_start_end_anchors removes '^' at the start of expr and '$' at the end of the expr.
 pub fn remove_start_end_anchors(expr: &str) -> &str {
@@ -86,16 +88,25 @@ pub fn try_escape_for_repeat_re(re: &str) -> String {
 /// This escapes the opening "{" if it's not followed by a valid repeat pattern (e.g., 4,6).
 ///
 /// Regexes used in PromQL are fully anchored.
+fn build(re: &str) -> Result<Regex, regex::Error> {
+    // flags to match Prometheus' behavior
+    RegexBuilder::new(re)
+        .size_limit(REGEX_SIZE_LIMIT)
+        .dfa_size_limit(DFA_SIZE_LIMIT)
+        .dot_matches_new_line(true)
+        .build()
+}
+
+/// Compiles `re`, retrying with Go-style `{...}` repeats escaped if the first attempt fails to
+/// parse. Both attempts go through `build`, so the size limit applies on the retry too.
+pub(crate) fn build_with_repeat_fallback(re: &str) -> Result<Regex, regex::Error> {
+    build(re).or_else(|_| build(&try_escape_for_repeat_re(re)))
+}
+
 fn try_parse_re(original_re: &str) -> Result<Regex, ParseError> {
     let re = format!("^(?:{original_re})$",);
 
-    // flags to match Prometheus' behavior
-    RegexBuilder::new(&re)
-        .size_limit(REGEX_SIZE_LIMIT)
-        .dot_matches_new_line(true)
-        .build()
-        .or_else(|_| Regex::new(&try_escape_for_repeat_re(&re)))
-        .map_err(|_| ParseError::InvalidRegex(original_re.to_string()))
+    build_with_repeat_fallback(&re).map_err(|_| ParseError::InvalidRegex(original_re.to_string()))
 }
 
 pub fn parse_regex_anchored(value: &str) -> Result<(Regex, &str), ParseError> {

--- a/src/labels/regex_utils.rs
+++ b/src/labels/regex_utils.rs
@@ -1144,13 +1144,17 @@ mod test {
                 Ok(_) => {
                     // The important property here is that complex patterns should
                     // not be decomposed into simpler forms; they should be
-                    // returned as RegexDecomposition::Regex. Building an exact
-                    // expected Regex object may fail under compilation size
-                    // limits, so just assert the decomposition kind.
-                    let got = decompose_regex(c).unwrap();
-                    match got {
-                        RegexDecomposition::Regex(_) => {}
-                        _ => panic!("pattern {} unexpectedly decomposed", c),
+                    // returned as RegexDecomposition::Regex. Compiling the actual
+                    // Regex object can fail if the pattern exceeds the compiled-size
+                    // limit (e.g. `\w+`'s Unicode-aware character class) -- that is
+                    // also an acceptable outcome, since the limit must be enforced
+                    // consistently rather than silently bypassed.
+                    match decompose_regex(c) {
+                        Ok(RegexDecomposition::Regex(_)) => {}
+                        Ok(other) => {
+                            panic!("pattern {} unexpectedly decomposed to {:?}", c, other)
+                        }
+                        Err(_) => {}
                     }
                 }
                 Err(_) => assert!(

--- a/src/labels/regex_utils.rs
+++ b/src/labels/regex_utils.rs
@@ -6,11 +6,10 @@ use crate::labels::filters::{
     PredicateMatch, PredicateValue, RegexMatcher, validate_contains_value,
     validate_starts_with_value,
 };
-use crate::labels::regex::try_escape_for_repeat_re;
+use crate::labels::regex::build_with_repeat_fallback;
 use crate::parser::{ParseError, ParseResult};
 use regex::Error as RegexError;
 use regex::Regex;
-use regex::RegexBuilder;
 use regex_syntax::hir::Class::{Bytes, Unicode};
 use regex_syntax::hir::{Class, Hir, HirKind, Look};
 use regex_syntax::parse as parse_regex;
@@ -497,11 +496,7 @@ pub fn decompose_regex(expr: &str) -> Result<RegexDecomposition, RegexError> {
 
 pub(crate) fn compile_regex(expr: &str) -> Result<Regex, RegexError> {
     let anchored = format!("^(?:{})$", expr);
-    RegexBuilder::new(&anchored)
-        .size_limit(16 * 1024)
-        .dot_matches_new_line(true)
-        .build()
-        .or_else(|_| Regex::new(&try_escape_for_repeat_re(&anchored)))
+    build_with_repeat_fallback(&anchored)
 }
 
 pub(crate) fn compile_prefixed_regex(

--- a/src/parser/series_selector.rs
+++ b/src/parser/series_selector.rs
@@ -36,7 +36,37 @@ pub fn parse_series_selector(s: &str) -> ParseResult<SeriesSelector> {
     let mut lex = Token::lexer(s);
     let result = parse_series_selector_internal(&mut lex)?;
     expect_token(&mut lex, Token::Eof)?;
+    validate_selector(&result)?;
     Ok(result)
+}
+
+/// A selector (or, for an `OR` selector, each of its branches) made up entirely of matchers
+/// that match the empty string — negative matchers, or matchers like `l=""` / `l=~".*"` that
+/// happen to match empty — has nothing to intersect against but the whole keyspace. Reject it,
+/// mirroring Prometheus's requirement that a selector contain at least one matcher that does
+/// not match the empty string.
+fn validate_selector(selector: &SeriesSelector) -> ParseResult<()> {
+    match selector {
+        SeriesSelector::And(filters) => validate_filter_group(filters),
+        SeriesSelector::Or(groups) => groups.iter().try_for_each(validate_filter_group),
+    }
+}
+
+fn validate_filter_group(filters: &FilterList) -> ParseResult<()> {
+    if filters.is_empty() {
+        return Ok(());
+    }
+    let has_positive_matcher = filters
+        .iter()
+        .any(|f| !f.is_negative_matcher() && !f.matches_empty());
+    if has_positive_matcher {
+        Ok(())
+    } else {
+        Err(ParseError::General(
+            "selector must contain at least one matcher that does not match the empty string"
+                .to_string(),
+        ))
+    }
 }
 
 fn parse_series_selector_internal(p: &mut Lexer<Token>) -> ParseResult<SeriesSelector> {

--- a/src/parser/series_selector.rs
+++ b/src/parser/series_selector.rs
@@ -36,37 +36,7 @@ pub fn parse_series_selector(s: &str) -> ParseResult<SeriesSelector> {
     let mut lex = Token::lexer(s);
     let result = parse_series_selector_internal(&mut lex)?;
     expect_token(&mut lex, Token::Eof)?;
-    validate_selector(&result)?;
     Ok(result)
-}
-
-/// A selector (or, for an `OR` selector, each of its branches) made up entirely of matchers
-/// that match the empty string — negative matchers, or matchers like `l=""` / `l=~".*"` that
-/// happen to match empty — has nothing to intersect against but the whole keyspace. Reject it,
-/// mirroring Prometheus's requirement that a selector contain at least one matcher that does
-/// not match the empty string.
-fn validate_selector(selector: &SeriesSelector) -> ParseResult<()> {
-    match selector {
-        SeriesSelector::And(filters) => validate_filter_group(filters),
-        SeriesSelector::Or(groups) => groups.iter().try_for_each(validate_filter_group),
-    }
-}
-
-fn validate_filter_group(filters: &FilterList) -> ParseResult<()> {
-    if filters.is_empty() {
-        return Ok(());
-    }
-    let has_positive_matcher = filters
-        .iter()
-        .any(|f| !f.is_negative_matcher() && !f.matches_empty());
-    if has_positive_matcher {
-        Ok(())
-    } else {
-        Err(ParseError::General(
-            "selector must contain at least one matcher that does not match the empty string"
-                .to_string(),
-        ))
-    }
 }
 
 fn parse_series_selector_internal(p: &mut Lexer<Token>) -> ParseResult<SeriesSelector> {

--- a/src/parser/series_selector_tests.rs
+++ b/src/parser/series_selector_tests.rs
@@ -1,9 +1,26 @@
 #[cfg(test)]
 mod tests {
+    use crate::commands::command_parser::validate_selector_list;
+    use crate::error_consts;
     use crate::labels::filters::{
         FilterList, LabelFilter, MatchOp, PredicateMatch, PredicateValue, SeriesSelector,
     };
     use crate::labels::parse_series_selector;
+
+    /// Asserts that `selector` parses, but is rejected as the sole filter of a command.
+    fn assert_unbounded_alone(selector: &str) -> SeriesSelector {
+        let parsed = parse_series_selector(selector)
+            .unwrap_or_else(|e| panic!("expected {selector} to parse, got {e}"));
+        assert!(!parsed.is_bounded(), "{selector} should not be bounded");
+        let err = validate_selector_list(std::slice::from_ref(&parsed))
+            .expect_err("selector has no positive matcher");
+        assert_eq!(
+            err.to_string(),
+            error_consts::UNBOUNDED_SERIES_FILTERS,
+            "unexpected error for {selector}"
+        );
+        parsed
+    }
 
     fn assert_matcher(matcher: &LabelFilter, label: &str, op: MatchOp, value: &str) {
         let expected = LabelFilter::create(op, label, value).unwrap();
@@ -137,8 +154,7 @@ mod tests {
 
     #[test]
     fn test_parse_series_selector_multiple_or_conditions() {
-        let selector =
-            r#"{job="prometheus",env="prod" or datacenter=~"us-.*" or instance="localhost",role!="standby"}"#;
+        let selector = r#"{job="prometheus",env="prod" or datacenter=~"us-.*" or instance="localhost",role!="standby"}"#;
         let matchers = parse_series_selector(selector).unwrap();
 
         assert!(matchers.get_metric_name().is_none());
@@ -156,52 +172,80 @@ mod tests {
                 MatchOp::RegexEqual,
                 "us-.*",
             );
-            assert_matcher(
-                &or_matchers[2][0],
-                "instance",
-                MatchOp::Equal,
-                "localhost",
-            );
+            assert_matcher(&or_matchers[2][0], "instance", MatchOp::Equal, "localhost");
             assert_matcher(&or_matchers[2][1], "role", MatchOp::NotEqual, "standby");
         });
     }
 
     #[test]
     fn test_parse_series_selector_or_branch_without_positive_matcher_is_rejected() {
-        // Each OR branch is evaluated independently, so a branch with only a negative
-        // matcher is just as much a full-keyspace scan as a plain selector would be.
-        let selector = r#"{job="prometheus",env="prod" or instance!="localhost"}"#;
-        let err = parse_series_selector(selector).expect_err("branch has no positive matcher");
-        assert!(
-            err.to_string()
-                .contains("at least one matcher that does not match the empty string"),
-            "unexpected error: {err}"
-        );
+        // OR branches are unioned, so an unbounded branch drags the whole selector
+        // unbounded even though the other branch is bounded.
+        assert_unbounded_alone(r#"{job="prometheus",env="prod" or instance!="localhost"}"#);
     }
 
     #[test]
     fn test_parse_series_selector_with_regex_not_equal_matchers() {
-        // A selector consisting solely of negative matchers has nothing to intersect against
-        // but the whole keyspace, so it is rejected (mirrors Prometheus).
-        let input = r#"{job!~"prom.*",instance!~"local.*"}"#;
-        let err = parse_series_selector(input).expect_err("selector has no positive matcher");
-        assert!(
-            err.to_string()
-                .contains("at least one matcher that does not match the empty string"),
-            "unexpected error: {err}"
-        );
+        // A filter set consisting solely of negative matchers has nothing to intersect
+        // against but the whole keyspace, so it is rejected (mirrors RedisTimeSeries).
+        let matchers = assert_unbounded_alone(r#"{job!~"prom.*",instance!~"local.*"}"#);
+
+        assert!(matchers.get_metric_name().is_none());
+        with_and_matchers(&matchers, |and_matchers| {
+            assert_eq!(and_matchers.len(), 2);
+            assert_matcher(&and_matchers[0], "job", MatchOp::RegexNotEqual, "prom.*");
+            assert_matcher(
+                &and_matchers[1],
+                "instance",
+                MatchOp::RegexNotEqual,
+                "local.*",
+            );
+        });
     }
 
     #[test]
     fn test_parse_series_selector_with_negated_label_matchers() {
         // Same as above: two negative matchers, no positive matcher.
-        let input = r#"{job!="prometheus",instance!="localhost:9090"}"#;
-        let err = parse_series_selector(input).expect_err("selector has no positive matcher");
-        assert!(
-            err.to_string()
-                .contains("at least one matcher that does not match the empty string"),
-            "unexpected error: {err}"
-        );
+        let matchers = assert_unbounded_alone(r#"{job!="prometheus",instance!="localhost:9090"}"#);
+
+        assert!(matchers.get_metric_name().is_none());
+        with_and_matchers(&matchers, |and_matchers| {
+            assert_eq!(and_matchers.len(), 2);
+            assert_matcher(&and_matchers[0], "job", MatchOp::NotEqual, "prometheus");
+            assert_matcher(
+                &and_matchers[1],
+                "instance",
+                MatchOp::NotEqual,
+                "localhost:9090",
+            );
+        });
+    }
+
+    #[test]
+    fn test_validate_selector_list_accepts_bounded_sibling() {
+        // The filter list is conjunctive, so one bounded selector bounds the whole query:
+        // `TS.QUERYINDEX n=1 i!=a` must be accepted even though `i!=a` alone is not.
+        let bounded = parse_series_selector("n=1").unwrap();
+        let unbounded = parse_series_selector("i!=a").unwrap();
+        assert!(bounded.is_bounded());
+        assert!(!unbounded.is_bounded());
+
+        validate_selector_list(&[bounded.clone(), unbounded.clone()])
+            .expect("bounded sibling should bound the list");
+        validate_selector_list(&[unbounded.clone(), bounded]).expect("order must not matter");
+        validate_selector_list(&[unbounded]).expect_err("no bounded selector in the list");
+    }
+
+    #[test]
+    fn test_validate_selector_list_rejects_empty_and_empty_matching_filters() {
+        // `l=` (label absent) and `l=~".*"` are both satisfied by a missing label, so neither
+        // narrows the search. `l=~".+"` requires a non-empty value, so it does.
+        for selector in [r#"{i=""}"#, r#"{i=~".*"}"#, r#"{i!=""}"#] {
+            assert_unbounded_alone(selector);
+        }
+        let bounded = parse_series_selector(r#"{i=~".+"}"#).unwrap();
+        assert!(bounded.is_bounded());
+        validate_selector_list(&[bounded]).expect("`.+` cannot match a missing label");
     }
 
     #[test]
@@ -365,13 +409,7 @@ mod tests {
     #[test]
     fn redis_ts_selector_not_equal_with_lists() {
         // A bare NotEqual-with-list selector has no positive matcher and is rejected.
-        let input = "flavor!=(original,cajun,\"extra spicy\")";
-        let err = parse_series_selector(input).expect_err("selector has no positive matcher");
-        assert!(
-            err.to_string()
-                .contains("at least one matcher that does not match the empty string"),
-            "unexpected error: {err}"
-        );
+        assert_unbounded_alone("flavor!=(original,cajun,\"extra spicy\")");
 
         let input = "{size=(small,medium,large),flavor!=(original,cajun,\"extra spicy\")}";
         let result = parse_series_selector(input).unwrap();
@@ -410,13 +448,7 @@ mod tests {
     #[test]
     fn prometheus_selector_not_starts_with_with_lists() {
         // A bare NotStartsWith-with-list selector has no positive matcher and is rejected.
-        let input = r#"{service^~(api,worker)}"#;
-        let err = parse_series_selector(input).expect_err("selector has no positive matcher");
-        assert!(
-            err.to_string()
-                .contains("at least one matcher that does not match the empty string"),
-            "unexpected error: {err}"
-        );
+        assert_unbounded_alone(r#"{service^~(api,worker)}"#);
 
         let input = r#"{env="prod",service^~(api,worker)}"#;
         let result = parse_series_selector(input).unwrap();
@@ -451,13 +483,7 @@ mod tests {
         // `l=~".*"` matches the empty string, so a selector consisting only of such matchers
         // is just as much a full-keyspace scan as `l!="nonexistent"` and is rejected for the
         // same reason.
-        let input = r#"{service=~".*", instance=~"^.*$"}"#;
-        let err = parse_series_selector(input).expect_err("selector has no positive matcher");
-        assert!(
-            err.to_string()
-                .contains("at least one matcher that does not match the empty string"),
-            "unexpected error: {err}"
-        );
+        assert_unbounded_alone(r#"{service=~".*", instance=~"^.*$"}"#);
 
         let input = r#"{job="x", service=~".*", instance=~"^.*$"}"#;
         let result = parse_series_selector(input).unwrap();
@@ -620,13 +646,7 @@ mod tests {
 
     #[test]
     fn test_parse_or_with_list_matchers_branch_without_positive_matcher_is_rejected() {
-        let input = r#"{a="b", foo!="bar" or flavor!=(original,cajun,"extra spicy")}"#;
-        let err = parse_series_selector(input).expect_err("second branch has no positive matcher");
-        assert!(
-            err.to_string()
-                .contains("at least one matcher that does not match the empty string"),
-            "unexpected error: {err}"
-        );
+        assert_unbounded_alone(r#"{a="b", foo!="bar" or flavor!=(original,cajun,"extra spicy")}"#);
     }
 
     #[test]

--- a/src/parser/series_selector_tests.rs
+++ b/src/parser/series_selector_tests.rs
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn test_parse_series_selector_multiple_or_conditions() {
         let selector =
-            r#"{job="prometheus",env="prod" or datacenter=~"us-.*" or instance!="localhost"}"#;
+            r#"{job="prometheus",env="prod" or datacenter=~"us-.*" or instance="localhost",role!="standby"}"#;
         let matchers = parse_series_selector(selector).unwrap();
 
         assert!(matchers.get_metric_name().is_none());
@@ -147,7 +147,7 @@ mod tests {
 
             assert_eq!(or_matchers[0].len(), 2);
             assert_eq!(or_matchers[1].len(), 1);
-            assert_eq!(or_matchers[2].len(), 1);
+            assert_eq!(or_matchers[2].len(), 2);
             assert_matcher(&or_matchers[0][0], "job", MatchOp::Equal, "prometheus");
             assert_matcher(&or_matchers[0][1], "env", MatchOp::Equal, "prod");
             assert_matcher(
@@ -159,40 +159,61 @@ mod tests {
             assert_matcher(
                 &or_matchers[2][0],
                 "instance",
-                MatchOp::NotEqual,
+                MatchOp::Equal,
                 "localhost",
             );
+            assert_matcher(&or_matchers[2][1], "role", MatchOp::NotEqual, "standby");
         });
+    }
+
+    #[test]
+    fn test_parse_series_selector_or_branch_without_positive_matcher_is_rejected() {
+        // Each OR branch is evaluated independently, so a branch with only a negative
+        // matcher is just as much a full-keyspace scan as a plain selector would be.
+        let selector = r#"{job="prometheus",env="prod" or instance!="localhost"}"#;
+        let err = parse_series_selector(selector).expect_err("branch has no positive matcher");
+        assert!(
+            err.to_string()
+                .contains("at least one matcher that does not match the empty string"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
     fn test_parse_series_selector_with_regex_not_equal_matchers() {
+        // A selector consisting solely of negative matchers has nothing to intersect against
+        // but the whole keyspace, so it is rejected (mirrors Prometheus).
         let input = r#"{job!~"prom.*",instance!~"local.*"}"#;
-        let matchers = parse_series_selector(input).unwrap();
-
-        assert!(matchers.get_metric_name().is_none());
-
-        with_and_matchers(&matchers, |and_matchers| {
-            assert_eq!(and_matchers.len(), 2);
-            assert_matcher(&and_matchers[0], "job", MatchOp::RegexNotEqual, "prom.*");
-            assert_matcher(
-                &and_matchers[1],
-                "instance",
-                MatchOp::RegexNotEqual,
-                "local.*",
-            );
-        });
+        let err = parse_series_selector(input).expect_err("selector has no positive matcher");
+        assert!(
+            err.to_string()
+                .contains("at least one matcher that does not match the empty string"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
     fn test_parse_series_selector_with_negated_label_matchers() {
+        // Same as above: two negative matchers, no positive matcher.
         let input = r#"{job!="prometheus",instance!="localhost:9090"}"#;
+        let err = parse_series_selector(input).expect_err("selector has no positive matcher");
+        assert!(
+            err.to_string()
+                .contains("at least one matcher that does not match the empty string"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_series_selector_with_negated_label_matchers_and_positive_matcher() {
+        // Pairing a negative matcher with a positive one is still allowed.
+        let input = r#"{job="prometheus",instance!="localhost:9090"}"#;
         let matchers = parse_series_selector(input).unwrap();
 
         assert!(matchers.get_metric_name().is_none());
         with_and_matchers(&matchers, |and_matchers| {
             assert_eq!(and_matchers.len(), 2);
-            assert_matcher(&and_matchers[0], "job", MatchOp::NotEqual, "prometheus");
+            assert_matcher(&and_matchers[0], "job", MatchOp::Equal, "prometheus");
             assert_matcher(
                 &and_matchers[1],
                 "instance",
@@ -343,13 +364,22 @@ mod tests {
 
     #[test]
     fn redis_ts_selector_not_equal_with_lists() {
+        // A bare NotEqual-with-list selector has no positive matcher and is rejected.
         let input = "flavor!=(original,cajun,\"extra spicy\")";
+        let err = parse_series_selector(input).expect_err("selector has no positive matcher");
+        assert!(
+            err.to_string()
+                .contains("at least one matcher that does not match the empty string"),
+            "unexpected error: {err}"
+        );
+
+        let input = "{size=(small,medium,large),flavor!=(original,cajun,\"extra spicy\")}";
         let result = parse_series_selector(input).unwrap();
 
         with_and_matchers(&result, |matchers| {
-            assert_eq!(matchers.len(), 1);
+            assert_eq!(matchers.len(), 2);
 
-            let matcher = &matchers[0];
+            let matcher = &matchers[1];
             assert_list_matcher(
                 matcher,
                 "flavor",
@@ -379,13 +409,22 @@ mod tests {
 
     #[test]
     fn prometheus_selector_not_starts_with_with_lists() {
+        // A bare NotStartsWith-with-list selector has no positive matcher and is rejected.
         let input = r#"{service^~(api,worker)}"#;
+        let err = parse_series_selector(input).expect_err("selector has no positive matcher");
+        assert!(
+            err.to_string()
+                .contains("at least one matcher that does not match the empty string"),
+            "unexpected error: {err}"
+        );
+
+        let input = r#"{env="prod",service^~(api,worker)}"#;
         let result = parse_series_selector(input).unwrap();
 
         with_and_matchers(&result, |matchers| {
-            assert_eq!(matchers.len(), 1);
+            assert_eq!(matchers.len(), 2);
 
-            let matcher = &matchers[0];
+            let matcher = &matchers[1];
             assert_list_matcher(
                 matcher,
                 "service",
@@ -408,16 +447,27 @@ mod tests {
     }
 
     #[test]
-    fn regex_match_all_selector_normalizes_to_match_all() {
+    fn regex_match_all_selector_normalizes_to_match_all_but_is_rejected() {
+        // `l=~".*"` matches the empty string, so a selector consisting only of such matchers
+        // is just as much a full-keyspace scan as `l!="nonexistent"` and is rejected for the
+        // same reason.
         let input = r#"{service=~".*", instance=~"^.*$"}"#;
+        let err = parse_series_selector(input).expect_err("selector has no positive matcher");
+        assert!(
+            err.to_string()
+                .contains("at least one matcher that does not match the empty string"),
+            "unexpected error: {err}"
+        );
+
+        let input = r#"{job="x", service=~".*", instance=~"^.*$"}"#;
         let result = parse_series_selector(input).unwrap();
 
         with_and_matchers(&result, |matchers| {
-            assert_eq!(matchers.len(), 2);
-            assert_eq!(matchers[0].label, "service");
-            assert!(matches!(matchers[0].matcher, PredicateMatch::MatchAll));
-            assert_eq!(matchers[1].label, "instance");
+            assert_eq!(matchers.len(), 3);
+            assert_eq!(matchers[1].label, "service");
             assert!(matches!(matchers[1].matcher, PredicateMatch::MatchAll));
+            assert_eq!(matchers[2].label, "instance");
+            assert!(matches!(matchers[2].matcher, PredicateMatch::MatchAll));
         });
     }
 
@@ -535,7 +585,7 @@ mod tests {
     // OR tests
     #[test]
     fn test_parse_or_with_list_matchers() {
-        let input = r#"{a="b", foo!="bar" or size=(small,medium,large) or flavor!=(original,cajun,"extra spicy")}"#;
+        let input = r#"{a="b", foo!="bar" or size=(small,medium,large) or color="red",flavor!=(original,cajun,"extra spicy")}"#;
         let result = parse_series_selector(input).unwrap();
 
         assert!(result.get_metric_name().is_none());
@@ -557,14 +607,26 @@ mod tests {
             );
 
             // Third OR branch
-            assert_eq!(or_matchers[2].len(), 1);
+            assert_eq!(or_matchers[2].len(), 2);
+            assert_contains_matcher(&or_matchers[2], "color", MatchOp::Equal, "red");
             assert_list_matcher(
-                &or_matchers[2][0],
+                &or_matchers[2][1],
                 "flavor",
                 MatchOp::NotEqual,
                 &["original", "cajun", "extra spicy"],
             );
         });
+    }
+
+    #[test]
+    fn test_parse_or_with_list_matchers_branch_without_positive_matcher_is_rejected() {
+        let input = r#"{a="b", foo!="bar" or flavor!=(original,cajun,"extra spicy")}"#;
+        let err = parse_series_selector(input).expect_err("second branch has no positive matcher");
+        assert!(
+            err.to_string()
+                .contains("at least one matcher that does not match the empty string"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/tests/test_queryindex_prometheus.py
+++ b/tests/test_queryindex_prometheus.py
@@ -11,6 +11,10 @@ class TestTsQueryIndex(ValkeyTimeSeriesTestCaseBase):
     used by the Prometheus project for their label matching logic.
     """
 
+    def assert_query_rejected(self, *filters):
+        """Assert a TS.QUERYINDEX filter list is rejected for lacking a bounded matcher."""
+        self.assert_filters_rejected('TS.QUERYINDEX', *filters)
+
     def setup_test_data(self, client):
         """Create a set of time series with different label combinations for testing"""
         # Create test series with various labels
@@ -43,9 +47,13 @@ class TestTsQueryIndex(ValkeyTimeSeriesTestCaseBase):
         """Test filtering for series with or without specific labels"""
         self.setup_test_data(self.client)
 
-        # Find series without 'i' label
-        result = sorted(self.client.execute_command('TS.QUERYINDEX', 'i='))
-        assert result == [b'ts1', b'ts5', b'ts6', b'ts8']
+        # 'i=' means "series lacking label i" -- satisfied by every series without the label,
+        # so on its own it is unbounded and rejected.
+        self.assert_query_rejected('i=')
+
+        # Paired with a bounded filter it is allowed, and narrows the result.
+        result = sorted(self.client.execute_command('TS.QUERYINDEX', 'n=1', 'i='))
+        assert result == [b'ts1']
 
         # Find series with 'i' label
         result = sorted(self.client.execute_command('TS.QUERYINDEX', 'i=~".+"'))
@@ -55,17 +63,15 @@ class TestTsQueryIndex(ValkeyTimeSeriesTestCaseBase):
         """Test negation matching with TS.QUERYINDEX"""
         self.setup_test_data(self.client)
 
-        # Not equal to n=1
-        result = sorted(self.client.execute_command('TS.QUERYINDEX', 'n!=1'))
-        assert result == [b'ts5', b'ts6', b'ts7', b'ts8']
+        # A lone negative matcher is unbounded and rejected.
+        self.assert_query_rejected('n!=1')
 
-        # Combine equality and negation
+        # Combine equality and negation -- 'n=1' bounds the query, so 'i!=a' is allowed.
         result = sorted(self.client.execute_command('TS.QUERYINDEX', 'n=1', 'i!=a'))
         assert result == [b'ts1', b'ts3', b'ts4']
 
-        # Negation of empty value (finds all with the label set)
-        result = sorted(self.client.execute_command('TS.QUERYINDEX', 'i!='))
-        assert result == [b'ts2', b'ts3', b'ts4', b'ts7']
+        # Negation of empty value ("has the label set") is still a negative matcher.
+        self.assert_query_rejected('i!=')
 
     def test_regex_matching(self):
         """Test regex matching capabilities of TS.QUERYINDEX"""
@@ -79,13 +85,11 @@ class TestTsQueryIndex(ValkeyTimeSeriesTestCaseBase):
         result = sorted(self.client.execute_command('TS.QUERYINDEX', 'n=~"1|2"'))
         assert result == [b'ts1', b'ts2', b'ts3', b'ts4', b'ts5']
 
-        # Match all with .* pattern
-        # NOTE: Prometheus has a **cough** interesting behavior where `.*` matches all series
-        # regardless of whether they have the label or not. So paradoxically, this matches all series.
-        result = sorted(self.client.execute_command('TS.QUERYINDEX', 'n=~".*"'))
-        assert len(result) == 8  # All series with label 'n'
+        # `.*` matches the empty string, so `n=~".*"` is satisfied by series that lack 'n'
+        # entirely -- it selects everything and is rejected on its own.
+        self.assert_query_rejected('n=~".*"')
 
-        # Match non-empty values with .+
+        # Match non-empty values with .+ -- this cannot match a missing label, so it is bounded.
         result = sorted(self.client.execute_command('TS.QUERYINDEX', 'i=~".+"'))
         assert result == [b'ts2', b'ts3', b'ts4', b'ts7']
 
@@ -93,17 +97,18 @@ class TestTsQueryIndex(ValkeyTimeSeriesTestCaseBase):
         """Test regex negation matching of TS.QUERYINDEX"""
         self.setup_test_data(self.client)
 
-        # Not matching regex
-        result = sorted(self.client.execute_command('TS.QUERYINDEX', 'n!~"^1$"'))
-        assert result == [b'ts5', b'ts6', b'ts7', b'ts8']
+        # Negative regex matchers are unbounded on their own.
+        self.assert_query_rejected('n!~"^1$"')
+        self.assert_query_rejected('n!~"1|2"')
 
-        # Not matching OR pattern
-        result = sorted(self.client.execute_command('TS.QUERYINDEX', 'n!~"1|2"'))
-        assert result == [b'ts6', b'ts7', b'ts8']
-
-        # Not matching anything (should return empty set)
+        # `n!~".*"` is the exception: it normalizes to "match nothing", so it can only ever
+        # return the empty set and is bounded rather than a keyspace scan.
         result = sorted(self.client.execute_command('TS.QUERYINDEX', 'n!~".*"'))
         assert result == []
+
+        # Paired with a bounded filter they are allowed.
+        result = sorted(self.client.execute_command('TS.QUERYINDEX', 'i=~".+"', 'n!~"^1$"'))
+        assert result == [b'ts7']
 
     def test_complex_combinations(self):
         """Test more complex query combinations"""
@@ -192,11 +197,8 @@ class TestTsQueryIndex(ValkeyTimeSeriesTestCaseBase):
         """Test special patterns that match all or none"""
         self.setup_test_data(self.client)
 
-        # Match all series with a wildcard
-        # NOTE: Prometheus has a **cough** interesting behavior where `.*` matches all series
-        # regardless of whether they have the label or not. So paradoxically, this matches all series.
-        result = sorted(self.client.execute_command('TS.QUERYINDEX', 'n=~".*"'))
-        assert len(result) == 8  # All series
+        # A bare wildcard selects every series, bounded by nothing, so it is rejected.
+        self.assert_query_rejected('n=~".*"')
 
         # Match all and filter with another condition
         result = sorted(self.client.execute_command('TS.QUERYINDEX', 'n=~".*"', 'i=a'))

--- a/tests/test_ts_card.py
+++ b/tests/test_ts_card.py
@@ -94,12 +94,17 @@ class TestTsCard(ValkeyTimeSeriesTestCaseBase):
 
         self.setup_data()
 
-        # Inequality filters
-        result = self.client.execute_command('TS.CARD', 'FILTER', 'sensor!=temp')
+        # A filter list of nothing but negative matchers is unbounded and rejected.
+        self.assert_filters_rejected('TS.CARD', 'FILTER', 'sensor!=temp')
+        self.assert_filters_rejected('TS.CARD', 'FILTER', 'sensor!=temp', 'area!=D')
+
+        # Every series here has a 'sensor' label, so 'sensor=~".+"' bounds the query without
+        # excluding anything -- it just supplies the positive matcher the filter list needs.
+        result = self.client.execute_command('TS.CARD', 'FILTER', 'sensor=~".+"', 'sensor!=temp')
         assert result == 3  # ts3, ts4, ts_nodata
 
         # Multiple inequality filters
-        result = self.client.execute_command('TS.CARD', 'FILTER', 'sensor!=temp', 'area!=D')
+        result = self.client.execute_command('TS.CARD', 'FILTER', 'sensor=~".+"', 'sensor!=temp', 'area!=D')
         assert result == 2  # ts3, ts4
 
         # Mix equality and inequality
@@ -120,7 +125,7 @@ class TestTsCard(ValkeyTimeSeriesTestCaseBase):
         assert result == 1  # Only ts1 has data in this early range
 
         # Filter for data after a specific time
-        result = self.client.execute_command('TS.CARD', 'FILTER_BY_RANGE', 2600, 3000, 'FILTER', 'sensor!=light')
+        result = self.client.execute_command('TS.CARD', 'FILTER_BY_RANGE', 2600, 3000, 'FILTER', 'sensor=~".+"', 'sensor!=light')
         assert result == 1  # Only ts4 has data after timestamp 2600
 
         # Filter that matches series but outside their data range
@@ -128,7 +133,7 @@ class TestTsCard(ValkeyTimeSeriesTestCaseBase):
         assert result == 0  # No temp sensors have data after timestamp 3000
 
         # Filter with very wide range
-        result = self.client.execute_command('TS.CARD', 'FILTER_BY_RANGE', 0, 5000, 'FILTER', 'sensor!=light')
+        result = self.client.execute_command('TS.CARD', 'FILTER_BY_RANGE', 0, 5000, 'FILTER', 'sensor=~".+"', 'sensor!=light')
         assert result == 4  # All except ts_nodata because it has no data points
 
     def test_card_with_negative_date_range(self):
@@ -159,7 +164,7 @@ class TestTsCard(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.CARD',
             'FILTER_BY_RANGE', 'NOT', 0, 5000,
-            'FILTER', 'sensor!=light',
+            'FILTER', 'sensor=~".+"', 'sensor!=light',
         )
         assert result == 0
 
@@ -168,7 +173,7 @@ class TestTsCard(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.CARD',
             'FILTER_BY_RANGE', 'NOT', 3000, 4000,
-            'FILTER', 'sensor!=light',
+            'FILTER', 'sensor=~".+"', 'sensor!=light',
         )
         assert result == 4
 

--- a/tests/test_ts_card_cme.py
+++ b/tests/test_ts_card_cme.py
@@ -35,7 +35,11 @@ class TestTsCardClusterCME(ValkeyTimeSeriesClusterTestCase):
         result = client.execute_command('TS.CARD', 'FILTER', 'host=server1')
         assert result == 2
 
-        result = client.execute_command('TS.CARD', 'FILTER', 'type!=memory')
+        # A lone negative matcher is unbounded and rejected; 'host' is on both series, so
+        # 'host=~".+"' supplies the positive matcher without excluding anything.
+        self.assert_filters_rejected('TS.CARD', 'FILTER', 'type!=memory', client=client)
+
+        result = client.execute_command('TS.CARD', 'FILTER', 'host=~".+"', 'type!=memory')
         assert result == 1
 
     def test_cluster_label_filtering(self):
@@ -79,7 +83,13 @@ class TestTsCardClusterCME(ValkeyTimeSeriesClusterTestCase):
         result = node0.execute_command('TS.CARD', 'FILTER', 'cpu{node!="nodeA"}')
         assert result == 2  # CPU metrics on nodeB and nodeC
 
-        result = node0.execute_command('TS.CARD', 'FILTER', '{__name__!="cpu", node!="nodeC"}')
+        # Two negative matchers with nothing positive to intersect against -- rejected.
+        self.assert_filters_rejected(
+            'TS.CARD', 'FILTER', '{__name__!="cpu", node!="nodeC"}', client=node0)
+
+        # Every series has instance="1", so it bounds the query without excluding anything.
+        result = node0.execute_command(
+            'TS.CARD', 'FILTER', '{instance="1", __name__!="cpu", node!="nodeC"}')
         assert result == 2  # memory and disk metrics (not on nodeC)
 
     def test_cluster_date_range_filtering(self):
@@ -104,34 +114,44 @@ class TestTsCardClusterCME(ValkeyTimeSeriesClusterTestCase):
         result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', 1000, 1500, 'FILTER', 'timing=early')
         assert result == 1  # Only early series in this range
 
-        result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', 1000, 3000, 'FILTER', 'slot!=slot2')
+        # A date range does not bound a query -- the filter list still needs a positive
+        # matcher. All three series carry type=test, so it bounds without excluding.
+        self.assert_filters_rejected(
+            'TS.CARD', 'FILTER_BY_RANGE', 1000, 3000, 'FILTER', 'slot!=slot2', client=node0)
+
+        result = node0.execute_command(
+            'TS.CARD', 'FILTER_BY_RANGE', 1000, 3000, 'FILTER', 'type=test', 'slot!=slot2')
         assert result == 2  # early and late series
 
-        result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', 2500, 3500, 'FILTER', 'timing!=early')
+        self.assert_filters_rejected(
+            'TS.CARD', 'FILTER_BY_RANGE', 2500, 3500, 'FILTER', 'timing!=early', client=node0)
+
+        result = node0.execute_command(
+            'TS.CARD', 'FILTER_BY_RANGE', 2500, 3500, 'FILTER', 'type=test', 'timing!=early')
         assert result == 1  # Only late series in this range
 
         # Test with special timestamp values
-        result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', '-', 2500, 'FILTER', 'slot!=slot3')
+        result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', '-', 2500, 'FILTER', 'type=test', 'slot!=slot3')
         assert result == 2  # early and middle series
 
-        result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', 1500, '+', 'FILTER', 'timing!=early')
+        result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', 1500, '+', 'FILTER', 'type=test', 'timing!=early')
         assert result == 2  # middle and late series
 
         # Test negative date range filtering with NOT
         result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', 'NOT', 1000, 1500, 'FILTER', 'type=test')
         assert result == 2  # (excludes early series in range 1000-1500)
 
-        result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', 'NOT', 1500, 2500, 'FILTER', 'slot!=slot1')
+        result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', 'NOT', 1500, 2500, 'FILTER', 'type=test', 'slot!=slot1')
         assert result == 1  # Only late series (excludes middle series in range 1500-2500)
 
         result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', 'NOT', 2500, 3500, 'FILTER', 'type=test')
         assert result == 2  # (excludes middle series)
 
         # Test NOT with special timestamp values
-        result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', 'NOT', '-', 2000, 'FILTER', 'slot!=slot3')
+        result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', 'NOT', '-', 2000, 'FILTER', 'type=test', 'slot!=slot3')
         assert result == 0  # No series excluded (all early/middle data is before/at 2000)
 
-        result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', 'NOT', 2000, '+', 'FILTER', 'timing!=late')
+        result = node0.execute_command('TS.CARD', 'FILTER_BY_RANGE', 'NOT', 2000, '+', 'FILTER', 'type=test', 'timing!=late')
         assert result == 1  # Only early series (excludes middle and late which have data at/after 2000)
 
     def test_cluster_complex_label_queries(self):
@@ -188,8 +208,13 @@ class TestTsCardClusterCME(ValkeyTimeSeriesClusterTestCase):
         result = node0.execute_command('TS.CARD', 'FILTER', 'latency{env!="dev"}')
         assert result == 2  # latency for service1 and service2 (not service3)
 
-        result = node0.execute_command('TS.CARD', 'FILTER', 'app!=', 'metric!=memory')
-        assert result == 5  # All app metrics (5) + infra CPU metrics (2) - infra memory (1) = 6, but app!= matches all series that don't have app label, so it's all series without app label and not memory metric
+        # 'app!=' ("has an app label") is still a negative matcher, so this list has no
+        # positive matcher and is rejected. Every series has a 'metric' label, so
+        # 'metric=~".+"' bounds the query without excluding anything.
+        self.assert_filters_rejected('TS.CARD', 'FILTER', 'app!=', 'metric!=memory', client=node0)
+
+        result = node0.execute_command('TS.CARD', 'FILTER', 'metric=~".+"', 'app!=', 'metric!=memory')
+        assert result == 5  # the 5 app series; none of them is a memory metric
 
     def test_cluster_edge_cases(self):
         """Test edge cases and error conditions in cluster mode"""
@@ -266,7 +291,12 @@ class TestTsCardClusterCME(ValkeyTimeSeriesClusterTestCase):
         result = client.execute_command('TS.CARD', 'FILTER', 'performance{region="us-east", service="api"}')
         assert result == 3  # 3 API instances in us-east
 
-        result = client.execute_command('TS.CARD', 'FILTER', 'service!=cache', 'region!=eu-central')
+        self.assert_filters_rejected(
+            'TS.CARD', 'FILTER', 'service!=cache', 'region!=eu-central', client=client)
+
+        # Every series has a 'service' label, so 'service=~".+"' bounds without excluding.
+        result = client.execute_command(
+            'TS.CARD', 'FILTER', 'service=~".+"', 'service!=cache', 'region!=eu-central')
         assert result == 12  # API and DB in us-east and us-west (2 regions * 2 services * 3 instances)
 
         # Test date range filtering on large dataset
@@ -362,5 +392,10 @@ class TestTsCardClusterCME(ValkeyTimeSeriesClusterTestCase):
         # assert len(user_sessions) == 0 # 15  # 5 users * 3 metrics each
 
         # Test complex filters combining user and metric dimensions
-        result = client.execute_command('TS.CARD', 'FILTER', 'metric!=purchase', 'user_id!=5')
+        self.assert_filters_rejected(
+            'TS.CARD', 'FILTER', 'metric!=purchase', 'user_id!=5', client=client)
+
+        # Every series is category=user_activity, so it bounds without excluding anything.
+        result = client.execute_command(
+            'TS.CARD', 'FILTER', 'category=user_activity', 'metric!=purchase', 'user_id!=5')
         assert result == 8  # login+pageview for users 1-4 (4 users * 2 metrics)

--- a/tests/test_ts_labelnames.py
+++ b/tests/test_ts_labelnames.py
@@ -264,9 +264,13 @@ class TestTsLabelNames(ValkeyTimeSeriesTestCaseBase):
 
         assert result == [b'name', b'node', b'ts5', b'ts6', b'type']
 
-        # Complex filter with regex: nodes that don't match the pattern
-        result = self.exec_sorted_values('FILTER', 'node!~"node[12]"')
-        assert result == [b'location', b'name', b'node', b'rack', b'ts6', b'ts7', b'ts8', b'ts9', b'type']
+        # A lone negative regex matcher is unbounded and rejected.
+        self.assert_filters_rejected('TS.LABELNAMES', 'FILTER', 'node!~"node[12]"')
+
+        # Complex filter with regex: nodes that don't match the pattern. 'name=~".+"' supplies
+        # the positive matcher, which also excludes ts8 and ts9 -- neither has a 'name' label.
+        result = self.exec_sorted_values('FILTER', 'name=~".+"', 'node!~"node[12]"')
+        assert result == [b'name', b'node', b'ts6', b'ts7', b'type']
 
     def test_labelnames_with_empty_database(self):
         """Test TS.LABELNAMES with an empty database"""

--- a/tests/test_ts_labelnames_cme.py
+++ b/tests/test_ts_labelnames_cme.py
@@ -254,6 +254,10 @@ class TestTsLabelNamesCME(ValkeyTimeSeriesClusterTestCase):
         result = exec_sorted_values(client, 'FILTER', 'name=cpu', 'type!=usage')
         assert result == [b'name', b'node', b'ts5', b'ts6', b'type']
 
-        # Complex filter with regex: nodes that don't match the pattern
-        result = exec_sorted_values(client, 'FILTER', 'node!~"node[12]"')
-        assert result == [b'location', b'name', b'node', b'rack', b'ts6', b'ts7', b'ts8', b'ts9', b'type']
+        # A lone negative regex matcher is unbounded and rejected.
+        self.assert_filters_rejected('TS.LABELNAMES', 'FILTER', 'node!~"node[12]"', client=client)
+
+        # Complex filter with regex: nodes that don't match the pattern. 'name=~".+"' supplies
+        # the positive matcher, which also excludes ts8 and ts9 -- neither has a 'name' label.
+        result = exec_sorted_values(client, 'FILTER', 'name=~".+"', 'node!~"node[12]"')
+        assert result == [b'name', b'node', b'ts6', b'ts7', b'type']

--- a/tests/test_ts_mrange_cme.py
+++ b/tests/test_ts_mrange_cme.py
@@ -24,6 +24,25 @@ class TestTimeSeriesMRangeClustered(ValkeyTimeSeriesClusterTestCase):
             cluster_client.execute_command('TS.ADD', 'ts:{slot2}:humid1', self.start_ts + i, 50 + (i % 20))
             cluster_client.execute_command('TS.ADD', 'ts:{slot2}:humid2', self.start_ts + i, 60 + (i % 15))
 
+    def test_mrange_cme_rejects_unbounded_filter(self):
+        """A 'match everything' filter list must still carry a positive matcher.
+
+        The tests below use 'sensor=~".+"' / 'region=~".+"' to select every series. The
+        older idiom 'sensor!=none' selects the same set but is a negative matcher, so a
+        filter list containing only that has nothing to intersect against but the whole
+        keyspace and is rejected.
+        """
+        self.setup_clustered_data()
+
+        client = self.new_client_for_primary(0)
+        self.assert_filters_rejected('TS.MRANGE', self.start_ts, self.start_ts + 100,
+                                     'FILTER', 'sensor!=none', client=client)
+
+        # The bounded form selects every series, since all of them have a 'sensor' label.
+        result = client.execute_command('TS.MRANGE', self.start_ts, self.start_ts + 100,
+                                        'FILTER', 'sensor=~".+"')
+        assert len(result) == 4
+
     def test_mrange_cme_basic(self):
         """Test TS.MRANGE across series in different hash slots."""
         self.setup_clustered_data()
@@ -60,7 +79,7 @@ class TestTimeSeriesMRangeClustered(ValkeyTimeSeriesClusterTestCase):
 
         result = client.execute_command('TS.MRANGE', self.start_ts, self.start_ts + 100,
                                         'WITHLABELS',
-                                        'FILTER', 'region!=none',
+                                        'FILTER', 'region=~".+"',
                                         'GROUPBY', 'region',
                                         'REDUCE', 'sum')
 
@@ -84,7 +103,7 @@ class TestTimeSeriesMRangeClustered(ValkeyTimeSeriesClusterTestCase):
         result = client.execute_command('TS.MRANGE', self.start_ts, self.start_ts + 100,
                                         'AGGREGATION', 'avg', 20,
                                         'WITHLABELS',
-                                        'FILTER', 'sensor!=none',
+                                        'FILTER', 'sensor=~".+"',
                                         'GROUPBY', 'sensor',
                                         'REDUCE', 'max')
 
@@ -120,7 +139,7 @@ class TestTimeSeriesMRangeClustered(ValkeyTimeSeriesClusterTestCase):
         client = self.new_client_for_primary(0)
         result = client.execute_command('TS.MRANGE', self.start_ts, self.start_ts + 100,
                                         'COUNT', 4,
-                                        'FILTER', 'sensor!=none',
+                                        'FILTER', 'sensor=~".+"',
                                         'GROUPBY', 'region',
                                         'REDUCE', 'avg')
 
@@ -150,7 +169,7 @@ class TestTimeSeriesMRangeClustered(ValkeyTimeSeriesClusterTestCase):
         client = self.new_client_for_primary(0)
         result = client.execute_command('TS.MRANGE', self.start_ts, self.start_ts + 100,
                                         'SELECTED_LABELS', 'region',
-                                        'FILTER', 'sensor!=none')
+                                        'FILTER', 'sensor=~".+"')
 
         assert len(result) == 4
         for series in result:
@@ -292,7 +311,7 @@ class TestTimeSeriesMRangeClustered(ValkeyTimeSeriesClusterTestCase):
 
         client = self.new_client_for_primary(0)
         result = client.execute_command('TS.MREVRANGE', self.start_ts, self.start_ts + 100,
-                                        'FILTER', 'region!=none',
+                                        'FILTER', 'region=~".+"',
                                         'GROUPBY', 'sensor',
                                         'REDUCE', 'sum')
 
@@ -343,7 +362,7 @@ class TestTimeSeriesMRangeClustered(ValkeyTimeSeriesClusterTestCase):
         result = client.execute_command(
             'TS.MREVRANGE', self.start_ts, self.start_ts + 100,
             'SELECTED_LABELS', 'region',
-            'FILTER', 'sensor!=none'
+            'FILTER', 'sensor=~".+"'
         )
 
         assert len(result) == 4

--- a/tests/test_ts_multi_aggregation_cme.py
+++ b/tests/test_ts_multi_aggregation_cme.py
@@ -49,6 +49,25 @@ class TestTimeSeriesMultiAggregationClustered(ValkeyTimeSeriesClusterTestCase):
     def series_by_key(result):
         return {series[0]: series[2] for series in result}
 
+    def test_mrange_cme_rejects_unbounded_filter(self):
+        """A 'match everything' filter list must still carry a positive matcher.
+
+        The tests below use 'kind=~".+"' to select every series. The older idiom
+        'kind!=none' selects the same set but is a negative matcher, so a filter list
+        containing only that is rejected as an unbounded keyspace scan.
+        """
+        self.setup_clustered_data()
+        client = self.new_client_for_primary(0)
+
+        self.assert_filters_rejected(
+            'TS.MRANGE', '-', '+', 'AGGREGATION', 'avg', 1000,
+            'FILTER', 'kind!=none', client=client)
+
+        # The bounded form selects every series, since all of them have a 'kind' label.
+        result = client.execute_command(
+            'TS.MRANGE', '-', '+', 'AGGREGATION', 'avg', 1000, 'FILTER', 'kind=~".+"')
+        assert len(result) == 4
+
     def test_mrange_cme_multi_aggregation_basic(self):
         """Per-series multi-aggregation across slots: each bucket row is
         [ts, avg, max, count] in the requested column order."""
@@ -80,14 +99,14 @@ class TestTimeSeriesMultiAggregationClustered(ValkeyTimeSeriesClusterTestCase):
         multi = client.execute_command(
             'TS.MRANGE', '-', '+',
             'AGGREGATION', ','.join(aggregators), 1000,
-            'FILTER', 'kind!=none')
+            'FILTER', 'kind=~".+"')
         multi_by_key = self.series_by_key(multi)
 
         for i, agg in enumerate(aggregators):
             single = client.execute_command(
                 'TS.MRANGE', '-', '+',
                 'AGGREGATION', agg, 1000,
-                'FILTER', 'kind!=none')
+                'FILTER', 'kind=~".+"')
             single_by_key = self.series_by_key(single)
             assert multi_by_key.keys() == single_by_key.keys()
             for key, rows in single_by_key.items():
@@ -190,7 +209,7 @@ class TestTimeSeriesMultiAggregationClustered(ValkeyTimeSeriesClusterTestCase):
 
         queries = [
             ('TS.MRANGE', '-', '+', 'AGGREGATION', 'avg,max,count', 1000,
-             'FILTER', 'kind!=none'),
+             'FILTER', 'kind=~".+"'),
             ('TS.MREVRANGE', '-', '+', 'AGGREGATION', 'sum,min', 1000,
              'COUNT', 2, 'FILTER', 'region=us'),
             ('TS.MRANGE', '-', '+', 'AGGREGATION', 'avg,max', 1000,

--- a/tests/test_ts_queryindex.py
+++ b/tests/test_ts_queryindex.py
@@ -7,6 +7,10 @@ from valkey_timeseries_test_case import ValkeyTimeSeriesTestCaseBase
 
 class TestTsQueryIndex(ValkeyTimeSeriesTestCaseBase):
 
+    def assert_query_rejected(self, *filters):
+        """Assert a TS.QUERYINDEX filter list is rejected for lacking a bounded matcher."""
+        self.assert_filters_rejected('TS.QUERYINDEX', *filters)
+
     def setup_test_data(self, client):
         """Create a set of time series with different label combinations for testing"""
         # Create test series with various labels
@@ -63,29 +67,41 @@ class TestTsQueryIndex(ValkeyTimeSeriesTestCaseBase):
         """Test querying with negation patterns"""
         self.setup_test_data(self.client)
 
-        # Query for all metrics with a name not equal to cpu
-        result = self.client.execute_command('TS.QUERYINDEX', 'name!=cpu')
+        # A bare negative matcher is unbounded and rejected -- it must be paired with a
+        # filter that cannot be satisfied by a missing label.
+        self.assert_query_rejected('name!=cpu')
+        self.assert_query_rejected('type!=usage')
+
+        # Query for all usage metrics with a name not equal to cpu
+        result = self.client.execute_command('TS.QUERYINDEX', 'type=usage', 'name!=cpu')
         assert result == [b'ts3', b'ts4', b'ts7', b'ts8']
 
-        # Query for all metrics with type not matching 'usage'
-        result = self.client.execute_command('TS.QUERYINDEX', 'type!=usage')
+        # Query for all named metrics with type not matching 'usage'
+        result = self.client.execute_command('TS.QUERYINDEX', 'name=~".+"', 'type!=usage')
         assert result == [b'ts5', b'ts6']
 
     def test_prometheus_not_regex_matcher(self):
         """Test Prometheus-style regex negation matchers (label!~"regex")"""
         self.setup_test_data(self.client)
 
+        # Negative regex matchers are unbounded on their own, so each is paired with
+        # 'type=usage' (ts1-ts4, ts7, ts8) or 'name=~".+"' (ts1-ts7) to bound the query.
+        self.assert_query_rejected('name!~"c.*"')
+        self.assert_query_rejected('name!~"cpu|memory"')
+        self.assert_query_rejected('node!~"node[12]"')
+
         # Not matching regex
-        result = self.client.execute_command('TS.QUERYINDEX', 'name!~"c.*"')
+        result = self.client.execute_command('TS.QUERYINDEX', 'type=usage', 'name!~"c.*"')
         assert result == [b'ts3', b'ts4', b'ts7', b'ts8']
 
         # Not matching regex alternation
-        result = self.client.execute_command('TS.QUERYINDEX', 'name!~"cpu|memory"')
+        result = self.client.execute_command('TS.QUERYINDEX', 'type=usage', 'name!~"cpu|memory"')
         assert result == [b'ts7', b'ts8']
 
-        # Not matching using character class
-        result = self.client.execute_command('TS.QUERYINDEX', 'node!~"node[12]"')
-        assert result == [b'ts6', b'ts7', b'ts8']
+        # Not matching using character class. ts8 has no 'node' label -- it would satisfy the
+        # negative matcher, but it has no 'name' either, so the bounding filter excludes it.
+        result = self.client.execute_command('TS.QUERYINDEX', 'name=~".+"', 'node!~"node[12]"')
+        assert result == [b'ts6', b'ts7']
 
     def test_complex_queries(self):
         """Test more complex query combinations"""
@@ -99,28 +115,37 @@ class TestTsQueryIndex(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command('TS.QUERYINDEX', 'name!=cpu', 'type=usage')
         assert result == [b'ts3', b'ts4', b'ts7', b'ts8']
 
-        # Regex not matching
-        result = self.client.execute_command('TS.QUERYINDEX', 'name!~"c.*"')
+        # Regex not matching, bounded by the 'type' filter
+        result = self.client.execute_command('TS.QUERYINDEX', 'type=usage', 'name!~"c.*"')
         assert result == [b'ts3', b'ts4', b'ts7', b'ts8']
 
     def test_missing_labels(self):
         """Test querying for metrics with missing labels"""
         self.setup_test_data(self.client)
 
-        # Find series without the 'name' label
-        result = self.client.execute_command('TS.QUERYINDEX', 'name=')
+        # 'label=' matches every series lacking that label, so it cannot bound a query
+        # on its own and must be paired with a bounded filter.
+        self.assert_query_rejected('name=')
+        self.assert_query_rejected('node=')
+
+        # Find usage series without the 'name' label
+        result = self.client.execute_command('TS.QUERYINDEX', 'type=usage', 'name=')
         assert result == [b'ts8']
 
-        # Find series without the 'node' label
-        result = self.client.execute_command('TS.QUERYINDEX', 'node=')
+        # Find usage series without the 'node' label
+        result = self.client.execute_command('TS.QUERYINDEX', 'type=usage', 'node=')
         assert result == [b'ts8']
 
     def test_combined_operations(self):
         """Test combination of different operations"""
         self.setup_test_data(self.client)
 
+        # Both filters here match a missing label -- `.*` matches empty and `!=` is negative --
+        # so the list as a whole is unbounded and rejected. `.+` is the bounded form.
+        self.assert_query_rejected('name=~".*"', 'type!=usage')
+
         # Find series that match regex but don't match another condition
-        result = self.client.execute_command('TS.QUERYINDEX', 'name=~".*"', 'type!=usage')
+        result = self.client.execute_command('TS.QUERYINDEX', 'name=~".+"', 'type!=usage')
         assert result == [b'ts5', b'ts6']
 
         # Mix of equals, not equals, and regex

--- a/tests/test_ts_queryindex_cme.py
+++ b/tests/test_ts_queryindex_cme.py
@@ -83,12 +83,17 @@ class TestTsQueryIndex(ValkeyTimeSeriesClusterTestCase):
         client = self.new_client_for_primary(0)
         self.setup_test_data(cluster)
 
-        # Query for all metrics with a name not equal to cpu
-        result = client.execute_command('TS.QUERYINDEX', 'name!=cpu')
+        # A bare negative matcher is unbounded and rejected -- it must be paired with a
+        # filter that cannot be satisfied by a missing label.
+        self.assert_filters_rejected('TS.QUERYINDEX', 'name!=cpu', client=client)
+        self.assert_filters_rejected('TS.QUERYINDEX', 'type!=usage', client=client)
+
+        # Query for all usage metrics with a name not equal to cpu
+        result = client.execute_command('TS.QUERYINDEX', 'type=usage', 'name!=cpu')
         assert result == [TS3, TS4, TS7, TS8]
 
-        # Query for all metrics with type not matching 'usage'
-        result = client.execute_command('TS.QUERYINDEX', 'type!=usage')
+        # Query for all named metrics with type not matching 'usage'
+        result = client.execute_command('TS.QUERYINDEX', 'name=~".+"', 'type!=usage')
         assert result == [TS5, TS6]
 
     def test_prometheus_not_regex_matcher(self):
@@ -97,17 +102,24 @@ class TestTsQueryIndex(ValkeyTimeSeriesClusterTestCase):
         client = self.new_client_for_primary(0)
         self.setup_test_data(cluster)
 
+        # Negative regex matchers are unbounded on their own, so each is paired with
+        # 'type=usage' or 'name=~".+"' to bound the query.
+        self.assert_filters_rejected('TS.QUERYINDEX', 'name!~"c.*"', client=client)
+        self.assert_filters_rejected('TS.QUERYINDEX', 'name!~"cpu|memory"', client=client)
+        self.assert_filters_rejected('TS.QUERYINDEX', 'node!~"node[12]"', client=client)
+
         # Not matching regex
-        result = client.execute_command('TS.QUERYINDEX', 'name!~"c.*"')
+        result = client.execute_command('TS.QUERYINDEX', 'type=usage', 'name!~"c.*"')
         assert result == [TS3, TS4, TS7, TS8]
 
         # Not matching regex alternation
-        result = client.execute_command('TS.QUERYINDEX', 'name!~"cpu|memory"')
+        result = client.execute_command('TS.QUERYINDEX', 'type=usage', 'name!~"cpu|memory"')
         assert result == [TS7, TS8]
 
-        # Not matching using character class
-        result = client.execute_command('TS.QUERYINDEX', 'node!~"node[12]"')
-        assert result == [TS6, TS7, TS8]
+        # Not matching using character class. TS8 has no 'node' label -- it would satisfy the
+        # negative matcher, but it has no 'name' either, so the bounding filter excludes it.
+        result = client.execute_command('TS.QUERYINDEX', 'name=~".+"', 'node!~"node[12]"')
+        assert result == [TS6, TS7]
 
     def test_complex_queries(self):
         """Test more complex query combinations"""
@@ -123,8 +135,8 @@ class TestTsQueryIndex(ValkeyTimeSeriesClusterTestCase):
         result = client.execute_command('TS.QUERYINDEX', 'name!=cpu', 'type=usage')
         assert result == [TS3, TS4, TS7, TS8]
 
-        # Regex not matching
-        result = client.execute_command('TS.QUERYINDEX', 'name!~"c.*"')
+        # Regex not matching, bounded by the 'type' filter
+        result = client.execute_command('TS.QUERYINDEX', 'type=usage', 'name!~"c.*"')
         assert result == [TS3, TS4, TS7, TS8]
 
     def test_missing_labels(self):
@@ -133,12 +145,17 @@ class TestTsQueryIndex(ValkeyTimeSeriesClusterTestCase):
         client = self.new_client_for_primary(0)
         self.setup_test_data(cluster)
 
-        # Find series without the 'name' label
-        result = client.execute_command('TS.QUERYINDEX', 'name=')
+        # 'label=' matches every series lacking that label, so it cannot bound a query
+        # on its own and must be paired with a bounded filter.
+        self.assert_filters_rejected('TS.QUERYINDEX', 'name=', client=client)
+        self.assert_filters_rejected('TS.QUERYINDEX', 'node=', client=client)
+
+        # Find usage series without the 'name' label
+        result = client.execute_command('TS.QUERYINDEX', 'type=usage', 'name=')
         assert result == [TS8]
 
-        # Find series without the 'node' label
-        result = client.execute_command('TS.QUERYINDEX', 'node=')
+        # Find usage series without the 'node' label
+        result = client.execute_command('TS.QUERYINDEX', 'type=usage', 'node=')
         assert result == [TS8]
 
     def test_combined_operations(self):
@@ -147,8 +164,12 @@ class TestTsQueryIndex(ValkeyTimeSeriesClusterTestCase):
         self.setup_test_data(cluster)
         client = self.new_client_for_primary(0)
 
+        # Both filters here match a missing label -- `.*` matches empty and `!=` is negative --
+        # so the list as a whole is unbounded and rejected. `.+` is the bounded form.
+        self.assert_filters_rejected('TS.QUERYINDEX', 'name=~".*"', 'type!=usage', client=client)
+
         # Find series that match regex but don't match another condition
-        result = client.execute_command('TS.QUERYINDEX', 'name=~".*"', 'type!=usage')
+        result = client.execute_command('TS.QUERYINDEX', 'name=~".+"', 'type!=usage')
         assert result == [TS5, TS6]
 
         # Mix of equals, not equals, and regex

--- a/tests/valkey_timeseries_test_case.py
+++ b/tests/valkey_timeseries_test_case.py
@@ -240,6 +240,18 @@ class ValkeyTimeSeriesTestCaseCommon(ValkeyTestCase):
             else:
                 assert info_dict[k] == v, f"Expected {k} to be {v}, but got {info_dict[k]}"
 
+    # A filter list must contain at least one matcher that cannot be satisfied by a missing
+    # label, so that a query never degenerates into a full keyspace scan. Filters are
+    # conjunctive, so the requirement applies to the list as a whole: one bounded filter
+    # licenses any number of negative or empty-matching ones alongside it.
+    UNBOUNDED_FILTER_ERROR = "at least one matcher that does not match the empty string"
+
+    def assert_filters_rejected(self, *args, client=None):
+        """Assert a command is rejected because its filter list lacks a bounded matcher."""
+        client = client if client is not None else self.client
+        with pytest.raises(ResponseError, match=self.UNBOUNDED_FILTER_ERROR):
+            client.execute_command(*args)
+
     def verify_error_response(self, client, cmd, expected_err_reply):
         try:
             client.execute_command(cmd)


### PR DESCRIPTION
This pull request introduces several improvements and important behavioral changes to series selector parsing and regex handling, along with expanded documentation and more robust tests. The most significant update is the enforcement of a validation rule that rejects selectors (and OR branches) that do not contain at least one matcher that cannot match the empty string, aligning the behavior with Prometheus and preventing expensive full-keyspace scans. Regex compilation is also made more robust and consistent, and the documentation is updated to reflect new subsystems and conventions.

**Behavioral changes to series selector parsing:**

* Selectors (and OR branches) are now validated to ensure that at least one matcher does not match the empty string; selectors made up entirely of negative or empty-match matchers are rejected, mirroring Prometheus's behavior. [[1]](diffhunk://#diff-d4489554b8c91a358902c23fae5af46f26f731ca176a4960de524b16e4ca65f0R39-R71) [[2]](diffhunk://#diff-8a83b140fb5dd1682fa36b2879eaaebe8e8a4919f3d74abda98668d2aa731541L162-R216) [[3]](diffhunk://#diff-8a83b140fb5dd1682fa36b2879eaaebe8e8a4919f3d74abda98668d2aa731541R367-R382) [[4]](diffhunk://#diff-8a83b140fb5dd1682fa36b2879eaaebe8e8a4919f3d74abda98668d2aa731541R412-R427) [[5]](diffhunk://#diff-8a83b140fb5dd1682fa36b2879eaaebe8e8a4919f3d74abda98668d2aa731541L411-R470)
* Tests are updated and expanded to cover these new validation rules, including cases for negative matchers, regex match-all, and OR-branch validation. [[1]](diffhunk://#diff-8a83b140fb5dd1682fa36b2879eaaebe8e8a4919f3d74abda98668d2aa731541L141-R141) [[2]](diffhunk://#diff-8a83b140fb5dd1682fa36b2879eaaebe8e8a4919f3d74abda98668d2aa731541L150-R150) [[3]](diffhunk://#diff-8a83b140fb5dd1682fa36b2879eaaebe8e8a4919f3d74abda98668d2aa731541L162-R216) [[4]](diffhunk://#diff-8a83b140fb5dd1682fa36b2879eaaebe8e8a4919f3d74abda98668d2aa731541R367-R382) [[5]](diffhunk://#diff-8a83b140fb5dd1682fa36b2879eaaebe8e8a4919f3d74abda98668d2aa731541R412-R427) [[6]](diffhunk://#diff-8a83b140fb5dd1682fa36b2879eaaebe8e8a4919f3d74abda98668d2aa731541L411-R470) [[7]](diffhunk://#diff-8a83b140fb5dd1682fa36b2879eaaebe8e8a4919f3d74abda98668d2aa731541L538-R588)

**Regex compilation improvements:**

* Regex compilation now consistently applies size limits and handles fallback for Go-style `{...}` repeats via a new `build_with_repeat_fallback` utility, used throughout label regex handling. [[1]](diffhunk://#diff-f83bf927c56f739b6b29dc3290c801f63ef42c18daa3900c4b1b98dbbe3b2753R6-R7) [[2]](diffhunk://#diff-f83bf927c56f739b6b29dc3290c801f63ef42c18daa3900c4b1b98dbbe3b2753L89-R109) [[3]](diffhunk://#diff-b960a8fa9e9bc1e40ac0ef34c7aa404d702d15b9878e17fadcb4103a71a4f84bL9-L13) [[4]](diffhunk://#diff-b960a8fa9e9bc1e40ac0ef34c7aa404d702d15b9878e17fadcb4103a71a4f84bL500-R499)
* Tests for regex decomposition are clarified to allow for expected failures due to enforced size limits, ensuring consistent and predictable behavior.

**Documentation updates:**

* The architecture and key files sections in `AGENTS.md` are expanded to document new subsystems (e.g., outlier detection, aggregation, supporting utilities) and to clarify conventions, initialization order, and the current set of registered commands. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R42-R70) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R92-R112) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L92-R123)

**Parser and API simplification:**

* The `parse_series_selector_list` function is simplified to use the `?` operator for error propagation, improving readability.

These changes collectively improve query safety, maintainability, and documentation clarity.