### PR TITLE
[FEATURE] Persist postings index as RDB aux data to eliminate startup reindex cost

### DIFF
--- a/src/common/string_interner.rs
+++ b/src/common/string_interner.rs
@@ -604,7 +604,7 @@ mod tests {
     // Helper to reset memory tracking before each test
     fn reset_memory_tracking() {
         STRING_MEMORY_USED.store(0, std::sync::atomic::Ordering::SeqCst);
-        STRING_POOL.write().unwrap().clear();
+        crate::common::sync::write_lock(&STRING_POOL).clear();
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -238,7 +238,7 @@ pub fn is_index_persist_enabled() -> bool {
 }
 
 /// Cap on the transient buffer used by the sorted bulk index build during RDB/replication
-/// loads (`ts-index-bulk-build-max-memory`, bytes, 0 = unlimited; default 256MiB). The buffer holds `(id, key, label-keys)`
+/// loads (`ts-index-build-max-memory`, bytes, 0 = unlimited; default 256MiB). The buffer holds `(id, key, label-keys)`
 /// tuples at exactly the moment the loading dataset's own footprint peaks, so it must be
 /// bounded: crossing the cap drains the buffer with one sorted bulk build and degrades to
 /// per-key indexing for the remainder of the load window (`bulk_build.rs`).

--- a/src/config.rs
+++ b/src/config.rs
@@ -221,6 +221,18 @@ pub fn is_fanout_aggregation_pushdown_enabled() -> bool {
     FANOUT_AGGREGATION_PUSHDOWN.load(Ordering::Relaxed)
 }
 
+/// Runtime toggle for persisting the postings index as an RDB aux field
+/// (`ts-index-persist`, default on; see docs/postings-index-persistence.md).
+/// Gates both save and load: with it off, BGSAVE writes no aux payload and
+/// load discards any payload found in the RDB (the payload is still consumed
+/// to keep the RDB stream in sync) and rebuilds the index per key. Loading a
+/// payload-bearing RDB is always tolerated regardless of this setting.
+pub static INDEX_PERSIST: AtomicBool = AtomicBool::new(true);
+
+pub fn is_index_persist_enabled() -> bool {
+    INDEX_PERSIST.load(Ordering::Relaxed)
+}
+
 static SETTINGS: LazyLock<RwLock<ConfigSettings>> =
     LazyLock::new(|| RwLock::from(ConfigSettings::default()));
 
@@ -797,6 +809,18 @@ pub(super) fn register_config(ctx: &Context, args: &[ValkeyString]) -> ValkeyRes
         "ts-fanout-aggregation-pushdown",
         &FANOUT_AGGREGATION_PUSHDOWN,
         fanout_pushdown_default,
+        ConfigurationFlags::DEFAULT,
+        None,
+        Some(Box::new(on_bool_config_set)),
+    );
+
+    let index_persist_default = get_bool_default_config_value(args, "ts-index-persist", true)?;
+
+    register_bool_configuration(
+        ctx,
+        "ts-index-persist",
+        &INDEX_PERSIST,
+        index_persist_default,
         ConfigurationFlags::DEFAULT,
         None,
         Some(Box::new(on_bool_config_set)),

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,10 @@ pub(crate) const CHUNK_ENCODING_DEFAULT_STRING: &str = DEFAULT_CHUNK_ENCODING.na
 pub(crate) const CHUNK_SIZE_DEFAULT_STRING: &str = "4096";
 pub(crate) const DEFAULT_COMPACTION_POLICY: &str = "";
 
+pub const INDEX_BUILD_MAX_MEMORY_MIN: i64 = 0; // 0 = unlimited
+pub const INDEX_BUILD_MAX_MEMORY_MAX: i64 = i64::MAX;
+pub const INDEX_BUILD_MAX_MEMORY_DEFAULT: i64 = 256 * 1024 * 1024; // 256 MiB
+
 pub const CLUSTER_MAP_EXPIRATION_MS_DEFAULT: u64 = 750; // default: 0.25 second
 pub(crate) const CLUSTER_MAP_EXPIRATION_MIN_MS: i64 = 0; // min: 0 (no cache)
 pub(crate) const CLUSTER_MAP_EXPIRATION_MAX_MS: i64 = 3_600_000; // max: 1 hour
@@ -231,6 +235,17 @@ pub static INDEX_PERSIST: AtomicBool = AtomicBool::new(true);
 
 pub fn is_index_persist_enabled() -> bool {
     INDEX_PERSIST.load(Ordering::Relaxed)
+}
+
+/// Cap on the transient buffer used by the sorted bulk index build during RDB/replication
+/// loads (`ts-index-bulk-build-max-memory`, bytes, 0 = unlimited; default 256MiB). The buffer holds `(id, key, label-keys)`
+/// tuples at exactly the moment the loading dataset's own footprint peaks, so it must be
+/// bounded: crossing the cap drains the buffer with one sorted bulk build and degrades to
+/// per-key indexing for the remainder of the load window (`bulk_build.rs`).
+pub static INDEX_BUILD_MAX_MEMORY: AtomicI64 = AtomicI64::new(INDEX_BUILD_MAX_MEMORY_DEFAULT);
+
+pub fn index_build_max_memory() -> i64 {
+    INDEX_BUILD_MAX_MEMORY.load(Ordering::Relaxed)
 }
 
 static SETTINGS: LazyLock<RwLock<ConfigSettings>> =
@@ -824,6 +839,23 @@ pub(super) fn register_config(ctx: &Context, args: &[ValkeyString]) -> ValkeyRes
         ConfigurationFlags::DEFAULT,
         None,
         Some(Box::new(on_bool_config_set)),
+    );
+
+    let bulk_build_max_memory_default = get_i64_default(
+        args,
+        "ts-index-build-max-memory",
+        INDEX_BUILD_MAX_MEMORY_DEFAULT,
+    )?;
+    register_i64_configuration(
+        ctx,
+        "ts-index-build-max-memory",
+        &INDEX_BUILD_MAX_MEMORY,
+        bulk_build_max_memory_default,
+        INDEX_BUILD_MAX_MEMORY_MIN,
+        INDEX_BUILD_MAX_MEMORY_MAX,
+        ConfigurationFlags::DEFAULT,
+        None,
+        None,
     );
 
     // Initialize config settings

--- a/src/fanout/cluster_migrations.rs
+++ b/src/fanout/cluster_migrations.rs
@@ -1,3 +1,4 @@
+use crate::common::sync::{read_lock, write_lock};
 use crate::fanout::cluster_map::NUM_SLOTS;
 use crate::fanout::is_clustered;
 use range_set_blaze::RangeSetBlaze;
@@ -309,7 +310,7 @@ unsafe extern "C" fn on_atomic_slot_migration_event(
     data: *mut c_void,
 ) {
     fn raise_event(event: AtomicSlotMigrationEvent, data: *mut c_void) {
-        if let Some(handler) = *EVENT_HANDLER_FN.read().unwrap() {
+        if let Some(handler) = *read_lock(&EVENT_HANDLER_FN) {
             let info = unsafe { &*(data as *const ValkeyModuleAtomicSlotMigrationInfo) };
             let slots = info.convert_slot_ranges();
             handler(event, slots);
@@ -338,7 +339,7 @@ pub fn register_atomic_slot_migration_event_handler(
     on_event: Option<AtomicSlotMigrationEventHandler>,
 ) {
     {
-        let mut guard = EVENT_HANDLER_FN.write().unwrap();
+        let mut guard = write_lock(&EVENT_HANDLER_FN);
         *guard = on_event;
     }
     let res = unsafe {

--- a/src/fanout/fanout_command.rs
+++ b/src/fanout/fanout_command.rs
@@ -1,6 +1,7 @@
 use super::acl::{get_fanout_user, with_fanout_user};
 use super::cluster_rpc::{get_cluster_command_timeout, invoke_rpc};
 use super::fanout_error::{ErrorKind, FanoutError};
+use crate::common::sync::lock;
 use crate::common::threads::spawn;
 use crate::fanout::serialization::{Deserialized, Serializable};
 use crate::fanout::{FanoutResult, FanoutTargetMode, FanoutTargets, NodeInfo, get_fanout_targets};
@@ -120,12 +121,7 @@ where
         // when there are multiple outstanding requests, push the local request to the thread pool to avoid blocking.
         if outstanding > 1 {
             // push to the thread pool
-            let req_local = state
-                .inner
-                .lock()
-                .expect(MUTEX_POISONED_MSG)
-                .operation
-                .generate_request();
+            let req_local = lock(&state.inner).operation.generate_request();
             let local_state = state.clone();
             spawn_local_request(local_state, req_local, *local, fanout_user.clone());
         } else {
@@ -342,8 +338,6 @@ where
     inner: Mutex<FanoutStateInner<OP, F>>,
 }
 
-static MUTEX_POISONED_MSG: &str = "FanoutState mutex poisoned";
-
 impl<OP, F> FanoutState<OP, F>
 where
     OP: FanoutCommand + 'static,
@@ -364,12 +358,12 @@ where
     }
 
     fn on_error(&self, error: FanoutError, target: &NodeInfo) {
-        let mut inner = self.inner.lock().expect(MUTEX_POISONED_MSG);
+        let mut inner = lock(&self.inner);
         inner.on_error(error, target);
     }
 
     fn on_response(&self, resp: OP::Response, target: &NodeInfo) {
-        let mut inner = self.inner.lock().expect(MUTEX_POISONED_MSG);
+        let mut inner = lock(&self.inner);
         inner.on_response(resp, target);
     }
 

--- a/src/series/background_tasks.rs
+++ b/src/series/background_tasks.rs
@@ -1,6 +1,7 @@
 use crate::common::hash::BuildNoHashHasher;
 use crate::common::logging::log_debug;
 use crate::is_shutting_down;
+use crate::series::index::persistence::is_loading_active;
 use crate::series::index::{IndexKey, TIMESERIES_INDEX};
 use crate::series::tasks::{
     optimize_indices_for_db, process_series_trim, remove_stale_series_ids_incremental,
@@ -159,7 +160,7 @@ fn dispatch_background_task(task: TaskType) {
 
 #[cron_event_handler]
 fn cron_event_handler(_ctx: &Context, _hz: u64) {
-    if is_shutting_down() {
+    if is_shutting_down() || is_loading_active() {
         return;
     }
 

--- a/src/series/index/bulk_build.rs
+++ b/src/series/index/bulk_build.rs
@@ -1,0 +1,264 @@
+//! Sorted bulk-build fallback for index rebuild during load
+//!
+//! When a load window opens and a db's index was NOT preloaded from the RDB aux payload
+//! (payload absent, version-mismatched, corrupt, or `ts-index-persist` off at save time), the
+//! per-key rebuild pays O(labels) ART lookups and bitmap adds for every `loaded` key. This
+//! module defers that work: each loaded series is buffered as an `(id, key, label-keys)` tuple,
+//! and at `LoadingSubevent::Ended` the buffer is drained with one sorted bulk build per db
+//! ([`Postings::bulk_index`]): sorted-order ART inserts and one `add_many` per posting list.
+//!
+//! Scope: only RDB (`RdbStarted`) and replication full-sync (`ReplStarted`) windows. An AOF
+//! load is excluded because its command tail replays into a keyspace whose buffered keys are
+//! not indexed yet — a `DEL` or `RENAME` of a buffered key followed by re-creation would leave
+//! a dangling id at drain time. Pure RDB/repl windows execute no commands, so nothing can
+//! mutate a buffered key before the drain. For the same reason the drain at `Ended` runs
+//! synchronously on the main thread: the index must be complete before serving resumes,
+//! matching the per-key path's guarantee.
+//!
+//! Memory bounding: the buffer is transient overhead on top of a keyspace that is itself still
+//! filling, so it is capped by `ts-index-build-max-memory` (bytes, 0 = unlimited). On
+//! crossing the cap the buffer is drained immediately (the sorted work already collected is not
+//! wasted) and indexing degrades to the per-key path for the remainder of the load window.
+
+use super::postings::BulkIndexEntry;
+use super::{IndexKey, get_db_index};
+use crate::common::logging::{log_debug, log_notice};
+use crate::common::sync::lock;
+use crate::config::index_build_max_memory;
+use crate::labels::InternedLabel;
+use crate::series::get_timeseries_mut;
+use blart::AsBytes;
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use valkey_module::Context;
+
+/// Per-db buffered entries for the current load window. All access is from the main thread
+/// (`loaded` notifications and loading events); the mutex only makes the static `Sync`.
+static BULK_BUFFERS: Mutex<BTreeMap<i32, Vec<BulkIndexEntry>>> = Mutex::new(BTreeMap::new());
+
+/// Estimated heap footprint of everything in `BULK_BUFFERS` (see [`entry_footprint`]).
+static BULK_BUFFER_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+/// Buffering is engaged for the current load window (RDB/repl load in progress).
+static BULK_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// The memory cap was crossed: the buffer has been drained and the remainder of the load
+/// window uses the per-key path.
+static BULK_DEGRADED: AtomicBool = AtomicBool::new(false);
+
+/// Loading `*Started`: engage buffering for RDB/repl windows; AOF keeps the per-key path
+/// (see the module docs for why).
+pub(crate) fn on_load_started(is_aof: bool) {
+    BULK_ACTIVE.store(!is_aof, Ordering::Relaxed);
+    BULK_DEGRADED.store(false, Ordering::Relaxed);
+    // Defensive: leftover state from an earlier load cycle is stale by now.
+    lock(&BULK_BUFFERS).clear();
+    BULK_BUFFER_BYTES.store(0, Ordering::Relaxed);
+}
+
+/// Loading `Ended`: drain the buffer into the per-db indexes. Runs synchronously on the main
+/// thread so the index is complete before the server resumes serving.
+pub(crate) fn on_load_ended() {
+    if !BULK_ACTIVE.swap(false, Ordering::Relaxed) {
+        return;
+    }
+    drain_buffers("load end");
+    BULK_DEGRADED.store(false, Ordering::Relaxed);
+}
+
+/// Loading `Failed`: the keyspace state is engine-dependent (startup aborts; a replica may
+/// restore its pre-sync dataset), so drop the buffer — nothing from it was indexed, which is
+/// strictly safer than the per-key path (which would already have indexed those keys).
+pub(crate) fn on_load_failed() {
+    BULK_ACTIVE.store(false, Ordering::Relaxed);
+    BULK_DEGRADED.store(false, Ordering::Relaxed);
+    let discarded = {
+        let mut buffers = lock(&BULK_BUFFERS);
+        let n: usize = buffers.values().map(Vec::len).sum();
+        buffers.clear();
+        n
+    };
+    BULK_BUFFER_BYTES.store(0, Ordering::Relaxed);
+    if discarded > 0 {
+        log_notice(format!(
+            "Load failed; discarded {discarded} series buffered for bulk index build"
+        ));
+    }
+}
+
+/// Buffers one `loaded` key for the end-of-load bulk build. Returns `true` when the key was
+/// handled here (buffered, or not a live timeseries key — the per-key path would also index
+/// nothing for those); `false` when buffering is inactive for this window (AOF load, memory cap
+/// crossed) and the caller should fall through to `index_series_by_key`.
+pub(crate) fn try_buffer_loaded_key(ctx: &Context, db: i32, key: &[u8]) -> bool {
+    if !BULK_ACTIVE.load(Ordering::Relaxed) || BULK_DEGRADED.load(Ordering::Relaxed) {
+        return false;
+    }
+
+    let valkey_key = ctx.create_string(key);
+    let Ok(Some(mut series)) = get_timeseries_mut(ctx, &valkey_key, false, None) else {
+        return true;
+    };
+    series._db = Some(db);
+
+    let label_keys: Vec<IndexKey> = series
+        .labels
+        .iter()
+        .map(|InternedLabel { name, value }| IndexKey::for_label_value(name, value))
+        .collect();
+    let entry = BulkIndexEntry {
+        id: series.id,
+        key: key.to_vec().into_boxed_slice(),
+        label_keys,
+    };
+
+    buffer_entry(db, entry);
+    true
+}
+
+/// Appends `entry` to `db`'s buffer, tracking the memory estimate; on crossing
+/// `ts-index-build-max-memory`, drains everything collected so far and degrades to the
+/// per-key path for the remainder of the load window.
+fn buffer_entry(db: i32, entry: BulkIndexEntry) {
+    let footprint = entry_footprint(&entry);
+    let total = BULK_BUFFER_BYTES.fetch_add(footprint, Ordering::Relaxed) + footprint;
+    lock(&BULK_BUFFERS).entry(db).or_default().push(entry);
+
+    let max_bytes = index_build_max_memory();
+    if max_bytes > 0 && total > max_bytes as usize {
+        log_notice(format!(
+            "Bulk index build buffer reached {total} bytes (ts-index-build-max-memory = \
+             {max_bytes}); draining now and switching to per-key indexing for the rest of the load"
+        ));
+        BULK_DEGRADED.store(true, Ordering::Relaxed);
+        drain_buffers("memory cap");
+    }
+}
+
+/// Estimated heap footprint of one buffered entry: key bytes + label-key bytes (each IndexKey
+/// carries a NUL sentinel, included via `as_bytes`) + fixed per-allocation bookkeeping.
+fn entry_footprint(entry: &BulkIndexEntry) -> usize {
+    size_of::<BulkIndexEntry>()
+        + entry.key.len()
+        + entry
+            .label_keys
+            .iter()
+            .map(|k| size_of::<IndexKey>() + k.as_bytes().len())
+            .sum::<usize>()
+}
+
+/// Drains every db's buffer with one sorted bulk build each. Main-thread only (loaded
+/// notification or loading-event handler), so no shutdown coordination is needed.
+fn drain_buffers(reason: &str) {
+    let buffers = std::mem::take(&mut *lock(&BULK_BUFFERS));
+    BULK_BUFFER_BYTES.store(0, Ordering::Relaxed);
+
+    for (db, entries) in buffers {
+        if entries.is_empty() {
+            continue;
+        }
+        let count = entries.len();
+        let start = std::time::Instant::now();
+        let index = get_db_index(db);
+        index.get_postings_mut().bulk_index(entries);
+        log_debug(format!(
+            "Bulk index build for db {db} ({reason}): {count} series indexed in {:?}",
+            start.elapsed()
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn entry(id: u64, key: &str, labels: &[(&str, &str)]) -> BulkIndexEntry {
+        BulkIndexEntry {
+            id,
+            key: key.as_bytes().to_vec().into_boxed_slice(),
+            label_keys: labels
+                .iter()
+                .map(|(name, value)| IndexKey::for_label_value(name, value))
+                .collect(),
+        }
+    }
+
+    /// Drives the buffer/drain lifecycle directly (the ctx-dependent keyspace lookup in
+    /// `try_buffer_loaded_key` is exercised by the Python integration suite). Uses a dedicated
+    /// db number so the shared `TIMESERIES_INDEX` static doesn't collide with other tests.
+    #[test]
+    #[serial(bulk_build)]
+    fn test_buffer_and_drain_on_load_end() {
+        const DB: i32 = 240;
+        on_load_started(false);
+        assert!(BULK_ACTIVE.load(Ordering::Relaxed));
+
+        buffer_entry(DB, entry(1, "key1", &[("host", "a"), ("job", "web")]));
+        buffer_entry(DB, entry(2, "key2", &[("host", "b"), ("job", "web")]));
+        assert!(BULK_BUFFER_BYTES.load(Ordering::Relaxed) > 0);
+
+        on_load_ended();
+        assert_eq!(BULK_BUFFER_BYTES.load(Ordering::Relaxed), 0);
+
+        let index = get_db_index(DB);
+        let postings = index.get_postings();
+        assert_eq!(postings.count(), 2);
+        let web = postings.postings_for_label_value("job", "web");
+        assert!(web.contains(1) && web.contains(2));
+        assert!(postings.postings_for_label_value("host", "a").contains(1));
+        assert_eq!(
+            postings.get_key_by_id(2).map(|k| k.as_ref()),
+            Some(&b"key2"[..])
+        );
+    }
+
+    #[test]
+    #[serial(bulk_build)]
+    fn test_aof_window_disables_buffering() {
+        on_load_started(true);
+        assert!(!BULK_ACTIVE.load(Ordering::Relaxed));
+        on_load_ended();
+    }
+
+    #[test]
+    #[serial(bulk_build)]
+    fn test_load_failed_discards_buffer() {
+        const DB: i32 = 241;
+        on_load_started(false);
+        buffer_entry(DB, entry(10, "doomed", &[("host", "x")]));
+        on_load_failed();
+
+        assert_eq!(BULK_BUFFER_BYTES.load(Ordering::Relaxed), 0);
+        let index = get_db_index(DB);
+        assert_eq!(index.get_postings().count(), 0);
+    }
+
+    #[test]
+    #[serial(bulk_build)]
+    fn test_memory_cap_drains_and_degrades() {
+        use crate::config::INDEX_BUILD_MAX_MEMORY;
+        const DB: i32 = 242;
+
+        let saved = INDEX_BUILD_MAX_MEMORY.load(Ordering::Relaxed);
+        // Cap below one entry's footprint: the first buffered entry crosses it.
+        INDEX_BUILD_MAX_MEMORY.store(1, Ordering::Relaxed);
+
+        on_load_started(false);
+        buffer_entry(DB, entry(20, "key20", &[("host", "cap")]));
+
+        // The cap crossing drained immediately and degraded the window.
+        assert!(BULK_DEGRADED.load(Ordering::Relaxed));
+        assert_eq!(BULK_BUFFER_BYTES.load(Ordering::Relaxed), 0);
+        assert!(
+            get_db_index(DB)
+                .get_postings()
+                .postings_for_label_value("host", "cap")
+                .contains(20)
+        );
+
+        INDEX_BUILD_MAX_MEMORY.store(saved, Ordering::Relaxed);
+        on_load_ended();
+    }
+}

--- a/src/series/index/mod.rs
+++ b/src/series/index/mod.rs
@@ -1,4 +1,5 @@
 use std::ops::Deref;
+pub(crate) mod bulk_build;
 mod index_key;
 mod posting_stats;
 mod postings;

--- a/src/series/index/mod.rs
+++ b/src/series/index/mod.rs
@@ -26,6 +26,7 @@ mod ids;
 mod key_buffer;
 mod label_filter;
 mod label_querier;
+pub(crate) mod persistence;
 #[cfg(test)]
 mod postings_query_tests;
 pub(crate) mod server_events;

--- a/src/series/index/persistence.rs
+++ b/src/series/index/persistence.rs
@@ -1,0 +1,521 @@
+//! RDB aux-field persistence for the postings index.
+//!
+//! Design: docs/postings-index-persistence.md (Option A). The whole index snapshot for all dbs is
+//! written as a single length-prefixed string via the module type's `aux_save2` callback with
+//! `AUX_BEFORE_RDB`, so `aux_load` runs before any key loads and consumes exactly one string from
+//! the RDB stream. Any parse failure after that read is soft: the payload is discarded and the
+//! index is rebuilt by the existing per-key `loaded` notification path (`index_series_by_key`).
+//!
+//! Fork safety: `aux_save` runs in the BGSAVE fork child, where a background task holding the
+//! postings write lock at fork time would deadlock the child. All db locks are acquired with
+//! `try_read`; if any is contended we write nothing at all (`aux_save2` omits the aux field
+//! entirely) and the loader falls back to the rebuild path.
+
+use super::postings::{Postings, PostingsBitmap, PostingsIndex};
+use super::{TIMESERIES_INDEX, get_db_index};
+use crate::common::context::{get_current_db, set_current_db};
+use crate::common::encoding::{
+    try_read_byte_slice, try_read_u8, try_read_uvarint, write_byte_slice, write_u8, write_uvarint,
+};
+use crate::common::logging::{log_debug, log_notice, log_warning};
+use crate::config::is_index_persist_enabled;
+use crate::series::index::IndexKey;
+use crate::series::series_data_type::VK_TIME_SERIES_TYPE;
+use crate::series::{SeriesRef, TimeSeries};
+use croaring::{Bitmap64, Portable};
+use std::collections::BTreeMap;
+use std::os::raw::c_int;
+use std::sync::Mutex;
+use valkey_module::{MODULE_CONTEXT, RedisModuleIO, raw};
+
+/// Identifies the aux payload; guards against reading garbage from a foreign/corrupt field.
+const INDEX_AUX_MAGIC: &[u8; 4] = b"TSIX";
+
+/// Internal payload format version, independent of `TIMESERIES_TYPE_ENCODING_VERSION`.
+/// Any mismatch discards the payload and falls back to the per-key rebuild.
+const INDEX_AUX_VERSION: u8 = 1;
+
+/// Databases whose index was preloaded from the aux payload during the current load.
+/// Consumed by the post-load reconciliation pass (`LoadingSubevent::Ended`) or discarded
+/// on load failure.
+static PRELOADED_DBS: Mutex<Vec<i32>> = Mutex::new(Vec::new());
+
+const RECONCILE_BATCH_SIZE: usize = 256;
+
+type PayloadResult<T> = Result<T, String>;
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+fn write_bitmap(buf: &mut Vec<u8>, bitmap: &PostingsBitmap) {
+    let size = bitmap.get_serialized_size_in_bytes::<Portable>();
+    write_uvarint(buf, size as u64);
+    buf.reserve(size);
+    let before = buf.len();
+    let _ = bitmap.serialize_into_vec::<Portable>(buf);
+    debug_assert_eq!(buf.len() - before, size);
+}
+
+fn read_bitmap(buf: &mut &[u8]) -> PayloadResult<PostingsBitmap> {
+    let blob = try_read_byte_slice(buf).map_err(|e| e.to_string())?;
+    Bitmap64::try_deserialize::<Portable>(blob)
+        .ok_or_else(|| "corrupt roaring bitmap blob".to_string())
+}
+
+/// Appends one per-db section to `buf`.
+fn serialize_postings_section(buf: &mut Vec<u8>, db: i32, postings: &Postings) {
+    write_uvarint(buf, db as u64);
+
+    // label_index in tree iteration order (sorted): cache-friendly ART rebuild on load.
+    write_uvarint(buf, postings.label_index.len() as u64);
+    for (key, bitmap) in postings.label_index.iter() {
+        // `as_str` strips the NUL sentinel; `IndexKey::from(&[u8])` re-appends it on load.
+        write_byte_slice(buf, key.as_str().as_bytes());
+        write_bitmap(buf, bitmap);
+    }
+
+    // id_to_key in ascending id order: ids share their high epoch bits and increment densely,
+    // so varint deltas stay small.
+    write_uvarint(buf, postings.id_to_key.len() as u64);
+    let mut prev_id: SeriesRef = 0;
+    for (id, key) in postings.id_to_key.iter() {
+        write_uvarint(buf, id - prev_id);
+        prev_id = *id;
+        write_byte_slice(buf, key.as_ref());
+    }
+
+    write_bitmap(buf, &postings.all_postings);
+    write_bitmap(buf, &postings.stale_ids);
+}
+
+fn deserialize_postings_section(buf: &mut &[u8]) -> PayloadResult<(i32, Postings)> {
+    let db = try_read_uvarint(buf).map_err(|e| e.to_string())?;
+    let db = i32::try_from(db).map_err(|_| format!("invalid db number {db}"))?;
+
+    let label_count = try_read_uvarint(buf).map_err(|e| e.to_string())? as usize;
+    let mut label_index = PostingsIndex::new();
+    for _ in 0..label_count {
+        let key_bytes = try_read_byte_slice(buf).map_err(|e| e.to_string())?;
+        let key = IndexKey::from(key_bytes);
+        let bitmap = read_bitmap(buf)?;
+        label_index
+            .try_insert(key, bitmap)
+            .map_err(|e| format!("label index insert failed: {e}"))?;
+    }
+
+    let id_count = try_read_uvarint(buf).map_err(|e| e.to_string())? as usize;
+    let mut id_to_key = BTreeMap::new();
+    let mut prev_id: SeriesRef = 0;
+    for _ in 0..id_count {
+        let delta = try_read_uvarint(buf).map_err(|e| e.to_string())?;
+        let id = prev_id
+            .checked_add(delta)
+            .ok_or_else(|| "series id overflow".to_string())?;
+        prev_id = id;
+        let key = try_read_byte_slice(buf).map_err(|e| e.to_string())?;
+        id_to_key.insert(id, key.to_vec().into_boxed_slice());
+    }
+
+    let all_postings = read_bitmap(buf)?;
+    let stale_ids = read_bitmap(buf)?;
+
+    Ok((
+        db,
+        Postings {
+            label_index,
+            id_to_key,
+            stale_ids,
+            all_postings,
+        },
+    ))
+}
+
+/// Serializes every non-empty db index into a single payload buffer.
+/// Returns `None` if any db's postings lock is contended (possible fork-time writer:
+/// skip persisting entirely rather than risk deadlock or write a torn snapshot).
+fn build_aux_payload() -> Option<Vec<u8>> {
+    let map = TIMESERIES_INDEX.pin();
+    let mut dbs: Vec<i32> = map.keys().copied().collect();
+    dbs.sort_unstable();
+
+    let mut sections: Vec<u8> = Vec::new();
+    let mut section_count: u64 = 0;
+
+    for db in dbs {
+        let Some(index) = map.get(&db) else {
+            continue;
+        };
+        let Ok(postings) = index.inner.try_read() else {
+            log_warning(format!(
+                "Postings lock for db {db} contended at aux save time; skipping index persistence"
+            ));
+            return None;
+        };
+        if postings.id_to_key.is_empty() && postings.stale_ids.is_empty() {
+            continue;
+        }
+        serialize_postings_section(&mut sections, db, &postings);
+        section_count += 1;
+    }
+
+    if section_count == 0 {
+        return None;
+    }
+
+    let mut buf = Vec::with_capacity(sections.len() + 16);
+    buf.extend_from_slice(INDEX_AUX_MAGIC);
+    write_u8(&mut buf, INDEX_AUX_VERSION);
+    write_uvarint(&mut buf, section_count);
+    buf.extend_from_slice(&sections);
+    Some(buf)
+}
+
+fn parse_aux_payload(mut buf: &[u8]) -> PayloadResult<Vec<(i32, Postings)>> {
+    let buf = &mut buf;
+
+    let magic = try_read_byte_slice_exact(buf, INDEX_AUX_MAGIC.len())?;
+    if magic != INDEX_AUX_MAGIC {
+        return Err("bad magic".to_string());
+    }
+    let version = try_read_u8(buf).map_err(|e| e.to_string())?;
+    if version != INDEX_AUX_VERSION {
+        return Err(format!(
+            "unsupported index payload version {version} (expected {INDEX_AUX_VERSION})"
+        ));
+    }
+
+    let section_count = try_read_uvarint(buf).map_err(|e| e.to_string())? as usize;
+    let mut sections = Vec::with_capacity(section_count.min(16));
+    for _ in 0..section_count {
+        sections.push(deserialize_postings_section(buf)?);
+    }
+    if !buf.is_empty() {
+        return Err(format!("{} trailing bytes after payload", buf.len()));
+    }
+    Ok(sections)
+}
+
+fn try_read_byte_slice_exact<'a>(buf: &mut &'a [u8], len: usize) -> PayloadResult<&'a [u8]> {
+    if buf.len() < len {
+        return Err(format!(
+            "not enough bytes: {} available, {len} requested",
+            buf.len()
+        ));
+    }
+    let (head, tail) = buf.split_at(len);
+    *buf = tail;
+    Ok(head)
+}
+
+// ---------------------------------------------------------------------------
+// RDB aux save / load
+// ---------------------------------------------------------------------------
+
+/// `aux_save2` body. Runs in the BGSAVE fork child; must not block on locks.
+/// Writing nothing at all makes `aux_save2` omit the aux field from the RDB.
+pub(crate) fn save_index_to_rdb(rdb: *mut RedisModuleIO) {
+    if !is_index_persist_enabled() {
+        return;
+    }
+    let Some(payload) = build_aux_payload() else {
+        return;
+    };
+    log_debug(format!(
+        "Persisting postings index aux payload ({} bytes)",
+        payload.len()
+    ));
+    raw::save_slice(rdb, &payload);
+}
+
+/// `aux_load` body. Must consume exactly the string written by `save_index_to_rdb`; only a
+/// failure to read it at all is a hard error (the RDB stream would be desynced). Every error
+/// after that point discards the payload and falls back to the per-key rebuild.
+pub(crate) fn load_index_from_rdb(rdb: *mut RedisModuleIO) -> c_int {
+    let Ok(buffer) = raw::load_string_buffer(rdb) else {
+        log_warning("Failed to read postings index aux payload from RDB");
+        return raw::Status::Err as c_int;
+    };
+
+    if !is_index_persist_enabled() {
+        log_notice(
+            "ts-index-persist is disabled; discarding persisted postings index and rebuilding",
+        );
+        return raw::Status::Ok as c_int;
+    }
+
+    match parse_aux_payload(buffer.as_ref()) {
+        Ok(sections) => {
+            let mut preloaded = PRELOADED_DBS.lock().unwrap();
+            for (db, postings) in sections {
+                let series_count = postings.id_to_key.len();
+                let index = get_db_index(db);
+                *index.inner.write().unwrap() = postings;
+                if !preloaded.contains(&db) {
+                    preloaded.push(db);
+                }
+                log_notice(format!(
+                    "Preloaded postings index for db {db} ({series_count} series)"
+                ));
+            }
+        }
+        Err(e) => {
+            log_warning(format!(
+                "Discarding persisted postings index ({e}); falling back to per-key rebuild"
+            ));
+        }
+    }
+    raw::Status::Ok as c_int
+}
+
+// ---------------------------------------------------------------------------
+// Post-load reconciliation
+// ---------------------------------------------------------------------------
+
+/// Runs after a successful load (`LoadingSubevent::Ended`). A preloaded index can contain
+/// "dangling" ids whose key never made it into the keyspace (e.g. its `rdb_load` was skipped);
+/// nothing in the query path stale-marks those (`TS.CARD` would over-count and no-date-filter
+/// `TS.QUERYINDEX` would emit phantom key names), so sweep them here. Ids for keys that loaded
+/// but are missing from the index self-heal via the `has_id == false` path and need no work.
+pub(crate) fn reconcile_preloaded_indexes() {
+    let dbs: Vec<i32> = {
+        let mut guard = PRELOADED_DBS.lock().unwrap();
+        std::mem::take(&mut *guard)
+    };
+    if dbs.is_empty() {
+        return;
+    }
+
+    // Off the main thread: the sweep opens every indexed key once.
+    std::thread::spawn(move || {
+        for db in dbs {
+            reconcile_db(db);
+        }
+    });
+}
+
+fn reconcile_db(db: i32) {
+    let mut cursor: SeriesRef = 0;
+    let mut checked = 0usize;
+    let mut dangling = 0usize;
+
+    loop {
+        // Snapshot a window of (id, key) pairs under the read lock, then drop it before
+        // touching the keyspace or taking the write lock.
+        let window: Vec<(SeriesRef, Box<[u8]>)> = {
+            let index = get_db_index(db);
+            let postings = index.inner.read().unwrap();
+            postings
+                .id_to_key
+                .range(cursor..)
+                .take(RECONCILE_BATCH_SIZE)
+                .map(|(id, key)| (*id, key.clone()))
+                .collect()
+        };
+        let Some(&(last_id, _)) = window.last() else {
+            break;
+        };
+        cursor = last_id + 1;
+
+        let mut missing: Vec<SeriesRef> = Vec::new();
+        {
+            let ctx = MODULE_CONTEXT.lock();
+            let save_db = get_current_db(&ctx);
+            set_current_db(&ctx, db);
+            for (id, key) in &window {
+                let valkey_key = ctx.create_string(key.as_ref());
+                let key_handle = ctx.open_key(&valkey_key);
+                match key_handle.get_value::<TimeSeries>(&VK_TIME_SERIES_TYPE) {
+                    Ok(Some(series)) if series.id == *id => {}
+                    _ => missing.push(*id),
+                }
+            }
+            set_current_db(&ctx, save_db);
+        }
+
+        checked += window.len();
+        if !missing.is_empty() {
+            dangling += missing.len();
+            let index = get_db_index(db);
+            let mut postings = index.inner.write().unwrap();
+            postings.mark_ids_as_stale(&missing);
+        }
+    }
+
+    if dangling > 0 {
+        log_notice(format!(
+            "Postings index reconciliation for db {db}: {checked} ids checked, {dangling} dangling ids marked stale"
+        ));
+    } else {
+        log_debug(format!(
+            "Postings index reconciliation for db {db}: {checked} ids checked, none dangling"
+        ));
+    }
+}
+
+/// Runs when a load fails (`LoadingSubevent::Failed`). The keyspace state after a failed load is
+/// engine-dependent (startup aborts; a replica may restore its pre-sync dataset), so a preloaded
+/// index cannot be trusted — drop it and let the natural indexing paths rebuild.
+pub(crate) fn discard_preloaded_indexes() {
+    let dbs: Vec<i32> = {
+        let mut guard = PRELOADED_DBS.lock().unwrap();
+        std::mem::take(&mut *guard)
+    };
+    for db in dbs {
+        let index = get_db_index(db);
+        index.inner.write().unwrap().clear();
+        log_warning(format!(
+            "Load failed; discarded preloaded postings index for db {db}"
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_postings() -> Postings {
+        let mut postings = Postings::default();
+        let mut bmp_a = PostingsBitmap::new();
+        bmp_a.add_many(&[1, 2, 3]);
+        let mut bmp_b = PostingsBitmap::new();
+        bmp_b.add_many(&[2, 3]);
+        postings
+            .label_index
+            .try_insert(IndexKey::for_label_value("region", "us-east-1"), bmp_a)
+            .unwrap();
+        postings
+            .label_index
+            .try_insert(IndexKey::for_label_value("service", "api"), bmp_b)
+            .unwrap();
+        for (id, key) in [(1u64, "ts:one"), (2, "ts:two"), (3, "ts:three")] {
+            postings
+                .id_to_key
+                .insert(id, key.as_bytes().to_vec().into_boxed_slice());
+            postings.all_postings.add(id);
+        }
+        postings.stale_ids.add(99);
+        postings
+    }
+
+    fn assert_postings_eq(a: &Postings, b: &Postings) {
+        assert_eq!(a.id_to_key, b.id_to_key);
+        assert_eq!(a.all_postings, b.all_postings);
+        assert_eq!(a.stale_ids, b.stale_ids);
+        assert_eq!(a.label_index.len(), b.label_index.len());
+        for ((ka, va), (kb, vb)) in a.label_index.iter().zip(b.label_index.iter()) {
+            assert_eq!(ka, kb);
+            assert_eq!(va, vb);
+        }
+    }
+
+    fn build_payload(sections: &[(i32, &Postings)]) -> Vec<u8> {
+        let mut body = Vec::new();
+        for (db, postings) in sections {
+            serialize_postings_section(&mut body, *db, postings);
+        }
+        let mut buf = Vec::new();
+        buf.extend_from_slice(INDEX_AUX_MAGIC);
+        write_u8(&mut buf, INDEX_AUX_VERSION);
+        write_uvarint(&mut buf, sections.len() as u64);
+        buf.extend_from_slice(&body);
+        buf
+    }
+
+    #[test]
+    fn payload_roundtrip_single_db() {
+        let postings = sample_postings();
+        let payload = build_payload(&[(0, &postings)]);
+        let sections = parse_aux_payload(&payload).unwrap();
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].0, 0);
+        assert_postings_eq(&sections[0].1, &postings);
+    }
+
+    #[test]
+    fn payload_roundtrip_multiple_dbs() {
+        let postings_a = sample_postings();
+        let postings_b = Postings::default();
+        let payload = build_payload(&[(0, &postings_a), (5, &postings_b)]);
+        let sections = parse_aux_payload(&payload).unwrap();
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].0, 0);
+        assert_eq!(sections[1].0, 5);
+        assert_postings_eq(&sections[0].1, &postings_a);
+        assert_postings_eq(&sections[1].1, &postings_b);
+    }
+
+    #[test]
+    fn payload_roundtrip_empty_postings() {
+        let postings = Postings::default();
+        let payload = build_payload(&[(2, &postings)]);
+        let sections = parse_aux_payload(&payload).unwrap();
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].0, 2);
+        assert_postings_eq(&sections[0].1, &postings);
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let postings = sample_postings();
+        let mut payload = build_payload(&[(0, &postings)]);
+        payload[0] ^= 0xFF;
+        assert!(parse_aux_payload(&payload).is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_version() {
+        let postings = sample_postings();
+        let mut payload = build_payload(&[(0, &postings)]);
+        payload[INDEX_AUX_MAGIC.len()] = INDEX_AUX_VERSION + 1;
+        assert!(parse_aux_payload(&payload).is_err());
+    }
+
+    #[test]
+    fn rejects_truncated_payload() {
+        let postings = sample_postings();
+        let payload = build_payload(&[(0, &postings)]);
+        for len in 0..payload.len() {
+            assert!(
+                parse_aux_payload(&payload[..len]).is_err(),
+                "truncation at {len} bytes should fail"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_trailing_garbage() {
+        let postings = sample_postings();
+        let mut payload = build_payload(&[(0, &postings)]);
+        payload.push(0xAB);
+        assert!(parse_aux_payload(&payload).is_err());
+    }
+
+    #[test]
+    fn rejects_corrupt_bitmap_blob() {
+        // A blob whose declared length is intact but whose contents are not a valid portable
+        // bitmap: the leading u64 bucket count is absurd relative to the remaining bytes.
+        // (Bit flips that still decode as *some* valid bitmap are the RDB CRC's job to catch.)
+        let mut buf = Vec::new();
+        write_byte_slice(&mut buf, &[0xFF; 9]);
+        let mut slice = buf.as_slice();
+        assert!(read_bitmap(&mut slice).is_err());
+    }
+
+    #[test]
+    fn id_delta_encoding_handles_epoch_style_ids() {
+        // Ids with large shared high bits (epoch) and dense low bits.
+        let epoch = 0x0000_ABCD_u64 << 40;
+        let mut postings = Postings::default();
+        for i in 1..=100u64 {
+            let id = epoch | i;
+            postings
+                .id_to_key
+                .insert(id, format!("key:{i}").into_bytes().into_boxed_slice());
+            postings.all_postings.add(id);
+        }
+        let payload = build_payload(&[(0, &postings)]);
+        let sections = parse_aux_payload(&payload).unwrap();
+        assert_postings_eq(&sections[0].1, &postings);
+    }
+}

--- a/src/series/index/persistence.rs
+++ b/src/series/index/persistence.rs
@@ -27,8 +27,8 @@ use croaring::{Bitmap64, Portable};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::os::raw::c_int;
+use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{LazyLock, Mutex};
 use valkey_module::key::ValkeyKey;
 use valkey_module::{Context, KeysCursor, MODULE_CONTEXT, RedisModuleIO, ValkeyString, raw};
 
@@ -53,7 +53,9 @@ static LOADING_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 /// Per-db count of series that came through `rdb_load` during the current load window.
 /// Compared against the post-sweep index cardinality to detect keyspace-index drift.
-static LOADED_SERIES_COUNTS: Mutex<Vec<(i32, u64)>> = Mutex::new(Vec::new());
+/// Lock-free: `note_series_loaded` is called once per series deserialized from the RDB stream.
+static LOADED_SERIES_COUNTS: LazyLock<papaya::HashMap<i32, u64, BuildNoHashHasher<i32>>> =
+    LazyLock::new(papaya::HashMap::default);
 
 const RECONCILE_BATCH_SIZE: usize = 256;
 
@@ -315,7 +317,7 @@ pub(crate) fn load_index_from_rdb(rdb: *mut RedisModuleIO) -> c_int {
 /// Loading `RdbStarted`/`AofStarted`/`ReplStarted`: open the load window and reset per-load state.
 pub(crate) fn on_loading_started() {
     LOADING_ACTIVE.store(true, Ordering::SeqCst);
-    LOADED_SERIES_COUNTS.lock().unwrap().clear();
+    LOADED_SERIES_COUNTS.pin().clear();
     // Defensive: any leftover preload state from an earlier load cycle is stale by now.
     PRELOADED_DBS.pin().clear();
 }
@@ -330,7 +332,7 @@ pub(crate) fn on_loading_ended() {
 /// [`discard_preloaded_indexes`]).
 pub(crate) fn on_loading_failed() {
     LOADING_ACTIVE.store(false, Ordering::SeqCst);
-    LOADED_SERIES_COUNTS.lock().unwrap().clear();
+    LOADED_SERIES_COUNTS.pin().clear();
     discard_preloaded_indexes();
 }
 
@@ -369,17 +371,19 @@ pub(crate) fn observe_series_rdb_load(rdb: *mut RedisModuleIO, series: &mut Time
 }
 
 fn note_series_loaded(db: i32) {
-    let mut counts = LOADED_SERIES_COUNTS.lock().unwrap();
-    if let Some(entry) = counts.iter_mut().find(|(d, _)| *d == db) {
-        entry.1 += 1;
-    } else {
-        counts.push((db, 1));
-    }
+    LOADED_SERIES_COUNTS
+        .pin()
+        .update_or_insert(db, |count| count + 1, 1);
 }
 
+/// Drains `LOADED_SERIES_COUNTS`: snapshot the per-db counts, then clear. Not atomic with
+/// respect to a concurrent `note_series_loaded`, but there is none — this is only called from
+/// the loading-event handler, after the load window (and thus all `rdb_load` traffic) has ended.
 fn take_loaded_counts() -> Vec<(i32, u64)> {
-    let mut guard = LOADED_SERIES_COUNTS.lock().unwrap();
-    std::mem::take(&mut *guard)
+    let guard = LOADED_SERIES_COUNTS.pin();
+    let counts: Vec<(i32, u64)> = guard.iter().map(|(db, count)| (*db, *count)).collect();
+    guard.clear();
+    counts
 }
 
 /// Drains `PRELOADED_DBS`: snapshot the members, then clear. Not atomic with respect to a

--- a/src/series/index/persistence.rs
+++ b/src/series/index/persistence.rs
@@ -19,6 +19,7 @@ use crate::common::encoding::{
 };
 use crate::common::hash::BuildNoHashHasher;
 use crate::common::logging::{log_debug, log_notice, log_warning};
+use crate::common::sync::{read_lock, write_lock};
 use crate::config::is_index_persist_enabled;
 use crate::series::index::IndexKey;
 use crate::series::series_data_type::VK_TIME_SERIES_TYPE;
@@ -294,7 +295,7 @@ pub(crate) fn load_index_from_rdb(rdb: *mut RedisModuleIO) -> c_int {
             for (db, postings) in sections {
                 let series_count = postings.id_to_key.len();
                 let index = get_db_index(db);
-                *index.inner.write().unwrap() = postings;
+                *write_lock(&index.inner) = postings;
                 preloaded.insert(db);
                 log_notice(format!(
                     "Preloaded postings index for db {db} ({series_count} series)"
@@ -447,7 +448,7 @@ fn reconcile_preloaded_indexes() {
 fn verify_and_repair_db(db: i32, loaded_count: u64) {
     let indexed_count = {
         let index = get_db_index(db);
-        let postings = index.inner.read().unwrap();
+        let postings = read_lock(&index.inner);
         postings.count() as u64
     };
 
@@ -485,7 +486,7 @@ fn verify_and_repair_db(db: i32, loaded_count: u64) {
 
     let repaired_count = {
         let index = get_db_index(db);
-        let postings = index.inner.read().unwrap();
+        let postings = read_lock(&index.inner);
         postings.count() as u64
     };
     log_notice(format!(
@@ -509,7 +510,7 @@ fn reconcile_db(db: i32) {
         // touching the keyspace or taking the write lock.
         let window: Vec<(SeriesRef, Box<[u8]>)> = {
             let index = get_db_index(db);
-            let postings = index.inner.read().unwrap();
+            let postings = read_lock(&index.inner);
             postings
                 .id_to_key
                 .range(cursor..)
@@ -542,7 +543,7 @@ fn reconcile_db(db: i32) {
         if !missing.is_empty() {
             dangling += missing.len();
             let index = get_db_index(db);
-            let mut postings = index.inner.write().unwrap();
+            let mut postings = write_lock(&index.inner);
             postings.mark_ids_as_stale(&missing);
         }
     }
@@ -565,7 +566,7 @@ fn discard_preloaded_indexes() {
     let dbs: Vec<i32> = take_preloaded_dbs();
     for db in dbs {
         let index = get_db_index(db);
-        index.inner.write().unwrap().clear();
+        write_lock(&index.inner).clear();
         log_warning(format!(
             "Load failed; discarded preloaded postings index for db {db}"
         ));

--- a/src/series/index/persistence.rs
+++ b/src/series/index/persistence.rs
@@ -17,6 +17,7 @@ use crate::common::context::{get_current_db, set_current_db};
 use crate::common::encoding::{
     try_read_byte_slice, try_read_u8, try_read_uvarint, write_byte_slice, write_u8, write_uvarint,
 };
+use crate::common::hash::BuildNoHashHasher;
 use crate::common::logging::{log_debug, log_notice, log_warning};
 use crate::config::is_index_persist_enabled;
 use crate::series::index::IndexKey;
@@ -26,8 +27,8 @@ use croaring::{Bitmap64, Portable};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::os::raw::c_int;
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{LazyLock, Mutex};
 use valkey_module::key::ValkeyKey;
 use valkey_module::{Context, KeysCursor, MODULE_CONTEXT, RedisModuleIO, ValkeyString, raw};
 
@@ -40,8 +41,10 @@ const INDEX_AUX_VERSION: u8 = 1;
 
 /// Databases whose index was preloaded from the aux payload during the current load.
 /// Consumed by the post-load reconciliation pass (`LoadingSubevent::Ended`) or discarded
-/// on load failure.
-static PRELOADED_DBS: Mutex<Vec<i32>> = Mutex::new(Vec::new());
+/// on load failure. A lock-free set: `should_skip_load_indexing` probes it once per loaded
+/// key, so reads must not contend with each other or with the (rare) inserts from `aux_load`.
+static PRELOADED_DBS: LazyLock<papaya::HashSet<i32, BuildNoHashHasher<i32>>> =
+    LazyLock::new(papaya::HashSet::default);
 
 /// True between a loading `*Started` subevent and the matching `Ended`/`Failed`. Gates the
 /// loaded-series counter and the `loaded`-event short-circuit so neither engages for runtime
@@ -285,14 +288,12 @@ pub(crate) fn load_index_from_rdb(rdb: *mut RedisModuleIO) -> c_int {
 
     match parse_aux_payload(buffer.as_ref()) {
         Ok(sections) => {
-            let mut preloaded = PRELOADED_DBS.lock().unwrap();
+            let preloaded = PRELOADED_DBS.pin();
             for (db, postings) in sections {
                 let series_count = postings.id_to_key.len();
                 let index = get_db_index(db);
                 *index.inner.write().unwrap() = postings;
-                if !preloaded.contains(&db) {
-                    preloaded.push(db);
-                }
+                preloaded.insert(db);
                 log_notice(format!(
                     "Preloaded postings index for db {db} ({series_count} series)"
                 ));
@@ -316,7 +317,7 @@ pub(crate) fn on_loading_started() {
     LOADING_ACTIVE.store(true, Ordering::SeqCst);
     LOADED_SERIES_COUNTS.lock().unwrap().clear();
     // Defensive: any leftover preload state from an earlier load cycle is stale by now.
-    PRELOADED_DBS.lock().unwrap().clear();
+    PRELOADED_DBS.pin().clear();
 }
 
 /// Loading `Ended`: close the load window and kick off reconciliation of preloaded dbs.
@@ -333,13 +334,18 @@ pub(crate) fn on_loading_failed() {
     discard_preloaded_indexes();
 }
 
+#[inline]
+pub(crate) fn is_loading_active() -> bool {
+    LOADING_ACTIVE.load(Ordering::Relaxed)
+}
+
 /// True when the `loaded` keyspace notification for a key in `db` can be skipped outright:
 /// we are inside a load window and this db's index came from the aux payload. `rdb_load` has
 /// already assigned `_db` and counted the series; post-load verification covers any drift.
 /// This is the fast path that avoids the per-key `RedisModuleString` allocation and keyspace
 /// lookup entirely (for every key type — `loaded` fires for non-timeseries keys too).
 pub(crate) fn should_skip_load_indexing(db: i32) -> bool {
-    LOADING_ACTIVE.load(Ordering::Relaxed) && PRELOADED_DBS.lock().unwrap().contains(&db)
+    is_loading_active() && PRELOADED_DBS.pin().contains(&db)
 }
 
 /// Called from `rdb_load_series` for every series deserialized from an RDB stream: assigns
@@ -376,6 +382,16 @@ fn take_loaded_counts() -> Vec<(i32, u64)> {
     std::mem::take(&mut *guard)
 }
 
+/// Drains `PRELOADED_DBS`: snapshot the members, then clear. Not atomic with respect to a
+/// concurrent `aux_load` insert, but that race cannot happen in practice — this is only called
+/// from the loading-event handler, after `aux_load` for the current load window has finished.
+fn take_preloaded_dbs() -> Vec<i32> {
+    let guard = PRELOADED_DBS.pin();
+    let dbs: Vec<i32> = guard.iter().copied().collect();
+    guard.clear();
+    dbs
+}
+
 // ---------------------------------------------------------------------------
 // Post-load reconciliation
 // ---------------------------------------------------------------------------
@@ -387,10 +403,7 @@ fn take_loaded_counts() -> Vec<(i32, u64)> {
 /// a cardinality check against the loaded-series counter (see [`verify_and_repair_db`]) that
 /// catches the reverse direction, since preloaded dbs skip the per-key `has_id` self-heal.
 fn reconcile_preloaded_indexes() {
-    let dbs: Vec<i32> = {
-        let mut guard = PRELOADED_DBS.lock().unwrap();
-        std::mem::take(&mut *guard)
-    };
+    let dbs: Vec<i32> = take_preloaded_dbs();
     if dbs.is_empty() {
         return;
     }
@@ -526,10 +539,7 @@ fn reconcile_db(db: i32) {
 /// engine-dependent (startup aborts; a replica may restore its pre-sync dataset), so a preloaded
 /// index cannot be trusted — drop it and let the natural indexing paths rebuild.
 fn discard_preloaded_indexes() {
-    let dbs: Vec<i32> = {
-        let mut guard = PRELOADED_DBS.lock().unwrap();
-        std::mem::take(&mut *guard)
-    };
+    let dbs: Vec<i32> = take_preloaded_dbs();
     for db in dbs {
         let index = get_db_index(db);
         index.inner.write().unwrap().clear();
@@ -763,7 +773,7 @@ mod tests {
         );
 
         // Simulate aux preload of DB_A and some rdb_load traffic.
-        PRELOADED_DBS.lock().unwrap().push(DB_A);
+        PRELOADED_DBS.pin().insert(DB_A);
         note_series_loaded(DB_A);
         note_series_loaded(DB_A);
         note_series_loaded(DB_B);
@@ -788,7 +798,7 @@ mod tests {
             !should_skip_load_indexing(DB_A),
             "no skip outside a load window"
         );
-        assert!(PRELOADED_DBS.lock().unwrap().is_empty());
+        assert!(PRELOADED_DBS.pin().is_empty());
 
         // A new load window starts clean.
         note_series_loaded(DB_A);

--- a/src/series/index/persistence.rs
+++ b/src/series/index/persistence.rs
@@ -413,9 +413,16 @@ fn reconcile_preloaded_indexes() {
     }
     let counts = take_loaded_counts();
 
-    // Off the main thread: the sweep opens every indexed key once.
-    std::thread::spawn(move || {
+    // Off the main thread: the sweep opens every indexed key once. Runs on the module's
+    // thread pool (not a detached `std::thread`) so it participates in the same thread
+    // lifecycle as every other background job, and checks `is_shutting_down()` between
+    // batches — an aborted sweep is safe, since ids it never reached are either valid or
+    // will be stale-marked by the query path's self-heal.
+    crate::common::threads::spawn(move || {
         for db in dbs {
+            if crate::is_shutting_down() {
+                return;
+            }
             reconcile_db(db);
             let loaded = counts
                 .iter()
@@ -462,6 +469,12 @@ fn verify_and_repair_db(db: i32, loaded_count: u64) {
     let cursor = KeysCursor::new();
     let mut more = true;
     while more {
+        if crate::is_shutting_down() {
+            log_notice(format!(
+                "Postings index repair scan for db {db} aborted by shutdown"
+            ));
+            return;
+        }
         // Lock per scan bucket so the main thread is not starved for the whole scan.
         let ctx = MODULE_CONTEXT.lock();
         let save_db = get_current_db(&ctx);
@@ -486,6 +499,12 @@ fn reconcile_db(db: i32) {
     let mut dangling = 0usize;
 
     loop {
+        if crate::is_shutting_down() {
+            log_notice(format!(
+                "Postings index reconciliation for db {db} aborted by shutdown after {checked} ids"
+            ));
+            return;
+        }
         // Snapshot a window of (id, key) pairs under the read lock, then drop it before
         // touching the keyspace or taking the write lock.
         let window: Vec<(SeriesRef, Box<[u8]>)> = {

--- a/src/series/index/persistence.rs
+++ b/src/series/index/persistence.rs
@@ -12,7 +12,7 @@
 //! entirely) and the loader falls back to the rebuild path.
 
 use super::postings::{Postings, PostingsBitmap, PostingsIndex};
-use super::{TIMESERIES_INDEX, get_db_index};
+use super::{TIMESERIES_INDEX, get_db_index, index_series_by_key};
 use crate::common::context::{get_current_db, set_current_db};
 use crate::common::encoding::{
     try_read_byte_slice, try_read_u8, try_read_uvarint, write_byte_slice, write_u8, write_uvarint,
@@ -23,10 +23,13 @@ use crate::series::index::IndexKey;
 use crate::series::series_data_type::VK_TIME_SERIES_TYPE;
 use crate::series::{SeriesRef, TimeSeries};
 use croaring::{Bitmap64, Portable};
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::os::raw::c_int;
 use std::sync::Mutex;
-use valkey_module::{MODULE_CONTEXT, RedisModuleIO, raw};
+use std::sync::atomic::{AtomicBool, Ordering};
+use valkey_module::key::ValkeyKey;
+use valkey_module::{Context, KeysCursor, MODULE_CONTEXT, RedisModuleIO, ValkeyString, raw};
 
 /// Identifies the aux payload; guards against reading garbage from a foreign/corrupt field.
 const INDEX_AUX_MAGIC: &[u8; 4] = b"TSIX";
@@ -39,6 +42,15 @@ const INDEX_AUX_VERSION: u8 = 1;
 /// Consumed by the post-load reconciliation pass (`LoadingSubevent::Ended`) or discarded
 /// on load failure.
 static PRELOADED_DBS: Mutex<Vec<i32>> = Mutex::new(Vec::new());
+
+/// True between a loading `*Started` subevent and the matching `Ended`/`Failed`. Gates the
+/// loaded-series counter and the `loaded`-event short-circuit so neither engages for runtime
+/// `RESTORE`/`TS._RESTORE` traffic.
+static LOADING_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Per-db count of series that came through `rdb_load` during the current load window.
+/// Compared against the post-sweep index cardinality to detect keyspace-index drift.
+static LOADED_SERIES_COUNTS: Mutex<Vec<(i32, u64)>> = Mutex::new(Vec::new());
 
 const RECONCILE_BATCH_SIZE: usize = 256;
 
@@ -68,12 +80,38 @@ fn serialize_postings_section(buf: &mut Vec<u8>, db: i32, postings: &Postings) {
     write_uvarint(buf, db as u64);
 
     // label_index in tree iteration order (sorted): cache-friendly ART rebuild on load.
-    write_uvarint(buf, postings.label_index.len() as u64);
+    //
+    // Stale ids are subtracted here rather than persisted: `mark_ids_as_stale` already cleans
+    // `id_to_key` and `all_postings` at mark time, so the label bitmaps are the only structures
+    // still carrying stale ids — persisting them would persist a cleanup obligation. Subtracting
+    // yields exactly the state a completed GC drain would produce. A stale id whose key is still
+    // in the RDB (a fork can land mid-ASM-export, before the engine's lazy delete) is
+    // resurrected by the post-load count-verification scan, matching the keyspace either way.
+    // The subtraction only costs anything when `stale_ids` is non-empty (rare: the cron GC
+    // drains continuously); entries that become empty are dropped, so the entry count is
+    // written after the entries are serialized.
+    let stale = &postings.stale_ids;
+    let mut entries: Vec<u8> = Vec::new();
+    let mut entry_count: u64 = 0;
     for (key, bitmap) in postings.label_index.iter() {
+        if bitmap.is_empty() {
+            continue;
+        }
+        let cleaned: Cow<PostingsBitmap> = if stale.is_empty() {
+            Cow::Borrowed(bitmap)
+        } else {
+            Cow::Owned(bitmap.andnot(stale))
+        };
+        if cleaned.is_empty() {
+            continue;
+        }
         // `as_str` strips the NUL sentinel; `IndexKey::from(&[u8])` re-appends it on load.
-        write_byte_slice(buf, key.as_str().as_bytes());
-        write_bitmap(buf, bitmap);
+        write_byte_slice(&mut entries, key.as_str().as_bytes());
+        write_bitmap(&mut entries, &cleaned);
+        entry_count += 1;
     }
+    write_uvarint(buf, entry_count);
+    buf.extend_from_slice(&entries);
 
     // id_to_key in ascending id order: ids share their high epoch bits and increment densely,
     // so varint deltas stay small.
@@ -86,7 +124,6 @@ fn serialize_postings_section(buf: &mut Vec<u8>, db: i32, postings: &Postings) {
     }
 
     write_bitmap(buf, &postings.all_postings);
-    write_bitmap(buf, &postings.stale_ids);
 }
 
 fn deserialize_postings_section(buf: &mut &[u8]) -> PayloadResult<(i32, Postings)> {
@@ -118,14 +155,14 @@ fn deserialize_postings_section(buf: &mut &[u8]) -> PayloadResult<(i32, Postings
     }
 
     let all_postings = read_bitmap(buf)?;
-    let stale_ids = read_bitmap(buf)?;
 
     Ok((
         db,
         Postings {
             label_index,
             id_to_key,
-            stale_ids,
+            // Stale ids were subtracted at save time; the loaded index starts clean.
+            stale_ids: PostingsBitmap::default(),
             all_postings,
         },
     ))
@@ -152,7 +189,9 @@ fn build_aux_payload() -> Option<Vec<u8>> {
             ));
             return None;
         };
-        if postings.id_to_key.is_empty() && postings.stale_ids.is_empty() {
+        // Nothing worth persisting: with no live series, the payload would only carry
+        // stale leftovers that are dropped at save time anyway.
+        if postings.id_to_key.is_empty() {
             continue;
         }
         serialize_postings_section(&mut sections, db, &postings);
@@ -269,15 +308,85 @@ pub(crate) fn load_index_from_rdb(rdb: *mut RedisModuleIO) -> c_int {
 }
 
 // ---------------------------------------------------------------------------
+// Load lifecycle & fast path
+// ---------------------------------------------------------------------------
+
+/// Loading `RdbStarted`/`AofStarted`/`ReplStarted`: open the load window and reset per-load state.
+pub(crate) fn on_loading_started() {
+    LOADING_ACTIVE.store(true, Ordering::SeqCst);
+    LOADED_SERIES_COUNTS.lock().unwrap().clear();
+    // Defensive: any leftover preload state from an earlier load cycle is stale by now.
+    PRELOADED_DBS.lock().unwrap().clear();
+}
+
+/// Loading `Ended`: close the load window and kick off reconciliation of preloaded dbs.
+pub(crate) fn on_loading_ended() {
+    LOADING_ACTIVE.store(false, Ordering::SeqCst);
+    reconcile_preloaded_indexes();
+}
+
+/// Loading `Failed`: close the load window and drop preloaded state (see
+/// [`discard_preloaded_indexes`]).
+pub(crate) fn on_loading_failed() {
+    LOADING_ACTIVE.store(false, Ordering::SeqCst);
+    LOADED_SERIES_COUNTS.lock().unwrap().clear();
+    discard_preloaded_indexes();
+}
+
+/// True when the `loaded` keyspace notification for a key in `db` can be skipped outright:
+/// we are inside a load window and this db's index came from the aux payload. `rdb_load` has
+/// already assigned `_db` and counted the series; post-load verification covers any drift.
+/// This is the fast path that avoids the per-key `RedisModuleString` allocation and keyspace
+/// lookup entirely (for every key type — `loaded` fires for non-timeseries keys too).
+pub(crate) fn should_skip_load_indexing(db: i32) -> bool {
+    LOADING_ACTIVE.load(Ordering::Relaxed) && PRELOADED_DBS.lock().unwrap().contains(&db)
+}
+
+/// Called from `rdb_load_series` for every series deserialized from an RDB stream: assigns
+/// `series._db` from the IO context (previously done by the `loaded` notification handler,
+/// which required opening the key), and counts the series toward the current load window's
+/// per-db total. Payloads with no db context (`RESTORE` / `TS._RESTORE` strings) are skipped;
+/// their callers assign `_db` themselves.
+pub(crate) fn observe_series_rdb_load(rdb: *mut RedisModuleIO, series: &mut TimeSeries) {
+    // `GetDbIdFromIO` may be absent on older servers; fall back to the notification path.
+    let Some(get_db_id) = (unsafe { raw::RedisModule_GetDbIdFromIO }) else {
+        return;
+    };
+    let db = unsafe { get_db_id(rdb) };
+    if db < 0 {
+        return;
+    }
+    series._db = Some(db);
+    if LOADING_ACTIVE.load(Ordering::Relaxed) {
+        note_series_loaded(db);
+    }
+}
+
+fn note_series_loaded(db: i32) {
+    let mut counts = LOADED_SERIES_COUNTS.lock().unwrap();
+    if let Some(entry) = counts.iter_mut().find(|(d, _)| *d == db) {
+        entry.1 += 1;
+    } else {
+        counts.push((db, 1));
+    }
+}
+
+fn take_loaded_counts() -> Vec<(i32, u64)> {
+    let mut guard = LOADED_SERIES_COUNTS.lock().unwrap();
+    std::mem::take(&mut *guard)
+}
+
+// ---------------------------------------------------------------------------
 // Post-load reconciliation
 // ---------------------------------------------------------------------------
 
 /// Runs after a successful load (`LoadingSubevent::Ended`). A preloaded index can contain
 /// "dangling" ids whose key never made it into the keyspace (e.g. its `rdb_load` was skipped);
 /// nothing in the query path stale-marks those (`TS.CARD` would over-count and no-date-filter
-/// `TS.QUERYINDEX` would emit phantom key names), so sweep them here. Ids for keys that loaded
-/// but are missing from the index self-heal via the `has_id == false` path and need no work.
-pub(crate) fn reconcile_preloaded_indexes() {
+/// `TS.QUERYINDEX` would emit phantom key names), so sweep them here. The sweep is followed by
+/// a cardinality check against the loaded-series counter (see [`verify_and_repair_db`]) that
+/// catches the reverse direction, since preloaded dbs skip the per-key `has_id` self-heal.
+fn reconcile_preloaded_indexes() {
     let dbs: Vec<i32> = {
         let mut guard = PRELOADED_DBS.lock().unwrap();
         std::mem::take(&mut *guard)
@@ -285,13 +394,73 @@ pub(crate) fn reconcile_preloaded_indexes() {
     if dbs.is_empty() {
         return;
     }
+    let counts = take_loaded_counts();
 
     // Off the main thread: the sweep opens every indexed key once.
     std::thread::spawn(move || {
         for db in dbs {
             reconcile_db(db);
+            let loaded = counts
+                .iter()
+                .find(|(d, _)| *d == db)
+                .map(|(_, n)| *n)
+                .unwrap_or(0);
+            verify_and_repair_db(db, loaded);
         }
     });
+}
+
+/// Post-sweep verification for a preloaded db. `reconcile_db` has just established that every
+/// id remaining in `id_to_key` maps to a live key with a matching series id — i.e. the index is
+/// a *subset* of the loaded keyspace. Equal cardinality therefore proves set equality, so a
+/// count match means no key was missed by the preload. On mismatch, scan the db's keyspace and
+/// index anything with `has_id == false` (the same per-key path the fast path skipped).
+///
+/// Runtime traffic between load end and this check can legitimately skew the counts (a DEL
+/// removes a key and unindexes it; a TS.CREATE adds an id the loader never counted). That only
+/// makes the scan fire spuriously — `index_series_by_key` is guarded, so the scan is always
+/// safe, just not free.
+fn verify_and_repair_db(db: i32, loaded_count: u64) {
+    let indexed_count = {
+        let index = get_db_index(db);
+        let postings = index.inner.read().unwrap();
+        postings.count() as u64
+    };
+
+    if indexed_count == loaded_count {
+        log_debug(format!(
+            "Postings index verification for db {db}: {indexed_count} indexed series match the loaded count"
+        ));
+        return;
+    }
+
+    log_warning(format!(
+        "Postings index verification for db {db}: {indexed_count} indexed vs {loaded_count} loaded; scanning keyspace to repair"
+    ));
+
+    let scan_callback = |ctx: &Context, key_name: ValkeyString, _key: Option<&ValkeyKey>| {
+        index_series_by_key(ctx, key_name.as_slice());
+    };
+
+    let cursor = KeysCursor::new();
+    let mut more = true;
+    while more {
+        // Lock per scan bucket so the main thread is not starved for the whole scan.
+        let ctx = MODULE_CONTEXT.lock();
+        let save_db = get_current_db(&ctx);
+        set_current_db(&ctx, db);
+        more = cursor.scan(&ctx, &scan_callback);
+        set_current_db(&ctx, save_db);
+    }
+
+    let repaired_count = {
+        let index = get_db_index(db);
+        let postings = index.inner.read().unwrap();
+        postings.count() as u64
+    };
+    log_notice(format!(
+        "Postings index repair scan for db {db} finished: {indexed_count} -> {repaired_count} indexed series"
+    ));
 }
 
 fn reconcile_db(db: i32) {
@@ -356,7 +525,7 @@ fn reconcile_db(db: i32) {
 /// Runs when a load fails (`LoadingSubevent::Failed`). The keyspace state after a failed load is
 /// engine-dependent (startup aborts; a replica may restore its pre-sync dataset), so a preloaded
 /// index cannot be trusted — drop it and let the natural indexing paths rebuild.
-pub(crate) fn discard_preloaded_indexes() {
+fn discard_preloaded_indexes() {
     let dbs: Vec<i32> = {
         let mut guard = PRELOADED_DBS.lock().unwrap();
         std::mem::take(&mut *guard)
@@ -394,7 +563,6 @@ mod tests {
                 .insert(id, key.as_bytes().to_vec().into_boxed_slice());
             postings.all_postings.add(id);
         }
-        postings.stale_ids.add(99);
         postings
     }
 
@@ -430,6 +598,45 @@ mod tests {
         assert_eq!(sections.len(), 1);
         assert_eq!(sections[0].0, 0);
         assert_postings_eq(&sections[0].1, &postings);
+    }
+
+    /// Stale ids are subtracted at save time: the loaded index must look like the state a
+    /// completed GC drain would produce — clean bitmaps, no stale set, empty entries dropped.
+    #[test]
+    fn save_subtracts_stale_ids() {
+        let mut postings = sample_postings();
+        // A label whose bitmap holds only the id about to go stale: its entry must vanish.
+        let mut only_two = PostingsBitmap::new();
+        only_two.add(2);
+        postings
+            .label_index
+            .try_insert(IndexKey::for_label_value("host", "h2"), only_two)
+            .unwrap();
+        // Removes id 2 from id_to_key/all_postings, leaves it in the label bitmaps.
+        postings.mark_ids_as_stale(&[2]);
+        assert!(postings.stale_ids.contains(2));
+
+        let payload = build_payload(&[(0, &postings)]);
+        let sections = parse_aux_payload(&payload).unwrap();
+        let loaded = &sections[0].1;
+
+        assert!(loaded.stale_ids.is_empty(), "stale set is not persisted");
+        assert!(loaded.get_key_by_id(2).is_none());
+        assert!(!loaded.all_postings.contains(2));
+        for (key, bitmap) in loaded.label_index.iter() {
+            assert!(!bitmap.contains(2), "stale id survived in {key}");
+            assert!(!bitmap.is_empty());
+        }
+        assert!(
+            loaded
+                .label_index
+                .get(&IndexKey::for_label_value("host", "h2"))
+                .is_none(),
+            "entry that became empty must be dropped"
+        );
+        // The live ids are untouched.
+        assert_eq!(loaded.count(), 2);
+        assert!(loaded.all_postings.contains(1) && loaded.all_postings.contains(3));
     }
 
     #[test]
@@ -500,6 +707,94 @@ mod tests {
         write_byte_slice(&mut buf, &[0xFF; 9]);
         let mut slice = buf.as_slice();
         assert!(read_bitmap(&mut slice).is_err());
+    }
+
+    /// The repair-scan scenario: the reconciliation sweep marks an id stale, then the keyspace
+    /// scan re-indexes the same id under its real key. Re-indexing must revoke the stale marking,
+    /// or the next GC drain would strip the id from the label bitmaps while it stays in
+    /// `id_to_key` — and the outcome would depend on GC timing.
+    #[test]
+    fn reindex_revokes_stale_marking() {
+        let mut postings = Postings::default();
+        let mut ts = TimeSeries::new();
+        ts.id = 424242;
+        ts.labels = r#"metric{region="us-east-4"}"#.parse().unwrap();
+
+        postings.index_timeseries(&ts, b"ts:4");
+        postings.mark_ids_as_stale(&[ts.id]);
+        assert!(postings.stale_ids.contains(ts.id));
+
+        postings.index_timeseries(&ts, b"tz:4");
+        assert!(
+            !postings.stale_ids.contains(ts.id),
+            "re-indexing must revoke the stale marking"
+        );
+
+        // A GC drain must now be a no-op for this id.
+        let mut cursor = None;
+        while let Some(next) = postings.remove_stale_ids(cursor.take(), 16) {
+            cursor = Some(next);
+        }
+        let key = IndexKey::for_label_value("region", "us-east-4");
+        let bitmap = postings
+            .label_index
+            .get(&key)
+            .expect("label bitmap must survive the GC drain");
+        assert!(bitmap.contains(ts.id));
+        assert_eq!(
+            postings.get_key_by_id(ts.id).map(|k| k.as_ref().to_vec()),
+            Some(b"tz:4".to_vec())
+        );
+        assert_eq!(postings.count(), 1);
+    }
+
+    /// Single test for the whole load-window lifecycle: the statics involved are process-global,
+    /// so exercising them from one test avoids intra-suite races under parallel test threads.
+    #[test]
+    fn load_window_lifecycle() {
+        // Db numbers chosen to not collide with other tests sharing TIMESERIES_INDEX.
+        const DB_A: i32 = 91;
+        const DB_B: i32 = 92;
+
+        on_loading_started();
+        assert!(
+            !should_skip_load_indexing(DB_A),
+            "no skip before this db's index is preloaded"
+        );
+
+        // Simulate aux preload of DB_A and some rdb_load traffic.
+        PRELOADED_DBS.lock().unwrap().push(DB_A);
+        note_series_loaded(DB_A);
+        note_series_loaded(DB_A);
+        note_series_loaded(DB_B);
+
+        assert!(should_skip_load_indexing(DB_A));
+        assert!(
+            !should_skip_load_indexing(DB_B),
+            "dbs without a preloaded index keep the per-key path"
+        );
+
+        let mut counts = take_loaded_counts();
+        counts.sort_unstable();
+        assert_eq!(counts, vec![(DB_A, 2), (DB_B, 1)]);
+        assert!(
+            take_loaded_counts().is_empty(),
+            "counts are consumed on take"
+        );
+
+        // Failure path: window closes, preloaded state is dropped.
+        on_loading_failed();
+        assert!(
+            !should_skip_load_indexing(DB_A),
+            "no skip outside a load window"
+        );
+        assert!(PRELOADED_DBS.lock().unwrap().is_empty());
+
+        // A new load window starts clean.
+        note_series_loaded(DB_A);
+        on_loading_started();
+        assert!(take_loaded_counts().is_empty());
+        LOADING_ACTIVE.store(false, Ordering::SeqCst);
     }
 
     #[test]

--- a/src/series/index/postings.rs
+++ b/src/series/index/postings.rs
@@ -135,6 +135,13 @@ impl Postings {
         debug_assert!(ts.id != 0);
         let id = ts.id;
 
+        // (Re)indexing asserts the series is alive: revoke any pending stale marking, or a later
+        // GC drain would strip the id from the very label bitmaps being filled here (e.g. the
+        // post-load repair scan re-indexing an id the reconciliation sweep just marked stale).
+        if !self.stale_ids.is_empty() {
+            self.stale_ids.remove(id);
+        }
+
         for InternedLabel { name, value } in ts.labels.iter() {
             self.add_posting_for_label_value_internal(id, name, value);
         }

--- a/src/series/index/postings.rs
+++ b/src/series/index/postings.rs
@@ -7,8 +7,8 @@ use crate::labels::filters::{
 };
 use crate::labels::{InternedLabel, SeriesLabel};
 use crate::series::{SeriesRef, TimeSeries};
-use blart::TreeMap;
 use blart::map::Entry as ARTEntry;
+use blart::{AsBytes, TreeMap};
 use croaring::Bitmap64;
 use smallvec::SmallVec;
 use std::borrow::Cow;
@@ -27,6 +27,14 @@ pub type PostingsIndex = TreeMap<IndexKey, PostingsBitmap>;
 
 /// Type for the key of the index.
 pub type KeyType = Box<[u8]>;
+
+/// One series buffered during a load window, consumed by [`Postings::bulk_index`]
+pub(crate) struct BulkIndexEntry {
+    pub id: SeriesRef,
+    pub key: KeyType,
+    /// Precomputed `label=value` index keys for every label of the series.
+    pub label_keys: Vec<IndexKey>,
+}
 
 /// `Postings` is the core in-memory inverted index for time series data. It is designed for efficient
 /// querying and retrieving of time series based on their labels.
@@ -117,6 +125,73 @@ impl Postings {
                 bitmap.add(ts_id);
                 entry.insert(bitmap);
                 true
+            }
+        }
+    }
+
+    /// Indexes a batch of loaded series in one pass. Semantically equivalent to calling
+    /// [`Postings::index_timeseries`] once per entry, but does the work set-at-a-time:
+    /// `all_postings` gets one sorted `add_many`, and the `(label=value, id)` pairs are sorted
+    /// so each posting list is touched once (`add_many` per run) with cache-friendly
+    /// sorted-order ART inserts.
+    ///
+    /// Safe against a non-empty index: existing posting lists are extended (bitmap adds are
+    /// idempotent) and `id_to_key` inserts overwrite.
+    pub(crate) fn bulk_index(&mut self, entries: Vec<BulkIndexEntry>) {
+        if entries.is_empty() {
+            return;
+        }
+
+        // (Re)indexing asserts the series are alive — revoke pending stale markings, same as
+        // `index_timeseries`.
+        if !self.stale_ids.is_empty() {
+            for entry in &entries {
+                self.stale_ids.remove(entry.id);
+            }
+        }
+
+        let mut ids: Vec<SeriesRef> = entries.iter().map(|e| e.id).collect();
+        ids.sort_unstable();
+        self.all_postings.add_many(&ids);
+
+        let total_labels: usize = entries.iter().map(|e| e.label_keys.len()).sum();
+        let mut pairs: Vec<(IndexKey, SeriesRef)> = Vec::with_capacity(total_labels);
+        for entry in entries {
+            for label_key in entry.label_keys {
+                pairs.push((label_key, entry.id));
+            }
+            self.id_to_key.insert(entry.id, entry.key);
+        }
+        pairs.sort_unstable_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()).then(a.1.cmp(&b.1)));
+
+        // Walk the sorted pairs, flushing one add_many per run of equal label keys.
+        let mut run_ids: Vec<SeriesRef> = Vec::new();
+        let mut current_key: Option<IndexKey> = None;
+        for (key, id) in pairs {
+            match &current_key {
+                Some(cur) if *cur == key => run_ids.push(id),
+                _ => {
+                    if let Some(cur) = current_key.take() {
+                        self.add_many_for_key(cur, &run_ids);
+                    }
+                    run_ids.clear();
+                    run_ids.push(id);
+                    current_key = Some(key);
+                }
+            }
+        }
+        if let Some(cur) = current_key.take() {
+            self.add_many_for_key(cur, &run_ids);
+        }
+    }
+
+    fn add_many_for_key(&mut self, key: IndexKey, ids: &[SeriesRef]) {
+        match self.label_index.entry(key) {
+            ARTEntry::Occupied(mut entry) => entry.get_mut().add_many(ids),
+            ARTEntry::Vacant(entry) => {
+                let mut bitmap = PostingsBitmap::new();
+                bitmap.add_many(ids);
+                entry.insert(bitmap);
             }
         }
     }
@@ -1144,6 +1219,124 @@ mod tests {
     use super::*;
     use crate::labels::{Label, MetricName};
     use crate::series::time_series::TimeSeries;
+
+    fn make_series(id: SeriesRef, labels: &[(&str, &str)]) -> TimeSeries {
+        let mut series = TimeSeries::new();
+        series.id = id;
+        let labels: Vec<Label> = labels
+            .iter()
+            .map(|(name, value)| Label::new(*name, *value))
+            .collect();
+        series.labels = MetricName::new(&labels);
+        series
+    }
+
+    fn make_bulk_entry(id: SeriesRef, key: &str, labels: &[(&str, &str)]) -> BulkIndexEntry {
+        BulkIndexEntry {
+            id,
+            key: key.as_bytes().to_vec().into_boxed_slice(),
+            label_keys: labels
+                .iter()
+                .map(|(name, value)| IndexKey::for_label_value(name, value))
+                .collect(),
+        }
+    }
+
+    /// Asserts the two indexes are structurally identical (same label keys, same posting-list
+    /// contents, same id map, same all_postings).
+    fn assert_postings_eq(a: &Postings, b: &Postings) {
+        assert_eq!(a.id_to_key, b.id_to_key);
+        assert_eq!(a.all_postings, b.all_postings, "all_postings differ");
+        let a_entries: Vec<_> = a.label_index.iter().collect();
+        let b_entries: Vec<_> = b.label_index.iter().collect();
+        assert_eq!(a_entries.len(), b_entries.len(), "label key counts differ");
+        for ((ka, va), (kb, vb)) in a_entries.iter().zip(b_entries.iter()) {
+            assert_eq!(ka.as_str(), kb.as_str());
+            assert_eq!(va, vb, "posting list for {} differs", ka.as_str());
+        }
+    }
+
+    type SeriesSpec = (SeriesRef, String, Vec<(String, String)>);
+
+    #[test]
+    fn test_bulk_index_matches_per_key_indexing() {
+        // 40 series over overlapping labels: shared job/env values, unique instance values.
+        let specs: Vec<SeriesSpec> = (1..=40u64)
+            .map(|i| {
+                let key = format!("ts:{i}");
+                let labels = vec![
+                    ("job".to_string(), format!("job{}", i % 3)),
+                    (
+                        "env".to_string(),
+                        if i % 2 == 0 { "prod" } else { "dev" }.to_string(),
+                    ),
+                    ("instance".to_string(), format!("host-{i}")),
+                ];
+                (i, key, labels)
+            })
+            .collect();
+
+        let mut per_key = Postings::default();
+        for (id, key, labels) in &specs {
+            let labels: Vec<(&str, &str)> = labels
+                .iter()
+                .map(|(n, v)| (n.as_str(), v.as_str()))
+                .collect();
+            let series = make_series(*id, &labels);
+            per_key.index_timeseries(&series, key.as_bytes());
+        }
+
+        let mut bulk = Postings::default();
+        let entries: Vec<BulkIndexEntry> = specs
+            .iter()
+            .map(|(id, key, labels)| {
+                let labels: Vec<(&str, &str)> = labels
+                    .iter()
+                    .map(|(n, v)| (n.as_str(), v.as_str()))
+                    .collect();
+                make_bulk_entry(*id, key, &labels)
+            })
+            .collect();
+        bulk.bulk_index(entries);
+
+        assert_postings_eq(&per_key, &bulk);
+    }
+
+    #[test]
+    fn test_bulk_index_merges_into_non_empty_index() {
+        // Pre-populate per-key (as in a degraded window: some keys per-key, some bulk).
+        let mut postings = Postings::default();
+        let series = make_series(1, &[("job", "web"), ("host", "a")]);
+        postings.index_timeseries(&series, b"key1");
+
+        postings.bulk_index(vec![
+            make_bulk_entry(2, "key2", &[("job", "web"), ("host", "b")]),
+            make_bulk_entry(3, "key3", &[("job", "batch"), ("host", "a")]),
+        ]);
+
+        let web = postings.postings_for_label_value("job", "web");
+        assert!(web.contains(1) && web.contains(2) && !web.contains(3));
+        let host_a = postings.postings_for_label_value("host", "a");
+        assert!(host_a.contains(1) && host_a.contains(3));
+        assert_eq!(postings.count(), 3);
+        assert!(postings.all_postings.contains(2));
+    }
+
+    #[test]
+    fn test_bulk_index_revokes_stale_marks() {
+        let mut postings = Postings::default();
+        let series = make_series(7, &[("job", "web")]);
+        postings.index_timeseries(&series, b"key7");
+        postings.mark_id_as_stale(7);
+        assert!(postings.has_stale_ids());
+
+        // Re-loading the id asserts it is alive again (same semantics as index_timeseries).
+        postings.bulk_index(vec![make_bulk_entry(7, "key7", &[("job", "web")])]);
+
+        assert!(!postings.stale_ids.contains(7));
+        assert!(postings.all_postings.contains(7));
+        assert!(postings.postings_for_label_value("job", "web").contains(7));
+    }
 
     #[test]
     fn test_memory_postings_add_and_remove() {

--- a/src/series/index/server_events.rs
+++ b/src/series/index/server_events.rs
@@ -7,6 +7,7 @@ use crate::fanout::cluster_migrations::{
     AtomicSlotMigrationEvent, register_atomic_slot_migration_event_handler,
     supports_atomic_slot_migration,
 };
+use crate::series::index::persistence::{discard_preloaded_indexes, reconcile_preloaded_indexes};
 use crate::series::index::{
     TIMESERIES_INDEX, clear_timeseries_index, get_db_index, get_timeseries_index,
     get_timeseries_index_for_db, index_series_by_key,
@@ -18,9 +19,9 @@ use range_set_blaze::RangeSetBlaze;
 use std::os::raw::c_void;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{LazyLock, Mutex, RwLock};
-use valkey_module::server_events::PersistenceSubevent;
+use valkey_module::server_events::{LoadingSubevent, PersistenceSubevent};
 use valkey_module::{Context, MODULE_CONTEXT, NotifyEvent, ValkeyResult, logging, raw};
-use valkey_module_macros::persistence_event_handler;
+use valkey_module_macros::{loading_event_handler, persistence_event_handler};
 
 const BATCH_SIZE: usize = 256;
 
@@ -397,6 +398,18 @@ fn persistence_event_handler(ctx: &Context, persistence_event: PersistenceSubeve
                 clear_delayed_keys_map();
             }
         }
+    }
+}
+
+/// Post-load lifecycle for the persisted postings index (see `persistence.rs`): after a
+/// successful load, sweep preloaded indexes for dangling ids; after a failed load, the preloaded
+/// state cannot be trusted, so drop it and let the natural indexing paths rebuild.
+#[loading_event_handler]
+fn loading_event_handler(_ctx: &Context, loading_event: LoadingSubevent) {
+    match loading_event {
+        LoadingSubevent::Ended => reconcile_preloaded_indexes(),
+        LoadingSubevent::Failed => discard_preloaded_indexes(),
+        _ => {}
     }
 }
 

--- a/src/series/index/server_events.rs
+++ b/src/series/index/server_events.rs
@@ -8,6 +8,7 @@ use crate::fanout::cluster_migrations::{
     AtomicSlotMigrationEvent, register_atomic_slot_migration_event_handler,
     supports_atomic_slot_migration,
 };
+use crate::series::index::bulk_build;
 use crate::series::index::persistence::{
     on_loading_ended, on_loading_failed, on_loading_started, should_skip_load_indexing,
 };
@@ -409,11 +410,26 @@ fn persistence_event_handler(ctx: &Context, persistence_event: PersistenceSubeve
 #[loading_event_handler]
 fn loading_event_handler(_ctx: &Context, loading_event: LoadingSubevent) {
     match loading_event {
-        LoadingSubevent::RdbStarted
-        | LoadingSubevent::AofStarted
-        | LoadingSubevent::ReplStarted => on_loading_started(),
-        LoadingSubevent::Ended => on_loading_ended(),
-        LoadingSubevent::Failed => on_loading_failed(),
+        LoadingSubevent::RdbStarted | LoadingSubevent::ReplStarted => {
+            on_loading_started();
+            bulk_build::on_load_started(false);
+        }
+        LoadingSubevent::AofStarted => {
+            on_loading_started();
+            // AOF loads keep the per-key indexing path (see bulk_build.rs module docs).
+            bulk_build::on_load_started(true);
+        }
+        LoadingSubevent::Ended => {
+            // Drain the bulk-build buffer first (synchronous — the index must be complete
+            // before serving resumes); the aux-preload reconciliation sweep then runs in the
+            // background for dbs that took the preload fast path instead.
+            bulk_build::on_load_ended();
+            on_loading_ended();
+        }
+        LoadingSubevent::Failed => {
+            bulk_build::on_load_failed();
+            on_loading_failed();
+        }
     }
 }
 
@@ -460,6 +476,13 @@ fn handle_key_restore(ctx: &Context, key: &[u8]) {
     // `rdb_load` has already assigned `_db` and counted the series; post-load verification in
     // `persistence.rs` catches any aux/keyspace drift.
     if should_skip_load_indexing(db) {
+        return;
+    }
+    // Fallback (bulk_build.rs): during an RDB/replication load window whose index was
+    // not preloaded, buffer the series for one sorted bulk build at load end instead of paying
+    // per-label ART inserts per key. Falls through when buffering is inactive for this window
+    // (AOF load, memory cap crossed, or runtime `restore` outside a load window).
+    if bulk_build::try_buffer_loaded_key(ctx, db, key) {
         return;
     }
     index_series_by_key(ctx, key);

--- a/src/series/index/server_events.rs
+++ b/src/series/index/server_events.rs
@@ -3,6 +3,7 @@
 use crate::common::context::{get_current_db, register_server_event_handler, set_current_db};
 use crate::common::hash::BuildNoHashHasher;
 use crate::common::logging::{log_debug, log_notice};
+use crate::common::sync::{lock, read_lock, write_lock};
 use crate::fanout::cluster_migrations::{
     AtomicSlotMigrationEvent, register_atomic_slot_migration_event_handler,
     supports_atomic_slot_migration,
@@ -51,10 +52,7 @@ pub fn add_delayed_indexing_key(db: i32, key: &[u8]) {
     let pending_keys = DELAYED_KEYS_MAP.pin();
 
     let converted_key = key.to_vec().into_boxed_slice();
-    pending_keys
-        .get_or_insert_with(db, || RwLock::new(Vec::with_capacity(64)))
-        .write()
-        .unwrap()
+    write_lock(pending_keys.get_or_insert_with(db, || RwLock::new(Vec::with_capacity(64))))
         .push(converted_key);
 
     let count = DELAYED_KEYS_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
@@ -82,7 +80,7 @@ fn index_timeseries_in_batch(db: i32, batch: &[Box<[u8]>]) -> usize {
     set_current_db(&ctx, db);
 
     let index = get_db_index(db);
-    let mut postings = index.inner.write().unwrap();
+    let mut postings = write_lock(&index.inner);
 
     for key_name in batch.iter() {
         let valkey_key = ctx.create_string(key_name.as_ref());
@@ -112,7 +110,7 @@ fn process_delayed_keys_for_db(db: i32) {
     // concurrent append is dropped. Empty entries are reused on the next import and cleared on
     // flush/abort.
     let keys_vec = {
-        let mut guard = lock.write().unwrap();
+        let mut guard = write_lock(lock);
         std::mem::take(&mut *guard)
     };
 
@@ -156,7 +154,7 @@ pub(super) fn process_delayed_indexing() {
     let total_keys: usize = dbs
         .iter()
         .filter_map(|db| pending_keys.get(db))
-        .map(|keys| keys.read().unwrap().len())
+        .map(|keys| read_lock(keys).len())
         .sum();
 
     log_debug(format!(
@@ -184,7 +182,7 @@ fn remove_non_owned_keys(db: i32, source_slots: &RangeSetBlaze<u16>) -> usize {
             return false;
         }
         let index = get_db_index(db);
-        let mut postings = index.inner.write().unwrap();
+        let mut postings = write_lock(&index.inner);
         postings.mark_ids_as_stale(batch);
         batch.clear();
         true
@@ -203,7 +201,7 @@ fn remove_non_owned_keys(db: i32, source_slots: &RangeSetBlaze<u16>) -> usize {
         let index = get_db_index(db);
         // Acquire a read lock to iterate a window of keys starting at `cursor`.
         // We must drop this read lock before acquiring the write lock inside `flush` to avoid deadlocks.
-        let postings_read = index.inner.read().unwrap();
+        let postings_read = read_lock(&index.inner);
 
         let mut processed = 0usize;
         for (id, key) in postings_read.id_to_key.range(cursor..).take(BATCH_SIZE) {
@@ -498,21 +496,21 @@ pub(crate) fn generic_key_events_handler(
             handle_key_restore(ctx, key);
         },
         "move_from" => {
-            *MOVE_FROM_DB.lock().unwrap() = get_current_db(ctx);
+            *lock(&MOVE_FROM_DB) = get_current_db(ctx);
         },
         "move_to" => {
-            let mut lock = MOVE_FROM_DB.lock().unwrap();
-            let old_db = *lock;
-            *lock = -1;
+            let mut guard = lock(&MOVE_FROM_DB);
+            let old_db = *guard;
+            *guard = -1;
             if old_db != -1 {
                  handle_key_move(ctx, key, old_db);
             }
         },
         "rename_from" => {
-            *RENAME_FROM_KEY.lock().unwrap() = key.to_vec();
+            *lock(&RENAME_FROM_KEY) = key.to_vec();
         },
         "rename_to" => {
-            let mut old_key = RENAME_FROM_KEY.lock().unwrap();
+            let mut old_key = lock(&RENAME_FROM_KEY);
             if !old_key.is_empty() {
                 handle_key_rename(ctx, &old_key, key);
                 old_key.clear();

--- a/src/series/index/server_events.rs
+++ b/src/series/index/server_events.rs
@@ -7,7 +7,9 @@ use crate::fanout::cluster_migrations::{
     AtomicSlotMigrationEvent, register_atomic_slot_migration_event_handler,
     supports_atomic_slot_migration,
 };
-use crate::series::index::persistence::{discard_preloaded_indexes, reconcile_preloaded_indexes};
+use crate::series::index::persistence::{
+    on_loading_ended, on_loading_failed, on_loading_started, should_skip_load_indexing,
+};
 use crate::series::index::{
     TIMESERIES_INDEX, clear_timeseries_index, get_db_index, get_timeseries_index,
     get_timeseries_index_for_db, index_series_by_key,
@@ -401,15 +403,19 @@ fn persistence_event_handler(ctx: &Context, persistence_event: PersistenceSubeve
     }
 }
 
-/// Post-load lifecycle for the persisted postings index (see `persistence.rs`): after a
-/// successful load, sweep preloaded indexes for dangling ids; after a failed load, the preloaded
-/// state cannot be trusted, so drop it and let the natural indexing paths rebuild.
+/// Load lifecycle for the persisted postings index (see `persistence.rs`): a `*Started` event
+/// opens the load window (enabling the loaded-series counter and the `loaded`-event fast path);
+/// after a successful load, preloaded indexes are swept for dangling ids and verified against
+/// the loaded count; after a failed load, the preloaded state cannot be trusted, so drop it and
+/// let the natural indexing paths rebuild.
 #[loading_event_handler]
 fn loading_event_handler(_ctx: &Context, loading_event: LoadingSubevent) {
     match loading_event {
-        LoadingSubevent::Ended => reconcile_preloaded_indexes(),
-        LoadingSubevent::Failed => discard_preloaded_indexes(),
-        _ => {}
+        LoadingSubevent::RdbStarted
+        | LoadingSubevent::AofStarted
+        | LoadingSubevent::ReplStarted => on_loading_started(),
+        LoadingSubevent::Ended => on_loading_ended(),
+        LoadingSubevent::Failed => on_loading_failed(),
     }
 }
 
@@ -449,6 +455,13 @@ fn handle_key_restore(ctx: &Context, key: &[u8]) {
     let db = get_current_db(ctx);
     if is_in_asm_slot_import() {
         add_delayed_indexing_key(db, key);
+        return;
+    }
+    // Fast path: during an RDB load whose index for this db was preloaded from the aux payload,
+    // skip the per-key work entirely (string allocation, keyspace lookup, index lock).
+    // `rdb_load` has already assigned `_db` and counted the series; post-load verification in
+    // `persistence.rs` catches any aux/keyspace drift.
+    if should_skip_load_indexing(db) {
         return;
     }
     index_series_by_key(ctx, key);

--- a/src/series/index/timeseries_index.rs
+++ b/src/series/index/timeseries_index.rs
@@ -671,11 +671,27 @@ mod tests {
 
         // Exercises both lock-acquisition orders (a<b and b<a by address).
         a.swap(&b);
-        assert!(a.get_postings().postings_for_label_value("host", "b").contains(2));
-        assert!(b.get_postings().postings_for_label_value("host", "a").contains(1));
+        assert!(
+            a.get_postings()
+                .postings_for_label_value("host", "b")
+                .contains(2)
+        );
+        assert!(
+            b.get_postings()
+                .postings_for_label_value("host", "a")
+                .contains(1)
+        );
 
         b.swap(&a);
-        assert!(a.get_postings().postings_for_label_value("host", "a").contains(1));
-        assert!(b.get_postings().postings_for_label_value("host", "b").contains(2));
+        assert!(
+            a.get_postings()
+                .postings_for_label_value("host", "a")
+                .contains(1)
+        );
+        assert!(
+            b.get_postings()
+                .postings_for_label_value("host", "b")
+                .contains(2)
+        );
     }
 }

--- a/src/series/index/timeseries_index.rs
+++ b/src/series/index/timeseries_index.rs
@@ -109,7 +109,8 @@ impl TimeSeriesIndex {
         // Acquire the two write locks in address order so concurrent swaps of the same
         // pair (in opposite argument order) cannot deadlock. `Postings::swap` is
         // symmetric, so lock order doesn't affect the result.
-        let (first, second) = if std::ptr::from_ref(self).addr() < std::ptr::from_ref(other).addr()  {
+        let (first, second) = if std::ptr::from_ref(self).addr() < std::ptr::from_ref(other).addr()
+        {
             (self, other)
         } else {
             (other, self)

--- a/src/series/index/timeseries_index.rs
+++ b/src/series/index/timeseries_index.rs
@@ -100,9 +100,23 @@ impl TimeSeriesIndex {
     // swap the inner value with some other value
     // this is specifically to handle the `swapdb` event callback
     pub fn swap(&self, other: &Self) {
-        let mut self_inner = write_lock(&self.inner);
-        let mut other_inner = write_lock(&other.inner);
-        self_inner.swap(&mut other_inner);
+        // Swapping an index with itself is a no-op; proceeding would deadlock on the
+        // second write_lock (SWAPDB of a db with itself is rejected by the server, but
+        // don't rely on that here).
+        if std::ptr::eq(self, other) {
+            return;
+        }
+        // Acquire the two write locks in address order so concurrent swaps of the same
+        // pair (in opposite argument order) cannot deadlock. `Postings::swap` is
+        // symmetric, so lock order doesn't affect the result.
+        let (first, second) = if std::ptr::from_ref(self) < std::ptr::from_ref(other) {
+            (self, other)
+        } else {
+            (other, self)
+        };
+        let mut first_inner = write_lock(&first.inner);
+        let mut second_inner = write_lock(&second.inner);
+        first_inner.swap(&mut second_inner);
     }
 
     pub fn index_timeseries(&self, ts: &TimeSeries, key: &[u8]) {
@@ -622,4 +636,46 @@ impl<'a> BatchIterator<'a> {
 
 fn get_bitmap_size(bmp: &PostingsBitmap) -> usize {
     bmp.cardinality() as usize * size_of::<SeriesRef>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn index_with_posting(id: SeriesRef, label: &str, value: &str) -> TimeSeriesIndex {
+        let index = TimeSeriesIndex::new();
+        index
+            .get_postings_mut()
+            .add_posting_for_label_value(id, label, value);
+        index
+    }
+
+    #[test]
+    fn test_swap_with_self_is_noop() {
+        // SWAPDB with from_db == to_db resolves to the same index twice; without the
+        // identity guard this deadlocks on the second write lock.
+        let index = index_with_posting(1, "host", "a");
+        index.swap(&index);
+        assert!(
+            index
+                .get_postings()
+                .postings_for_label_value("host", "a")
+                .contains(1)
+        );
+    }
+
+    #[test]
+    fn test_swap_exchanges_contents_in_both_argument_orders() {
+        let a = index_with_posting(1, "host", "a");
+        let b = index_with_posting(2, "host", "b");
+
+        // Exercises both lock-acquisition orders (a<b and b<a by address).
+        a.swap(&b);
+        assert!(a.get_postings().postings_for_label_value("host", "b").contains(2));
+        assert!(b.get_postings().postings_for_label_value("host", "a").contains(1));
+
+        b.swap(&a);
+        assert!(a.get_postings().postings_for_label_value("host", "a").contains(1));
+        assert!(b.get_postings().postings_for_label_value("host", "b").contains(2));
+    }
 }

--- a/src/series/index/timeseries_index.rs
+++ b/src/series/index/timeseries_index.rs
@@ -109,7 +109,7 @@ impl TimeSeriesIndex {
         // Acquire the two write locks in address order so concurrent swaps of the same
         // pair (in opposite argument order) cannot deadlock. `Postings::swap` is
         // symmetric, so lock order doesn't affect the result.
-        let (first, second) = if std::ptr::from_ref(self) < std::ptr::from_ref(other) {
+        let (first, second) = if std::ptr::from_ref(self).addr() < std::ptr::from_ref(other).addr()  {
             (self, other)
         } else {
             (other, self)

--- a/src/series/serialization.rs
+++ b/src/series/serialization.rs
@@ -74,7 +74,7 @@ pub fn rdb_load_series(rdb: *mut raw::RedisModuleIO, enc_ver: i32) -> ValkeyResu
     }
     rules.shrink_to_fit();
 
-    let ts = TimeSeries {
+    let mut ts = TimeSeries {
         id,
         labels,
         retention,
@@ -91,7 +91,9 @@ pub fn rdb_load_series(rdb: *mut raw::RedisModuleIO, enc_ver: i32) -> ValkeyResu
         rules,
     };
 
-    // ts.update_meta();
-    // add to index
+    // Assign `_db` from the IO context and count the series toward the current load window
+    // (no-op for db-less payloads like RESTORE / TS._RESTORE strings).
+    crate::series::index::persistence::observe_series_rdb_load(rdb, &mut ts);
+
     Ok(ts)
 }

--- a/src/series/series_data_type.rs
+++ b/src/series/series_data_type.rs
@@ -8,6 +8,7 @@ use valkey_module::{RedisModuleIO, RedisModuleTypeMethods, logging, raw};
 use crate::common::logging::log_debug;
 use crate::series::TimeSeries;
 use crate::series::defrag_series;
+use crate::series::index::persistence::{load_index_from_rdb, save_index_to_rdb};
 use crate::series::index::{get_db_index, next_timeseries_id};
 use crate::series::serialization::{rdb_load_series, rdb_save_series};
 use std::os::raw::{c_int, c_void};
@@ -31,7 +32,7 @@ pub static VK_TIME_SERIES_TYPE: ValkeyType = ValkeyType::new(
         free: Some(free),
         mem_usage: Some(mem_usage),
         digest: Some(series_digest),
-        aux_load: None,
+        aux_load: Some(aux_load),
         aux_save: None,
         aux_save_triggers: REDISMODULE_AUX_BEFORE_RDB as i32,
         free_effort: None,
@@ -42,7 +43,7 @@ pub static VK_TIME_SERIES_TYPE: ValkeyType = ValkeyType::new(
         free_effort2: None,
         unlink2: None,
         copy2: None,
-        aux_save2: None,
+        aux_save2: Some(aux_save),
     },
 );
 
@@ -97,6 +98,26 @@ unsafe extern "C" fn rdb_load(rdb: *mut RedisModuleIO, enc_ver: c_int) -> *mut c
             std::ptr::null_mut()
         }
     }
+}
+
+/// Persists the postings index as an RDB aux field (`AUX_BEFORE_RDB`). Runs in the BGSAVE fork
+/// child, so all locking inside is non-blocking; on contention nothing is written and the loader
+/// falls back to the per-key rebuild. Registered as `aux_save2`, so writing nothing omits the aux
+/// field from the RDB entirely.
+unsafe extern "C" fn aux_save(rdb: *mut RedisModuleIO, when: c_int) {
+    if when != REDISMODULE_AUX_BEFORE_RDB as c_int {
+        return;
+    }
+    save_index_to_rdb(rdb);
+}
+
+/// Preloads the postings index from the RDB aux field. With `AUX_BEFORE_RDB` this runs before any
+/// key loads; the per-key `loaded` path then reduces to a `has_id` check per series.
+unsafe extern "C" fn aux_load(rdb: *mut RedisModuleIO, _encver: c_int, when: c_int) -> c_int {
+    if when != REDISMODULE_AUX_BEFORE_RDB as c_int {
+        return raw::Status::Ok as c_int;
+    }
+    load_index_from_rdb(rdb)
 }
 
 unsafe extern "C" fn mem_usage(value: *const c_void) -> usize {

--- a/src/series/tasks/optimize_indices.rs
+++ b/src/series/tasks/optimize_indices.rs
@@ -1,5 +1,6 @@
 use crate::common::logging::log_debug;
 use crate::common::threads::spawn;
+use crate::common::sync::lock;
 use crate::series::index::{IndexKey, TIMESERIES_INDEX, get_db_index};
 use crate::series::tasks::utils::find_next_db;
 use std::sync::{LazyLock, Mutex};
@@ -17,7 +18,7 @@ static LAZY_OPTIMIZE_CURSOR: LazyLock<Mutex<OptimizeContext>> =
 
 #[inline]
 fn set_optimize_cursor(db: i32, cursor: Option<IndexKey>) {
-    let mut context = LAZY_OPTIMIZE_CURSOR.lock().unwrap();
+    let mut context = lock(&LAZY_OPTIMIZE_CURSOR);
     if cursor.is_none() {
         context.db = find_next_db(db).unwrap_or(0);
     } else {
@@ -33,7 +34,7 @@ pub fn optimize_indices_for_db() {
 /// Process optimization for a specific database, called by the dispatcher.
 pub(in crate::series) fn optimize_indices_internal() {
     let (db, cursor) = {
-        let mut context = LAZY_OPTIMIZE_CURSOR.lock().unwrap();
+        let mut context = lock(&LAZY_OPTIMIZE_CURSOR);
         (context.db, context.cursor.take())
     };
 
@@ -68,7 +69,7 @@ mod tests {
     fn reset_test_state() {
         TIMESERIES_INDEX.pin().retain(|_, _| false);
 
-        let mut context = LAZY_OPTIMIZE_CURSOR.lock().unwrap();
+        let mut context = lock(&LAZY_OPTIMIZE_CURSOR);
         context.db = 0;
         context.cursor = None;
     }
@@ -93,12 +94,12 @@ mod tests {
     }
 
     fn current_context() -> (i32, Option<IndexKey>) {
-        let context = LAZY_OPTIMIZE_CURSOR.lock().unwrap();
+        let context = lock(&LAZY_OPTIMIZE_CURSOR);
         (context.db, context.cursor.clone())
     }
 
     fn set_context(db: i32, cursor: Option<IndexKey>) {
-        let mut context = LAZY_OPTIMIZE_CURSOR.lock().unwrap();
+        let mut context = lock(&LAZY_OPTIMIZE_CURSOR);
         context.db = db;
         context.cursor = cursor;
     }

--- a/src/series/tasks/optimize_indices.rs
+++ b/src/series/tasks/optimize_indices.rs
@@ -1,6 +1,6 @@
 use crate::common::logging::log_debug;
-use crate::common::threads::spawn;
 use crate::common::sync::lock;
+use crate::common::threads::spawn;
 use crate::series::index::{IndexKey, TIMESERIES_INDEX, get_db_index};
 use crate::series::tasks::utils::find_next_db;
 use std::sync::{LazyLock, Mutex};

--- a/src/series/tasks/series_trim.rs
+++ b/src/series/tasks/series_trim.rs
@@ -1,6 +1,7 @@
 use crate::common::context::{get_current_db, set_current_db};
 use crate::common::logging::{log_debug, log_warning};
 use crate::common::threads::spawn;
+use crate::common::sync::lock;
 use crate::is_shutting_down;
 use crate::series::tasks::utils::{fetch_series_batch, find_next_db};
 use orx_parallel::ParIter;
@@ -31,7 +32,7 @@ pub fn process_series_trim() {
 fn process_trim_internal() {
     let mut processed = 0;
     let start_db = {
-        let context = SERIES_TRIM_CURSORS.lock().unwrap();
+        let context = lock(&SERIES_TRIM_CURSORS);
         context.db
     };
 
@@ -44,7 +45,7 @@ fn process_trim_internal() {
         }
 
         let cursor = {
-            let context = SERIES_TRIM_CURSORS.lock().unwrap();
+            let context = lock(&SERIES_TRIM_CURSORS);
             context.cursor
         };
 
@@ -79,7 +80,7 @@ fn trim_series(ctx: &Context, db: i32, cursor: u64) -> (usize, i32) {
     set_current_db(ctx, save_db);
 
     if batch.is_empty() {
-        let mut context = SERIES_TRIM_CURSORS.lock().unwrap();
+        let mut context = lock(&SERIES_TRIM_CURSORS);
         let db = find_next_db(context.db).unwrap_or(0);
         context.db = db;
         context.cursor = 0;
@@ -103,7 +104,7 @@ fn trim_series(ctx: &Context, db: i32, cursor: u64) -> (usize, i32) {
         })
         .sum();
 
-    let mut context = SERIES_TRIM_CURSORS.lock().unwrap();
+    let mut context = lock(&SERIES_TRIM_CURSORS);
     context.cursor = last_processed;
 
     if processed > 0 {

--- a/src/series/tasks/series_trim.rs
+++ b/src/series/tasks/series_trim.rs
@@ -30,17 +30,23 @@ pub fn process_series_trim() {
 
 fn process_trim_internal() {
     let mut processed = 0;
-    let (start_db, cursor) = {
+    let start_db = {
         let context = SERIES_TRIM_CURSORS.lock().unwrap();
-        (context.db, context.cursor)
+        context.db
     };
 
     let mut db = start_db;
+    let mut first_iteration = true;
 
     for _ in 0..MAX_TRIM_TURNS {
         if is_shutting_down() {
             break;
         }
+
+        let cursor = {
+            let context = SERIES_TRIM_CURSORS.lock().unwrap();
+            context.cursor
+        };
 
         let ctx = MODULE_CONTEXT.lock();
         let (subtotal, next_db) = trim_series(&ctx, db, cursor);
@@ -51,9 +57,10 @@ fn process_trim_internal() {
         }
 
         db = next_db;
-        if db == start_db {
+        if !first_iteration && db == start_db {
             break;
         }
+        first_iteration = false;
     }
 }
 

--- a/src/series/tasks/series_trim.rs
+++ b/src/series/tasks/series_trim.rs
@@ -1,7 +1,7 @@
 use crate::common::context::{get_current_db, set_current_db};
 use crate::common::logging::{log_debug, log_warning};
-use crate::common::threads::spawn;
 use crate::common::sync::lock;
+use crate::common::threads::spawn;
 use crate::is_shutting_down;
 use crate::series::tasks::utils::{fetch_series_batch, find_next_db};
 use orx_parallel::ParIter;

--- a/src/series/tasks/stale_ids.rs
+++ b/src/series/tasks/stale_ids.rs
@@ -1,5 +1,6 @@
 use super::utils::find_next_db;
 use crate::is_shutting_down;
+use crate::common::sync::lock;
 use crate::series::index::{IndexKey, TIMESERIES_INDEX};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{LazyLock, Mutex};
@@ -25,7 +26,7 @@ impl Drop for StaleIdCleanupGuard {
 }
 
 fn set_stale_id_cleanup_cursor(db: i32, cursor: Option<IndexKey>) {
-    let mut context = STALE_ID_CLEANUP_CONTEXT.lock().unwrap();
+    let mut context = lock(&STALE_ID_CLEANUP_CONTEXT);
     if cursor.is_none() {
         context.db = find_next_db(db).unwrap_or(0);
     } else {
@@ -82,7 +83,7 @@ pub(in crate::series) fn remove_stale_series_internal() {
     };
 
     let (db, cursor) = {
-        let mut context = STALE_ID_CLEANUP_CONTEXT.lock().unwrap();
+        let mut context = lock(&STALE_ID_CLEANUP_CONTEXT);
         (context.db, context.cursor.take())
     };
 
@@ -113,7 +114,7 @@ pub(in crate::series) fn remove_all_stale_series_internal() {
         process_db_until_done(db, None);
     }
 
-    let mut context = STALE_ID_CLEANUP_CONTEXT.lock().unwrap();
+    let mut context = lock(&STALE_ID_CLEANUP_CONTEXT);
     context.db = 0;
     context.cursor = None;
 }
@@ -136,7 +137,7 @@ mod tests {
     fn reset_test_state() {
         TIMESERIES_INDEX.pin().retain(|_, _| false);
 
-        let mut context = STALE_ID_CLEANUP_CONTEXT.lock().unwrap();
+        let mut context = lock(&STALE_ID_CLEANUP_CONTEXT);
         context.db = 0;
         context.cursor = None;
 
@@ -180,7 +181,7 @@ mod tests {
         let cursor = Some(IndexKey::from("host=h1"));
         set_stale_id_cleanup_cursor(2, cursor.clone());
 
-        let context = STALE_ID_CLEANUP_CONTEXT.lock().unwrap();
+        let context = lock(&STALE_ID_CLEANUP_CONTEXT);
         assert_eq!(context.db, 2);
         assert_eq!(context.cursor, cursor);
     }
@@ -195,7 +196,7 @@ mod tests {
 
         set_stale_id_cleanup_cursor(2, None);
 
-        let context = STALE_ID_CLEANUP_CONTEXT.lock().unwrap();
+        let context = lock(&STALE_ID_CLEANUP_CONTEXT);
         assert_eq!(context.db, 4);
         assert_eq!(context.cursor, None);
     }

--- a/src/series/tasks/stale_ids.rs
+++ b/src/series/tasks/stale_ids.rs
@@ -1,6 +1,6 @@
 use super::utils::find_next_db;
-use crate::is_shutting_down;
 use crate::common::sync::lock;
+use crate::is_shutting_down;
 use crate::series::index::{IndexKey, TIMESERIES_INDEX};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{LazyLock, Mutex};

--- a/tests/test_ts_index_persistence.py
+++ b/tests/test_ts_index_persistence.py
@@ -1,6 +1,6 @@
 """Integration tests for postings-index RDB aux persistence.
 
-Covers the aux payload save/load cycle, the ts-index-persist config gate, the dangling-id 
+Covers the aux payload save/load cycle, the ts-index-persist config gate, the dangling-id
 reconciliation sweep and count-verification repair scan, and the AOF/replication interactions
 called out in that document's "Interaction with other flows" section.
 """

--- a/tests/test_ts_index_persistence.py
+++ b/tests/test_ts_index_persistence.py
@@ -1,0 +1,413 @@
+"""Integration tests for postings-index RDB aux persistence.
+
+Covers the aux payload save/load cycle, the ts-index-persist config gate, the dangling-id 
+reconciliation sweep and count-verification repair scan, and the AOF/replication interactions
+called out in that document's "Interaction with other flows" section.
+"""
+import os
+
+import pytest
+from valkeytestframework.conftest import resource_port_tracker
+from valkeytestframework.util.waiters import wait_for_equal, wait_for_true, TEST_MAX_WAIT_TIME_SECONDS
+from valkeytestframework.valkey_test_case import ReplicationTestCase
+
+from common import SERVER_PATH
+from valkey_timeseries_test_case import ValkeyTimeSeriesTestCaseBase
+
+
+PRELOADED_LOG = "Preloaded postings index"
+DISABLED_LOG = "ts-index-persist is disabled; discarding persisted postings index and rebuilding"
+DANGLING_LOG = "dangling ids marked stale"
+REPAIR_LOG = "scanning keyspace to repair"
+
+
+class TestIndexPersistenceBasic(ValkeyTimeSeriesTestCaseBase):
+
+    def _create_series(self, client, count, prefix="ts"):
+        """Create `count` series with a mix of shared and per-series labels."""
+        keys = []
+        for i in range(count):
+            key = f"{prefix}:{i}"
+            keys.append(key)
+            client.execute_command(
+                "TS.CREATE", key,
+                "LABELS", "service", "api", "shard", str(i % 3), "instance", str(i),
+            )
+            client.execute_command("TS.ADD", key, 1000 + i, float(i))
+        return keys
+
+    def test_index_preloaded_after_restart(self):
+        """Happy path: aux payload preloads the index and reconciliation finds no drift."""
+        client = self.server.get_new_client()
+        keys = self._create_series(client, 10)
+
+        pre_card = client.execute_command("TS.CARD", "FILTER", "service=api")
+        pre_shard0 = sorted(client.execute_command("TS.QUERYINDEX", "shard=0"))
+        assert pre_card == 10
+
+        client.bgsave()
+        self.server.wait_for_save_done()
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+        assert self.server.is_alive()
+        wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
+
+        # "none dangling" / "match the loaded count" are log_debug and not visible at the
+        # harness's default loglevel; absence of a repair-scan (log_warning) is the
+        # externally-observable proxy for "reconciliation found no drift".
+        assert self.server.verify_string_in_logfile(PRELOADED_LOG)
+        assert not self.server.verify_string_in_logfile(REPAIR_LOG)
+
+        post_card = client.execute_command("TS.CARD", "FILTER", "service=api")
+        post_shard0 = sorted(client.execute_command("TS.QUERYINDEX", "shard=0"))
+        assert post_card == pre_card
+        assert post_shard0 == pre_shard0
+        for key in keys:
+            assert client.execute_command("EXISTS", key) == 1
+
+    def test_index_preloaded_with_many_series_and_labels(self):
+        """Larger/more varied index still preloads to an exactly correct state."""
+        client = self.server.get_new_client()
+        keys = self._create_series(client, 60)
+
+        pre_card_total = client.execute_command("TS.CARD")
+        pre_per_shard = {
+            s: sorted(client.execute_command("TS.QUERYINDEX", f"shard={s}"))
+            for s in ("0", "1", "2")
+        }
+
+        client.bgsave()
+        self.server.wait_for_save_done()
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+        assert self.server.is_alive()
+        wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
+        assert self.server.verify_string_in_logfile(PRELOADED_LOG)
+
+        assert client.execute_command("TS.CARD") == pre_card_total
+        for s in ("0", "1", "2"):
+            assert sorted(client.execute_command("TS.QUERYINDEX", f"shard={s}")) == pre_per_shard[s]
+        for key in keys:
+            assert client.execute_command("EXISTS", key) == 1
+
+    def test_flushall_then_restart_yields_empty_index(self):
+        """An empty db must not leave a stale/garbage aux payload behind."""
+        client = self.server.get_new_client()
+        self._create_series(client, 5)
+        client.flushall()
+        assert client.execute_command("DBSIZE") == 0
+
+        client.bgsave()
+        self.server.wait_for_save_done()
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+        assert self.server.is_alive()
+        wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
+
+        # Nothing to preload: build_aux_payload writes no aux field when every db is empty.
+        assert not self.server.verify_string_in_logfile(PRELOADED_LOG)
+        assert client.execute_command("DBSIZE") == 0
+        assert client.execute_command("TS.CARD") == 0
+
+        # And the server still works normally afterward.
+        client.execute_command("TS.CREATE", "ts:after", "LABELS", "service", "api")
+        assert client.execute_command("TS.CARD", "FILTER", "service=api") == 1
+
+    def test_ts_index_persist_disabled_falls_back_to_rebuild(self):
+        """With the feature off at load time, a real aux payload is read (to keep the RDB
+        stream in sync) and discarded, falling back to the per-key rebuild.
+
+        `ts-index-persist` is a module-registered config: this build's CLI/config-file
+        parser resolves module directives before modules load, so it cannot be set via
+        `--ts-index-persist` at process startup outside a real config file with
+        `loadmodule` preceding it. `CONFIG SET` + `DEBUG RELOAD NOSAVE` sidesteps that:
+        it flips the config at runtime and reloads the *existing* RDB (written earlier,
+        while the feature was on) without re-saving it, giving the load path a genuine
+        aux payload to discard.
+        """
+        client = self.server.get_new_client()
+        keys = self._create_series(client, 8)
+        pre_card = client.execute_command("TS.CARD", "FILTER", "service=api")
+
+        # Written with ts-index-persist on (default): the RDB now carries a real aux payload.
+        client.bgsave()
+        self.server.wait_for_save_done()
+
+        # The module namespaces its registered configs as "ts.<name>".
+        client.config_set("ts.ts-index-persist", "no")
+        client.execute_command("DEBUG", "RELOAD", "NOSAVE")
+
+        assert self.server.verify_string_in_logfile(DISABLED_LOG)
+        assert not self.server.verify_string_in_logfile(PRELOADED_LOG)
+
+        # Rebuilt via the per-key path: still fully correct.
+        assert client.execute_command("TS.CARD", "FILTER", "service=api") == pre_card
+        for key in keys:
+            assert client.execute_command("EXISTS", key) == 1
+
+    def test_deleted_series_do_not_reappear_after_restart(self):
+        """Deleted series are gone from id_to_key at save time, so they cannot leak back in."""
+        client = self.server.get_new_client()
+        keys = self._create_series(client, 10)
+        to_delete = keys[2:5]
+        for key in to_delete:
+            client.execute_command("DEL", key)
+
+        client.bgsave()
+        self.server.wait_for_save_done()
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+        assert self.server.is_alive()
+        wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
+
+        assert self.server.verify_string_in_logfile(PRELOADED_LOG)
+        assert not self.server.verify_string_in_logfile(REPAIR_LOG)
+        assert client.execute_command("TS.CARD") == len(keys) - len(to_delete)
+        for key in to_delete:
+            assert client.execute_command("EXISTS", key) == 0
+        for key in keys:
+            if key not in to_delete:
+                assert client.execute_command("EXISTS", key) == 1
+
+
+class TestIndexPersistenceDanglingRepair(ValkeyTimeSeriesTestCaseBase):
+    """Exercises the case where the aux payload names an id whose key does not load
+    (RDB body corruption / a fork landing mid-write). The reconciliation sweep must
+    mark the id stale, and the count-verification scan must repair the index so the
+    renamed key becomes findable under its real name."""
+
+    @property
+    def rdb_path(self):
+        return os.path.join(self.server.cwd, self.server.args["dbfilename"])
+
+    def _rename_key_in_rdb_body(self, old_name: bytes, new_name: bytes):
+        """Flip a key's literal bytes in the on-disk RDB, in place (same length only).
+
+        The aux payload is LZF-compressed by the engine, so a literal key name should
+        appear exactly once in the file: in the RDB body's key-value section. This
+        simulates the aux payload and the keyspace disagreeing about a key's name,
+        without touching the (compressed, harder to hand-edit) aux blob itself.
+        """
+        assert len(old_name) == len(new_name), "in-place edit requires equal-length names"
+        with open(self.rdb_path, "rb") as f:
+            data = bytearray(f.read())
+        idx = data.find(old_name)
+        assert idx != -1, f"key name {old_name!r} not found in rdb file"
+        assert data.find(old_name, idx + 1) == -1, (
+            f"key name {old_name!r} found more than once; test assumption violated"
+        )
+        data[idx:idx + len(old_name)] = new_name
+        with open(self.rdb_path, "wb") as f:
+            f.write(bytes(data))
+
+    def test_dangling_id_triggers_reconciliation_and_repair_scan(self):
+        # rdbchecksum is IMMUTABLE_CONFIG (can't CONFIG SET at runtime); disable it from
+        # process start so the hand-edited RDB below isn't rejected by checksum verification
+        # before our aux/per-key logic ever runs. The dataset is still empty at this point.
+        self.server.args["rdbchecksum"] = "no"
+        self.server.restart(remove_rdb=True, remove_nodes_conf=True, connect_client=True)
+        assert self.server.is_alive()
+        client = self.server.get_new_client()
+
+        keys = [f"ts:{i}" for i in range(7)]
+        for i, key in enumerate(keys):
+            client.execute_command("TS.CREATE", key, "LABELS", "region", f"us-east-{i}", "service", "api")
+
+        client.bgsave()
+        self.server.wait_for_save_done()
+        self.server.exit(cleanup=False, remove_nodes_conf=False)
+
+        old_name, new_name = b"ts:4", b"tz:4"
+        self._rename_key_in_rdb_body(old_name, new_name)
+
+        self.server.start(connect_client=True)
+        assert self.server.is_alive()
+        wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
+
+        assert self.server.verify_string_in_logfile(PRELOADED_LOG)
+        assert self.server.verify_string_in_logfile(DANGLING_LOG)
+        assert self.server.verify_string_in_logfile(REPAIR_LOG)
+
+        client = self.server.get_new_client()
+        # Repair must converge to the correct final state regardless of GC timing.
+        wait_for_equal(lambda: client.execute_command("TS.CARD", "FILTER", "service=api"), len(keys))
+
+        assert client.execute_command("EXISTS", old_name.decode()) == 0
+        assert client.execute_command("EXISTS", new_name.decode()) == 1
+        # The dangling id must resolve under its real (renamed) key, not the stale aux name.
+        assert client.execute_command("TS.QUERYINDEX", "region=us-east-4") == [new_name]
+
+        for i, key in enumerate(keys):
+            if key == old_name.decode():
+                continue
+            assert client.execute_command("EXISTS", key) == 1
+
+
+class TestIndexPersistenceDebugReload(ValkeyTimeSeriesTestCaseBase):
+
+    def test_debug_reload_preserves_index_correctness(self):
+        """DEBUG RELOAD exercises aux save/load without a process restart. Freeing the
+        pre-reload objects can race the aux payload's index install (asynchronous key
+        frees during the engine's flush-before-load step), so the index can transiently
+        under-count until the reconciliation/repair pass converges it. The end state
+        must always be exactly correct."""
+        client = self.server.get_new_client()
+        keys = []
+        for i in range(12):
+            key = f"ts:{i}"
+            keys.append(key)
+            client.execute_command("TS.CREATE", key, "LABELS", "region", f"us-east-{i}", "service", "api")
+            client.execute_command("TS.ADD", key, 1000 + i, float(i))
+
+        pre_digest = client.execute_command("DEBUG", "DIGEST")
+        pre_queryindex = sorted(client.execute_command("TS.QUERYINDEX", "service=api"))
+
+        client.execute_command("DEBUG", "RELOAD")
+
+        # The repair scan (if triggered) runs on a background thread; give it a moment
+        # to converge rather than asserting instantaneous consistency.
+        wait_for_equal(
+            lambda: client.execute_command("TS.CARD", "FILTER", "service=api"),
+            len(keys),
+            timeout=TEST_MAX_WAIT_TIME_SECONDS,
+        )
+
+        post_digest = client.execute_command("DEBUG", "DIGEST")
+        post_queryindex = sorted(client.execute_command("TS.QUERYINDEX", "service=api"))
+        assert post_digest == pre_digest
+        assert post_queryindex == pre_queryindex
+        for key in keys:
+            assert client.execute_command("EXISTS", key) == 1
+
+    def test_debug_reload_multiple_cycles_stay_consistent(self):
+        """Repeated reloads must not accumulate drift (stale ids, phantom entries)."""
+        client = self.server.get_new_client()
+        for i in range(8):
+            client.execute_command(
+                "TS.CREATE", f"ts:{i}", "LABELS", "region", f"us-east-{i}", "service", "api",
+            )
+
+        for _ in range(3):
+            client.execute_command("DEBUG", "RELOAD")
+            wait_for_equal(
+                lambda: client.execute_command("TS.CARD", "FILTER", "service=api"),
+                8,
+                timeout=TEST_MAX_WAIT_TIME_SECONDS,
+            )
+
+        assert client.execute_command("TS.CARD") == 8
+        assert len(client.execute_command("TS.QUERYINDEX", "service=api")) == 8
+
+
+class TestIndexPersistenceAof(ValkeyTimeSeriesTestCaseBase):
+
+    AOF_REWRITE_DONE_LOG = "Background AOF rewrite finished successfully"
+
+    def _count_string_in_logfile(self, string):
+        """Count occurrences rather than mere presence: with no samples in these series
+        the rewrite is fast enough that the initial CONFIG SET appendonly yes triggers
+        its own (empty-dataset) rewrite completing before our own bgrewriteaof() call
+        even starts. Checking presence alone (or the shared harness's
+        `wait_for_action_done`, which reads `aof_last_bgrewrite_status` without
+        confirming it reflects *this* rewrite) can observe that earlier completion and
+        proceed before our data-bearing rewrite has actually finished, so callers must
+        wait for the count to increase past a baseline captured before triggering it."""
+        path = os.path.join(self.server.cwd, self.server.args["logfile"])
+        if not os.path.exists(path):
+            return 0
+        with open(path) as f:
+            return sum(1 for line in f if string in line)
+
+    def _bgrewriteaof_and_wait(self, client):
+        finished_before = self._count_string_in_logfile(self.AOF_REWRITE_DONE_LOG)
+        client.bgrewriteaof()
+        wait_for_true(
+            lambda: self._count_string_in_logfile(self.AOF_REWRITE_DONE_LOG) > finished_before
+        )
+
+    def test_aof_with_rdb_preamble_preloads_index(self):
+        """Default AOF (RDB preamble on) carries the aux fields: restart preloads."""
+        client = self.client
+        client.config_set("appendonly", "yes")
+        wait_for_equal(lambda: client.info("persistence")["aof_rewrite_in_progress"], 0, timeout=30)
+
+        keys = []
+        for i in range(9):
+            key = f"ts:{i}"
+            keys.append(key)
+            client.execute_command("TS.CREATE", key, "LABELS", "service", "api", "idx", str(i))
+
+        self._bgrewriteaof_and_wait(client)
+
+        self.server.args["appendonly"] = "yes"
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+        assert self.server.is_alive()
+        wait_for_true(lambda: self.server.verify_string_in_logfile("DB loaded from"))
+
+        assert self.server.verify_string_in_logfile(PRELOADED_LOG)
+        client = self.server.get_new_client()
+        assert client.execute_command("TS.CARD", "FILTER", "service=api") == len(keys)
+        for key in keys:
+            assert client.execute_command("EXISTS", key) == 1
+
+    def test_plain_aof_command_format_rebuilds_without_preload(self):
+        """Command-format AOF (no RDB preamble) carries no aux field: per-key rebuild,
+        as documented in docs/postings-index-persistence.md."""
+        client = self.client
+        client.config_set("appendonly", "yes")
+        client.config_set("aof-use-rdb-preamble", "no")
+        wait_for_equal(lambda: client.info("persistence")["aof_rewrite_in_progress"], 0, timeout=30)
+
+        keys = []
+        for i in range(6):
+            key = f"ts:{i}"
+            keys.append(key)
+            client.execute_command("TS.CREATE", key, "LABELS", "service", "api", "idx", str(i))
+
+        self._bgrewriteaof_and_wait(client)
+
+        self.server.args["appendonly"] = "yes"
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+        assert self.server.is_alive()
+        wait_for_true(lambda: self.server.verify_string_in_logfile("DB loaded from"))
+
+        # No aux payload in a command-format AOF: preload never fires.
+        assert not self.server.verify_string_in_logfile(PRELOADED_LOG)
+        client = self.server.get_new_client()
+        assert client.execute_command("TS.CARD", "FILTER", "service=api") == len(keys)
+        for key in keys:
+            assert client.execute_command("EXISTS", key) == 1
+
+
+class TestIndexPersistenceReplication(ReplicationTestCase):
+    """Full-sync replicas receive the primary's RDB (including aux fields) and should
+    preload their index rather than rebuild it per key."""
+
+    @pytest.fixture(autouse=True)
+    def setup_test(self, setup):
+        self.args = {"enable-debug-command": "yes", "loadmodule": os.getenv("MODULE_PATH")}
+        self.server, self.client = self.create_server(
+            testdir=self.testdir, server_path=SERVER_PATH, args=self.args
+        )
+
+    def test_full_sync_replica_preloads_index(self):
+        client = self.client
+
+        keys = []
+        for i in range(10):
+            key = f"ts:{i}"
+            keys.append(key)
+            client.execute_command("TS.CREATE", key, "LABELS", "region", f"us-east-{i}", "service", "api")
+            client.execute_command("TS.ADD", key, 1000 + i, float(i))
+
+        pre_queryindex = sorted(client.execute_command("TS.QUERYINDEX", "service=api"))
+
+        # The replica attaches after the primary already has data, forcing a full sync
+        # that must transfer a non-trivial aux payload.
+        self.setup_replication(num_replicas=1)
+        replica = self.replicas[0]
+
+        assert replica.verify_string_in_logfile(PRELOADED_LOG)
+
+        replica_card = replica.client.execute_command("TS.CARD", "FILTER", "service=api")
+        assert replica_card == len(keys)
+        replica_queryindex = sorted(replica.client.execute_command("TS.QUERYINDEX", "service=api"))
+        assert replica_queryindex == pre_queryindex
+        for key in keys:
+            assert replica.client.execute_command("EXISTS", key) == 1


### PR DESCRIPTION
Serialize the in-memory postings index (label→series inverted index) as RDB aux data, loaded before individual keys, so that server startup and replica full-sync no longer pay the cost of rebuilding the index one label-pair at a time per series.

This pull request also introduces a new, memory-bounded, sorted bulk-build fallback path for rebuilding the postings index during RDB and replication loads, along with several related configuration and code hygiene improvements. The bulk-build mechanism buffers loaded series during a load window and performs a single efficient bulk index build at the end, falling back to the per-key path if a configurable memory cap is exceeded. Additionally, the PR adds configuration toggles for index persistence and bulk-build memory, and refactors code to use safer locking utilities.

**Index Persistence and Load Coordination:**

* Added a runtime toggle for index persistence (gating both save and load of the RDB aux field) and a check to suppress background tasks while a load is in progress, preventing index rebuilds from interfering with ongoing loads. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR228-R250) [[2]](diffhunk://#diff-dd4b249d81d34c58ced6491174132142dea80acf387187ca7e4cf0a2b30e8b0fR4) [[3]](diffhunk://#diff-dd4b249d81d34c58ced6491174132142dea80acf387187ca7e4cf0a2b30e8b0fL162-R163)


**Bulk Index Build for Postings Index:**

* Added a new module `bulk_build.rs` implementing a sorted bulk-build mechanism for index rebuilds during RDB/replication loads. The buffer is memory-capped (default 256 MiB, configurable), and falls back to per-key indexing if the cap is exceeded. The bulk build is only active for RDB and replication load windows, not AOF. [[1]](diffhunk://#diff-78b56036d97453437fa8d33d8efbae011c8af4382caee8706972d2d26b49f5a4R1-R264) [[2]](diffhunk://#diff-1770fabed32ba156df24ef5808eabcb08448db45de17495baaac8544a487744fR2) [[3]](diffhunk://#diff-1770fabed32ba156df24ef5808eabcb08448db45de17495baaac8544a487744fR30) [[4]](diffhunk://#diff-d796c4c9310749f510a1fc6a9a040afea078b1d3b2d3d3bbe0a8210918044638R31-R38)

**Configuration Additions:**

* Added new configuration parameters: `ts-index-persist` (enables/disables index persistence in RDB aux field) and `ts-index-build-max-memory` (bytes, cap for bulk build buffer). These are now registered and handled at runtime. [[1]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR77-R80) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR228-R250) [[3]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR832-R860)

**Concurrency and Locking Improvements:**

* Refactored code to use custom `read_lock`, `write_lock`, and `lock` helpers instead of direct `.lock().unwrap()` or `.read().unwrap()`, improving code clarity and error handling. [[1]](diffhunk://#diff-97efe4d6502d241377d37800530dbd33c6fb9cc45c2192436d6a7053b77363f2R1) [[2]](diffhunk://#diff-97efe4d6502d241377d37800530dbd33c6fb9cc45c2192436d6a7053b77363f2L312-R313) [[3]](diffhunk://#diff-97efe4d6502d241377d37800530dbd33c6fb9cc45c2192436d6a7053b77363f2L341-R342) [[4]](diffhunk://#diff-1105b822c6608c8cde24aaafcd5044e23c20e27fa00b345c20ebf4e19968095cR4) [[5]](diffhunk://#diff-1105b822c6608c8cde24aaafcd5044e23c20e27fa00b345c20ebf4e19968095cL123-R124) [[6]](diffhunk://#diff-1105b822c6608c8cde24aaafcd5044e23c20e27fa00b345c20ebf4e19968095cL345-L346) [[7]](diffhunk://#diff-1105b822c6608c8cde24aaafcd5044e23c20e27fa00b345c20ebf4e19968095cL367-R366) [[8]](diffhunk://#diff-ebcd0400a4f966f67b1a722c59a40887341ae655fdd9df75b16229be30039669L607-R607)


**Supporting Types and Imports:**

* Introduced the `BulkIndexEntry` struct in `postings.rs` to represent buffered series during bulk index builds, and adjusted imports for supporting modules. [[1]](diffhunk://#diff-d796c4c9310749f510a1fc6a9a040afea078b1d3b2d3d3bbe0a8210918044638L10-R11) [[2]](diffhunk://#diff-d796c4c9310749f510a1fc6a9a040afea078b1d3b2d3d3bbe0a8210918044638R31-R38)

These changes collectively improve load performance for large datasets, make index rebuilds more robust and configurable, and improve code safety and maintainability.