### PR TITLE
[PERFORMANCE] Clustermap changes to minimize unnecessary updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.92.0
+          components: rustfmt, clippy
 
       - name: Install protobuf compiler
         run: |
@@ -87,6 +88,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.92.0
+          components: rustfmt, clippy
 
       - name: Install protobuf compiler
         run: brew install protobuf
@@ -115,6 +117,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.92.0
+          components: rustfmt, clippy
 
       - name: Install protobuf compiler
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+
       - name: Install protobuf compiler
         run: |
           sudo apt-get update
@@ -78,6 +83,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+
       - name: Install protobuf compiler
         run: brew install protobuf
 
@@ -100,6 +110,11 @@ jobs:
         server_version: ["unstable", "8.1"]
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
 
       - name: Install protobuf compiler
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = "1.0.4"
 croaring = "2.6"
 enquote = "1.1.0"
 enum_dispatch = "0.3.13"
-get-size2 = { version = "0.10.1", features = ["derive"] }
+get-size2 = { version = "0.10.2", features = ["derive"] }
 hashify = { version = "0.2" }
 itertools = "0.14"
 linkme = "0.3"
@@ -38,7 +38,7 @@ thiserror = "2.0"
 topo_sort = "0.4.0"
 valkey-module = "0.1.11"
 valkey-module-macros = "0.1.11"
-range-set-blaze = "0.6.0"
+range-set-blaze = "0.6.1"
 rayon-core = "1.13"
 regex = "1"
 strum = { version = "0.28", features = ["derive"] }

--- a/src/fanout/cluster_map.rs
+++ b/src/fanout/cluster_map.rs
@@ -12,6 +12,7 @@ use std::fmt::{Display, Formatter};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::net::{IpAddr, Ipv4Addr};
 use std::ops::Deref;
+use std::sync::atomic::{AtomicI64, Ordering as AtomicOrdering};
 use std::sync::{Arc, LazyLock, OnceLock};
 use valkey_module::logging::{log_notice, log_warning};
 use valkey_module::{
@@ -528,8 +529,10 @@ pub struct ClusterMap {
     primary_targets: LazyTargets,
     replica_targets: LazyTargets,
     all_targets: LazyTargets,
-    /// expiration timestamp in ms (since epoch)
-    expiration_ts: i64,
+    /// Expiration timestamp in ms (since epoch). Atomic so a refresh that
+    /// finds the topology unchanged can extend the published map's lifetime
+    /// in place instead of swapping in an identical copy.
+    expiration_ts: AtomicI64,
     /// is the current map consistent (no collisions/inconsistencies found while building)
     pub is_consistent: bool,
     /// Whether the cluster map covers all slots consecutively
@@ -841,15 +844,33 @@ impl ClusterMap {
         new_map.cluster_slots_fingerprint = new_map.compute_cluster_fingerprint();
 
         // Set expiration time
-        let expiration_ms = CLUSTER_MAP_EXPIRATION_MS.load(std::sync::atomic::Ordering::Relaxed);
-        new_map.expiration_ts = current_time_millis() + expiration_ms as i64;
+        new_map.extend_expiration();
 
         new_map
     }
 
     /// Convenience: is the cluster map expired?
     pub fn is_expired(&self) -> bool {
-        current_time_millis() >= self.expiration_ts
+        current_time_millis() >= self.expiration_ts.load(AtomicOrdering::Relaxed)
+    }
+
+    /// Push the expiration forward from now. Called when a rebuild confirmed
+    /// the topology is unchanged, so the published map can be kept (along with
+    /// its lazily-computed target caches) instead of being replaced.
+    pub fn extend_expiration(&self) {
+        let expiration_ms = CLUSTER_MAP_EXPIRATION_MS.load(AtomicOrdering::Relaxed);
+        self.expiration_ts.store(
+            current_time_millis() + expiration_ms as i64,
+            AtomicOrdering::Relaxed,
+        );
+    }
+
+    /// True when `other` describes the same topology: same shards with the
+    /// same primaries, replicas, addresses, roles, and slot assignments.
+    /// `slot_to_shard_map` and `owned_slots` are derived from the shard set,
+    /// so comparing the shards covers them.
+    pub fn same_topology(&self, other: &ClusterMap) -> bool {
+        self.shards == other.shards
     }
 
     fn check_cluster_map_full(&self) -> bool {
@@ -1226,6 +1247,66 @@ mod tests {
         // No clear role flag.
         let line = format!("{M1} 127.0.0.1:7001@17001 handshake - 0 0 1 connected");
         assert!(parse_node_line(&line, &id(M2)).is_none());
+    }
+
+    #[test]
+    fn test_same_topology_independent_of_line_order() {
+        let a = ClusterMap::from_cluster_nodes(&three_shard_nodes(), &id(M1));
+        let shuffled = format!(
+            "\
+{R3} 127.0.0.1:7103@17103 slave {M3} 0 0 3 connected\n\
+{M2} 127.0.0.1:7002@17002 master - 0 0 2 connected 5461-10922\n\
+{R1} 127.0.0.1:7101@17101 slave {M1} 0 0 1 connected\n\
+{M3} 127.0.0.1:7003@17003 master - 0 0 3 connected 10923-16383\n\
+{R2} 127.0.0.1:7102@17102 slave {M2} 0 0 2 connected\n\
+{M1} 127.0.0.1:7001@17001 myself,master - 0 0 1 connected 0-5460\n"
+        );
+        let b = ClusterMap::from_cluster_nodes(&shuffled, &id(M1));
+        assert!(a.same_topology(&b));
+        assert!(b.same_topology(&a));
+    }
+
+    #[test]
+    fn test_same_topology_detects_replica_change() {
+        // Removing a replica keeps the slot fingerprint identical but must
+        // still be seen as a topology change.
+        let a = ClusterMap::from_cluster_nodes(&three_shard_nodes(), &id(M1));
+        let without_r3 = format!(
+            "\
+{M1} 127.0.0.1:7001@17001 myself,master - 0 0 1 connected 0-5460\n\
+{R1} 127.0.0.1:7101@17101 slave {M1} 0 0 1 connected\n\
+{M2} 127.0.0.1:7002@17002 master - 0 0 2 connected 5461-10922\n\
+{R2} 127.0.0.1:7102@17102 slave {M2} 0 0 2 connected\n\
+{M3} 127.0.0.1:7003@17003 master - 0 0 3 connected 10923-16383\n"
+        );
+        let b = ClusterMap::from_cluster_nodes(&without_r3, &id(M1));
+        assert_eq!(a.cluster_slots_fingerprint(), b.cluster_slots_fingerprint());
+        assert!(!a.same_topology(&b));
+    }
+
+    #[test]
+    fn test_same_topology_detects_slot_move() {
+        let a = ClusterMap::from_cluster_nodes(&three_shard_nodes(), &id(M1));
+        let moved = format!(
+            "\
+{M1} 127.0.0.1:7001@17001 myself,master - 0 0 1 connected 0-5460\n\
+{R1} 127.0.0.1:7101@17101 slave {M1} 0 0 1 connected\n\
+{M2} 127.0.0.1:7002@17002 master - 0 0 2 connected 5461-10922 12000\n\
+{R2} 127.0.0.1:7102@17102 slave {M2} 0 0 2 connected\n\
+{M3} 127.0.0.1:7003@17003 master - 0 0 3 connected 10923-11999 12001-16383\n\
+{R3} 127.0.0.1:7103@17103 slave {M3} 0 0 3 connected\n"
+        );
+        let b = ClusterMap::from_cluster_nodes(&moved, &id(M1));
+        assert!(!a.same_topology(&b));
+    }
+
+    #[test]
+    fn test_extend_expiration_unexpires_map() {
+        let map = ClusterMap::from_cluster_nodes(&three_shard_nodes(), &id(M1));
+        map.expiration_ts.store(0, AtomicOrdering::Relaxed);
+        assert!(map.is_expired());
+        map.extend_expiration();
+        assert!(!map.is_expired());
     }
 
     #[test]

--- a/src/fanout/cluster_map.rs
+++ b/src/fanout/cluster_map.rs
@@ -846,7 +846,7 @@ impl ClusterMap {
         new_map.cluster_slots_fingerprint = new_map.compute_cluster_fingerprint();
 
         // Set expiration time
-        new_map.extend_expiration();
+        new_map.extend_expiration(CLUSTER_MAP_EXPIRATION_MS.load(AtomicOrdering::Relaxed));
 
         new_map
     }
@@ -856,13 +856,14 @@ impl ClusterMap {
         current_time_millis() >= self.expiration_ts.load(AtomicOrdering::Relaxed)
     }
 
-    /// Push the expiration forward from now. Called when a rebuild confirmed
-    /// the topology is unchanged, so the published map can be kept (along with
-    /// its lazily-computed target caches) instead of being replaced.
-    pub fn extend_expiration(&self) {
-        let expiration_ms = CLUSTER_MAP_EXPIRATION_MS.load(AtomicOrdering::Relaxed);
+    /// Push the expiration `ttl_ms` forward from now. Called when a rebuild
+    /// confirmed the topology is unchanged, so the published map can be kept
+    /// (along with its lazily-computed target caches) instead of being
+    /// replaced. The caller chooses the TTL: the configured expiration for a
+    /// freshly built map, or the adaptive backoff interval when extending.
+    pub fn extend_expiration(&self, ttl_ms: u64) {
         self.expiration_ts.store(
-            current_time_millis() + expiration_ms as i64,
+            current_time_millis() + ttl_ms as i64,
             AtomicOrdering::Relaxed,
         );
     }
@@ -1317,7 +1318,7 @@ mod tests {
         let map = ClusterMap::from_cluster_nodes(&three_shard_nodes(), &id(M1));
         map.expiration_ts.store(0, AtomicOrdering::Relaxed);
         assert!(map.is_expired());
-        map.extend_expiration();
+        map.extend_expiration(750);
         assert!(!map.is_expired());
     }
 

--- a/src/fanout/cluster_map.rs
+++ b/src/fanout/cluster_map.rs
@@ -4,6 +4,7 @@ use crate::fanout::calculate_hash_slot;
 use ahash::{AHashMap, HashSet, HashSetExt};
 use rand::{Rng, RngExt, rng};
 use range_set_blaze::{RangeMapBlaze, RangeSetBlaze, RangesIter};
+use smallvec::SmallVec;
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::BTreeSet;
@@ -699,8 +700,9 @@ impl ClusterMap {
         };
 
         // Parse every line first so masters and replicas can be assembled in
-        // two passes regardless of the order they appear.
-        let mut records: Vec<ParsedNodeLine> = Vec::new();
+        // two passes regardless of the order they appear. One record per line,
+        // so sizing from the line count avoids growth reallocations.
+        let mut records: Vec<ParsedNodeLine> = Vec::with_capacity(text.lines().count());
         for line in text.lines() {
             let line = line.trim();
             if line.is_empty() {
@@ -935,6 +937,11 @@ fn reply_as_string(call_reply: CallResult) -> Option<String> {
     }
 }
 
+/// Inline-capacity buffer for a master's slot ranges: a settled cluster has
+/// one contiguous range per shard, so four covers all but heavily fragmented
+/// topologies without a heap allocation per line.
+type SlotRangeBuf = SmallVec<[(u16, u16); 4]>;
+
 /// A single parsed line of `CLUSTER NODES` output.
 struct ParsedNodeLine {
     id: NodeId,
@@ -946,7 +953,7 @@ struct ParsedNodeLine {
     has_master: bool,
     master_id: NodeId,
     /// Owned slot ranges (masters only); import/export markers are excluded.
-    slot_ranges: Vec<(u16, u16)>,
+    slot_ranges: SlotRangeBuf,
 }
 
 impl ParsedNodeLine {
@@ -965,12 +972,18 @@ impl ParsedNodeLine {
 /// Returns `None` when the line is too malformed to trust (too few fields,
 /// unparseable node id, or no single clear role).
 fn parse_node_line(line: &str, my_node_id: &NodeId) -> Option<ParsedNodeLine> {
-    let fields: Vec<&str> = line.split_ascii_whitespace().collect();
-    if fields.len() < 8 {
-        return None;
-    }
+    // Walk the fields without collecting them: only the first four and the
+    // trailing slot specs carry information.
+    let mut fields = line.split_ascii_whitespace();
+    let id_field = fields.next()?;
+    let addr_field = fields.next()?;
+    let flags_field = fields.next()?;
+    let master_field = fields.next()?;
+    // Skip ping-sent/pong-recv/config-epoch and require link-state, so a line
+    // with fewer than 8 fields is rejected just as the indexed form did.
+    let mut fields = fields.skip(3);
+    fields.next()?;
 
-    let id_field = fields[0];
     if id_field.len() != VALKEYMODULE_NODE_ID_LEN as usize {
         return None;
     }
@@ -980,7 +993,7 @@ fn parse_node_line(line: &str, my_node_id: &NodeId) -> Option<ParsedNodeLine> {
     let mut is_replica = false;
     let mut is_myself = false;
     let mut noaddr = false;
-    for flag in fields[2].split(',') {
+    for flag in flags_field.split(',') {
         match flag {
             "master" => is_master = true,
             "slave" | "replica" => is_replica = true,
@@ -995,9 +1008,8 @@ fn parse_node_line(line: &str, my_node_id: &NodeId) -> Option<ParsedNodeLine> {
     }
     let is_local = is_myself || &id == my_node_id;
 
-    let socket_address = parse_node_address(fields[1], noaddr, is_local);
+    let socket_address = parse_node_address(addr_field, noaddr, is_local);
 
-    let master_field = fields[3];
     let has_master = is_replica && master_field.len() == VALKEYMODULE_NODE_ID_LEN as usize;
     let master_id = if has_master {
         NodeId::from_bytes(master_field.as_bytes())
@@ -1005,9 +1017,9 @@ fn parse_node_line(line: &str, my_node_id: &NodeId) -> Option<ParsedNodeLine> {
         NodeId::default()
     };
 
-    let mut slot_ranges = Vec::new();
+    let mut slot_ranges = SlotRangeBuf::new();
     if is_master {
-        for spec in &fields[8..] {
+        for spec in fields {
             // Skip importing/migrating markers like "[12000-<-<id>]".
             if spec.starts_with('[') {
                 continue;

--- a/src/fanout/cluster_migrations.rs
+++ b/src/fanout/cluster_migrations.rs
@@ -1,6 +1,7 @@
 use crate::common::sync::{read_lock, write_lock};
 use crate::fanout::cluster_map::NUM_SLOTS;
 use crate::fanout::is_clustered;
+use crate::fanout::mark_cluster_map_stale;
 use range_set_blaze::RangeSetBlaze;
 use std::ffi::{c_char, c_int, c_void};
 use std::sync::{LazyLock, RwLock};
@@ -319,15 +320,19 @@ unsafe extern "C" fn on_atomic_slot_migration_event(
 
     match sub_event {
         VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_STARTED => {
+            mark_cluster_map_stale();
             raise_event(AtomicSlotMigrationEvent::ImportStarted, data);
         }
         VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_COMPLETED => {
+            mark_cluster_map_stale();
             raise_event(AtomicSlotMigrationEvent::ImportCompleted, data);
         }
         VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_IMPORT_ABORTED => {
+            mark_cluster_map_stale();
             raise_event(AtomicSlotMigrationEvent::ImportAborted, data);
         }
         VALKEYMODULE_SUBEVENT_ATOMIC_SLOT_MIGRATION_EXPORT_COMPLETED => {
+            mark_cluster_map_stale();
             raise_event(AtomicSlotMigrationEvent::ExportCompleted, data);
         }
         _ => {}

--- a/src/fanout/mod.rs
+++ b/src/fanout/mod.rs
@@ -93,14 +93,27 @@ pub fn get_fanout_targets(ctx: &Context, mode: FanoutTargetMode) -> FanoutTarget
 }
 
 // Refresh the cluster map by creating a new one from the current cluster state.
-// If building the new map fails, the previous map is kept in place and a
-// warning is logged so subsequent calls will retry the refresh.
+// When the rebuild shows the topology is unchanged, the published map is kept
+// and its expiration extended instead of swapping in an identical copy: this
+// preserves the lazily-computed target caches and the allocations shared by
+// in-flight readers. If building the new map fails, the previous map is kept
+// in place and a warning is logged so subsequent calls will retry the refresh.
 pub fn refresh_cluster_map(ctx: &Context) {
     ctx.log_notice("Refreshing cluster map...");
     match ClusterMap::create(ctx) {
         Some(new_map) => {
-            update_cluster_map(new_map);
-            ctx.log_notice("Cluster map refreshed");
+            let current_map = CLUSTER_MAP.load();
+            if new_map.is_consistent
+                && current_map.is_consistent
+                && new_map.same_topology(&current_map)
+            {
+                current_map.extend_expiration();
+                ctx.log_notice("Cluster map unchanged; extended expiration");
+            } else {
+                drop(current_map);
+                update_cluster_map(new_map);
+                ctx.log_notice("Cluster map refreshed");
+            }
         }
         None => {
             ctx.log_warning(

--- a/src/fanout/mod.rs
+++ b/src/fanout/mod.rs
@@ -11,9 +11,10 @@ mod registry;
 pub mod serialization;
 mod utils;
 
+use crate::config::CLUSTER_MAP_EXPIRATION_MS;
 use ahash::HashSet;
 use arc_swap::{ArcSwap, Guard};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock};
 use valkey_module::Context;
 
@@ -41,6 +42,40 @@ static CLUSTER_MAP: LazyLock<ArcSwap<ClusterMap>> =
 /// The next target-selection or map access treats the local map as needing a
 /// refresh, so the following fanout is built from up-to-date topology.
 static CLUSTER_MAP_STALE: AtomicBool = AtomicBool::new(false);
+
+/// Upper bound on the adaptive refresh interval. Replica membership changes
+/// alter neither the slot fingerprint (so no peer ever rejects with a
+/// mismatch) nor, on remote nodes, any local event: the periodic refresh is
+/// the only mechanism that detects them, so the backoff must stay bounded.
+const CLUSTER_MAP_BACKOFF_CAP_MS: u64 = 5_000;
+
+/// Current adaptive refresh interval in ms. Starts at (and resets to) the
+/// configured expiration, and doubles up to [`CLUSTER_MAP_BACKOFF_CAP_MS`]
+/// each time a refresh confirms the topology is unchanged, so a stable
+/// cluster converges to one `CLUSTER NODES` call per cap interval while
+/// topology churn is re-checked at the configured floor.
+static CLUSTER_MAP_REFRESH_INTERVAL_MS: AtomicU64 = AtomicU64::new(0);
+
+/// Double the adaptive refresh interval and return the new value, clamped to
+/// [configured floor, cap]. Called when a refresh confirmed the topology
+/// unchanged. A floor configured above the cap wins: the operator asked for a
+/// longer expiration than the backoff would ever produce.
+fn grow_refresh_interval() -> u64 {
+    let floor = CLUSTER_MAP_EXPIRATION_MS.load(Ordering::Relaxed);
+    let cap = CLUSTER_MAP_BACKOFF_CAP_MS.max(floor);
+    let current = CLUSTER_MAP_REFRESH_INTERVAL_MS.load(Ordering::Relaxed);
+    let next = current.saturating_mul(2).clamp(floor, cap);
+    CLUSTER_MAP_REFRESH_INTERVAL_MS.store(next, Ordering::Relaxed);
+    next
+}
+
+/// Reset the adaptive refresh interval to the configured floor. Called when
+/// the topology changed or a rebuild failed, so the next quiet period starts
+/// backing off from scratch.
+fn reset_refresh_interval() {
+    let floor = CLUSTER_MAP_EXPIRATION_MS.load(Ordering::Relaxed);
+    CLUSTER_MAP_REFRESH_INTERVAL_MS.store(floor, Ordering::Relaxed);
+}
 
 /// The set of target nodes for a fanout, together with the cluster-map
 /// fingerprint of the *same* snapshot the targets were chosen from. Keeping them
@@ -107,15 +142,17 @@ pub fn refresh_cluster_map(ctx: &Context) {
                 && current_map.is_consistent
                 && new_map.same_topology(&current_map)
             {
-                current_map.extend_expiration();
+                current_map.extend_expiration(grow_refresh_interval());
                 ctx.log_notice("Cluster map unchanged; extended expiration");
             } else {
                 drop(current_map);
+                reset_refresh_interval();
                 update_cluster_map(new_map);
                 ctx.log_notice("Cluster map refreshed");
             }
         }
         None => {
+            reset_refresh_interval();
             ctx.log_warning(
                 "Failed to build cluster map; keeping the previous map and retrying later",
             );
@@ -137,4 +174,45 @@ pub fn get_or_refresh_cluster_map(ctx: &Context) -> Arc<ClusterMap> {
     }
 
     current_map.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole grow/reset lifecycle in one test: the interval is a
+    /// process-wide static, so splitting this across tests would race under
+    /// the parallel test runner.
+    #[test]
+    fn test_adaptive_refresh_interval_backoff() {
+        let floor = CLUSTER_MAP_EXPIRATION_MS.load(Ordering::Relaxed);
+        assert!(floor > 0 && floor * 2 < CLUSTER_MAP_BACKOFF_CAP_MS);
+
+        // Cold start: the static begins at 0, so the first grow lands on the floor.
+        CLUSTER_MAP_REFRESH_INTERVAL_MS.store(0, Ordering::Relaxed);
+        assert_eq!(grow_refresh_interval(), floor);
+
+        // Doubles per unchanged refresh, then saturates at the cap.
+        assert_eq!(grow_refresh_interval(), floor * 2);
+        assert_eq!(grow_refresh_interval(), floor * 4);
+        let mut prev = floor * 4;
+        loop {
+            let next = grow_refresh_interval();
+            assert!(next <= CLUSTER_MAP_BACKOFF_CAP_MS);
+            if next == prev {
+                break;
+            }
+            assert!(next > prev);
+            prev = next;
+        }
+        assert_eq!(prev, CLUSTER_MAP_BACKOFF_CAP_MS);
+
+        // A topology change or build failure resets to the floor.
+        reset_refresh_interval();
+        assert_eq!(
+            CLUSTER_MAP_REFRESH_INTERVAL_MS.load(Ordering::Relaxed),
+            floor
+        );
+        assert_eq!(grow_refresh_interval(), floor * 2);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ mod tests;
 
 use crate::series::background_tasks::init_background_tasks;
 use crate::series::index::init_croaring_allocator;
+use crate::series::index::persistence::check_required_module_apis;
 use crate::series::index::server_events::{
     generic_key_events_handler, register_server_event_handlers,
 };
@@ -92,6 +93,13 @@ fn preload(ctx: &Context, args: &[ValkeyString]) -> Status {
             )
                 .as_str(),
         );
+        return Status::Err;
+    }
+
+    if let Err(symbol) = check_required_module_apis() {
+        ctx.log_warning(&format!(
+            "Required module API {symbol} is unavailable on this server; refusing to load"
+        ));
         return Status::Err;
     }
 

--- a/src/series/index/persistence.rs
+++ b/src/series/index/persistence.rs
@@ -17,7 +17,7 @@ use crate::common::context::{get_current_db, set_current_db};
 use crate::common::encoding::{
     try_read_byte_slice, try_read_u8, try_read_uvarint, write_byte_slice, write_u8, write_uvarint,
 };
-use crate::common::hash::BuildNoHashHasher;
+use crate::common::hash::{BuildNoHashHasher, DeterministicHasher};
 use crate::common::logging::{log_debug, log_notice, log_warning};
 use crate::common::sync::{read_lock, write_lock};
 use crate::config::is_index_persist_enabled;
@@ -52,11 +52,57 @@ static PRELOADED_DBS: LazyLock<papaya::HashSet<i32, BuildNoHashHasher<i32>>> =
 /// `RESTORE`/`TS._RESTORE` traffic.
 static LOADING_ACTIVE: AtomicBool = AtomicBool::new(false);
 
-/// Per-db count of series that came through `rdb_load` during the current load window.
-/// Compared against the post-sweep index cardinality to detect keyspace-index drift.
+/// Per-db summary of the series that came through `rdb_load` during the current load window.
+/// Compared against the same summary computed over the preloaded index, both to gate the
+/// reconciliation sweep and to detect drift after it (see [`reconcile_preloaded_indexes`]).
 /// Lock-free: `note_series_loaded` is called once per series deserialized from the RDB stream.
-static LOADED_SERIES_COUNTS: LazyLock<papaya::HashMap<i32, u64, BuildNoHashHasher<i32>>> =
+static LOADED_SERIES_STATS: LazyLock<papaya::HashMap<i32, LoadStats, BuildNoHashHasher<i32>>> =
     LazyLock::new(papaya::HashMap::default);
+
+/// What the loader observed for one db, in a form comparable against `id_to_key` without
+/// touching the keyspace.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct LoadStats {
+    /// Number of series deserialized for this db.
+    count: u64,
+    /// Order-independent sum of per-entry `(id, key_name)` hashes. Detects the drift that
+    /// `count` alone cannot: an id whose key loaded under a *different name* leaves both
+    /// counts equal but changes the digest.
+    digest: u64,
+    /// Set when any series' key name could not be read, which makes `digest` meaningless.
+    /// Forces the sweep rather than trusting a partial digest.
+    incomplete: bool,
+}
+
+impl LoadStats {
+    fn observe(&self, entry_hash: Option<u64>) -> Self {
+        Self {
+            count: self.count + 1,
+            // Wrapping add rather than XOR: ids are unique within a db, but if a stream ever
+            // did repeat one, XOR would silently cancel the pair out of the digest.
+            digest: self.digest.wrapping_add(entry_hash.unwrap_or(0)),
+            incomplete: self.incomplete || entry_hash.is_none(),
+        }
+    }
+}
+
+/// Shared so the per-series load path does not rebuild the seed state on every call.
+static DIGEST_HASHER: LazyLock<DeterministicHasher> = LazyLock::new(DeterministicHasher::new);
+
+/// Per-entry digest contribution. Fixed-seed so both sides of the comparison agree; the digest
+/// never leaves the process (it is not persisted), so only intra-run consistency is required.
+///
+/// Not collision-resistant against a chosen-input adversary, and deliberately so: the threat
+/// model here is corruption and bugs, not forgery. Engineering a collision would require
+/// controlling key names *and* corrupting the RDB, and would buy only a skipped sweep — an
+/// index entry that stays stale until the query path's self-heal reaches it.
+fn entry_hash(id: SeriesRef, key_name: &[u8]) -> u64 {
+    use std::hash::{BuildHasher, Hasher};
+    let mut hasher = DIGEST_HASHER.build_hasher();
+    hasher.write_u64(id);
+    hasher.write(key_name);
+    hasher.finish()
+}
 
 const RECONCILE_BATCH_SIZE: usize = 256;
 
@@ -318,7 +364,7 @@ pub(crate) fn load_index_from_rdb(rdb: *mut RedisModuleIO) -> c_int {
 /// Loading `RdbStarted`/`AofStarted`/`ReplStarted`: open the load window and reset per-load state.
 pub(crate) fn on_loading_started() {
     LOADING_ACTIVE.store(true, Ordering::SeqCst);
-    LOADED_SERIES_COUNTS.pin().clear();
+    LOADED_SERIES_STATS.pin().clear();
     // Defensive: any leftover preload state from an earlier load cycle is stale by now.
     PRELOADED_DBS.pin().clear();
 }
@@ -333,7 +379,7 @@ pub(crate) fn on_loading_ended() {
 /// [`discard_preloaded_indexes`]).
 pub(crate) fn on_loading_failed() {
     LOADING_ACTIVE.store(false, Ordering::SeqCst);
-    LOADED_SERIES_COUNTS.pin().clear();
+    LOADED_SERIES_STATS.pin().clear();
     discard_preloaded_indexes();
 }
 
@@ -351,40 +397,82 @@ pub(crate) fn should_skip_load_indexing(db: i32) -> bool {
     is_loading_active() && PRELOADED_DBS.pin().contains(&db)
 }
 
+/// Verifies the module APIs this file depends on are present, at load time rather than at
+/// first use. `GetDbIdFromIO` is available on every server version the module supports (see
+/// `TIMESERIES_MIN_SUPPORTED_VERSION`), and the load-reconciliation logic treats its output as
+/// authoritative: `LOADED_SERIES_STATS` gates whether the post-load sweep runs at all, so a
+/// silently absent symbol would mean permanently under-counted loads and a keyspace scan after
+/// every RDB load. Refusing to load beats degrading quietly.
+pub(crate) fn check_required_module_apis() -> Result<(), &'static str> {
+    if unsafe { raw::RedisModule_GetDbIdFromIO }.is_none() {
+        return Err("RedisModule_GetDbIdFromIO");
+    }
+    if unsafe { raw::RedisModule_GetKeyNameFromIO }.is_none() {
+        return Err("RedisModule_GetKeyNameFromIO");
+    }
+    Ok(())
+}
+
+/// Digest contribution for the series currently being deserialized, from the key name the
+/// engine is loading it under. `None` when the name is unavailable, which degrades that db's
+/// digest to `incomplete` and forces the sweep rather than producing a wrong match.
+fn loaded_entry_hash(rdb: *mut RedisModuleIO, id: SeriesRef) -> Option<u64> {
+    // Presence is a load-time invariant (`check_required_module_apis`).
+    let get_key_name = unsafe { raw::RedisModule_GetKeyNameFromIO }
+        .expect("RedisModule_GetKeyNameFromIO unavailable");
+    let key = unsafe { get_key_name(rdb) };
+    if key.is_null() {
+        return None;
+    }
+    let mut len: usize = 0;
+    let ptr = raw::string_ptr_len(key, &mut len);
+    if ptr.is_null() {
+        return None;
+    }
+    // Borrowed for the duration of this call only: the engine owns the string, and we neither
+    // retain nor free it.
+    let name = unsafe { std::slice::from_raw_parts(ptr as *const u8, len) };
+    Some(entry_hash(id, name))
+}
+
 /// Called from `rdb_load_series` for every series deserialized from an RDB stream: assigns
 /// `series._db` from the IO context (previously done by the `loaded` notification handler,
 /// which required opening the key), and counts the series toward the current load window's
 /// per-db total. Payloads with no db context (`RESTORE` / `TS._RESTORE` strings) are skipped;
 /// their callers assign `_db` themselves.
 pub(crate) fn observe_series_rdb_load(rdb: *mut RedisModuleIO, series: &mut TimeSeries) {
-    // `GetDbIdFromIO` may be absent on older servers; fall back to the notification path.
-    let Some(get_db_id) = (unsafe { raw::RedisModule_GetDbIdFromIO }) else {
-        return;
-    };
+    // Presence is a load-time invariant (`check_required_module_apis`).
+    let get_db_id =
+        unsafe { raw::RedisModule_GetDbIdFromIO }.expect("RedisModule_GetDbIdFromIO unavailable");
+    // A negative db means there is no IO context to read it from: a `RESTORE`/`TS._RESTORE`
+    // payload rather than an RDB stream. Not an error — those callers assign `_db` themselves.
     let db = unsafe { get_db_id(rdb) };
     if db < 0 {
         return;
     }
     series._db = Some(db);
     if LOADING_ACTIVE.load(Ordering::Relaxed) {
-        note_series_loaded(db);
+        note_series_loaded(db, loaded_entry_hash(rdb, series.id));
     }
 }
 
-fn note_series_loaded(db: i32) {
-    LOADED_SERIES_COUNTS
-        .pin()
-        .update_or_insert(db, |count| count + 1, 1);
+fn note_series_loaded(db: i32, entry_hash: Option<u64>) {
+    let stats = LOADED_SERIES_STATS.pin();
+    stats.update_or_insert(
+        db,
+        |current| current.observe(entry_hash),
+        LoadStats::default().observe(entry_hash),
+    );
 }
 
-/// Drains `LOADED_SERIES_COUNTS`: snapshot the per-db counts, then clear. Not atomic with
+/// Drains `LOADED_SERIES_STATS`: snapshot the per-db stats, then clear. Not atomic with
 /// respect to a concurrent `note_series_loaded`, but there is none — this is only called from
 /// the loading-event handler, after the load window (and thus all `rdb_load` traffic) has ended.
-fn take_loaded_counts() -> Vec<(i32, u64)> {
-    let guard = LOADED_SERIES_COUNTS.pin();
-    let counts: Vec<(i32, u64)> = guard.iter().map(|(db, count)| (*db, *count)).collect();
+fn take_loaded_stats() -> Vec<(i32, LoadStats)> {
+    let guard = LOADED_SERIES_STATS.pin();
+    let stats: Vec<(i32, LoadStats)> = guard.iter().map(|(db, st)| (*db, *st)).collect();
     guard.clear();
-    counts
+    stats
 }
 
 /// Drains `PRELOADED_DBS`: snapshot the members, then clear. Not atomic with respect to a
@@ -402,17 +490,35 @@ fn take_preloaded_dbs() -> Vec<i32> {
 // ---------------------------------------------------------------------------
 
 /// Runs after a successful load (`LoadingSubevent::Ended`). A preloaded index can contain
-/// "dangling" ids whose key never made it into the keyspace (e.g. its `rdb_load` was skipped);
-/// nothing in the query path stale-marks those (`TS.CARD` would over-count and no-date-filter
-/// `TS.QUERYINDEX` would emit phantom key names), so sweep them here. The sweep is followed by
-/// a cardinality check against the loaded-series counter (see [`verify_and_repair_db`]) that
-/// catches the reverse direction, since preloaded dbs skip the per-key `has_id` self-heal.
+/// "dangling" ids whose key never made it into the keyspace (e.g. its `rdb_load` was skipped
+/// because its TTL had already elapsed); nothing in the query path stale-marks those, because
+/// a dangling id's `id_to_key` entry is intact — that entry is exactly what was serialized —
+/// so `get_key_by_id` still answers `Some`. The index-only commands (`TS.CARD` and
+/// `TS.QUERYINDEX` without a date filter, the label commands) never open a key and so never
+/// self-heal: they would over-count and emit phantom key names indefinitely. Hence the sweep.
+///
+/// The sweep is gated on a digest comparison rather than run unconditionally. A cardinality
+/// check alone would not be sound: it cannot see *identity* drift, where the payload and the
+/// keyspace disagree about a key's *name* (RDB body corruption, a fork landing mid-write),
+/// leaving an id dangling with both counts equal — the case
+/// `test_dangling_id_triggers_reconciliation_and_repair_scan` constructs. So the loader also
+/// accumulates a per-db digest over each series' `(id, key_name)` as it deserializes them
+/// ([`LoadStats`]), and the same digest is recomputed here over `id_to_key`. Agreement means
+/// the index describes exactly the set of series that loaded, under exactly the names they
+/// loaded under, so there is nothing for the sweep to find.
+///
+/// The digest costs one hash per series on each side and touches no keys, versus one keyspace
+/// probe per series (each under the GIL) for the sweep it replaces on a clean load.
+///
+/// Runtime traffic between load end and the digest can skew either side (a `DEL` unindexes a
+/// key, a `TS.CREATE` adds an id the loader never saw). That costs a spurious sweep, which is
+/// safe and bounded — never a spurious skip, since any such change alters the digest.
 fn reconcile_preloaded_indexes() {
     let dbs: Vec<i32> = take_preloaded_dbs();
     if dbs.is_empty() {
         return;
     }
-    let counts = take_loaded_counts();
+    let stats = take_loaded_stats();
 
     // Off the main thread: the sweep opens every indexed key once. Runs on the module's
     // thread pool (not a detached `std::thread`) so it participates in the same thread
@@ -424,15 +530,61 @@ fn reconcile_preloaded_indexes() {
             if crate::is_shutting_down() {
                 return;
             }
-            reconcile_db(db);
-            let loaded = counts
+            // Absent from the map means zero series arrived for this db, not "unknown":
+            // `observe_series_rdb_load` is called for every series in the stream, and neither
+            // its db nor its key-name lookup can be missing (both checked at load time by
+            // `check_required_module_apis`).
+            let loaded = stats
                 .iter()
                 .find(|(d, _)| *d == db)
-                .map(|(_, n)| *n)
-                .unwrap_or(0);
-            verify_and_repair_db(db, loaded);
+                .map(|(_, st)| *st)
+                .unwrap_or_default();
+
+            let indexed = read_indexed_stats(db);
+            if !loaded.incomplete && indexed == loaded {
+                // Notice rather than debug: this is the once-per-db outcome that says the
+                // sweep was skipped, and it is the only externally visible evidence that the
+                // digest fast path is working.
+                log_notice(format!(
+                    "Postings index for db {db}: {} indexed series match the loaded set by digest; skipping reconciliation sweep",
+                    indexed.count
+                ));
+                continue;
+            }
+
+            log_notice(format!(
+                "Postings index for db {db}: index ({} series) does not match the loaded set ({} series{}); reconciling",
+                indexed.count,
+                loaded.count,
+                if loaded.incomplete {
+                    ", digest unavailable"
+                } else {
+                    ""
+                }
+            ));
+            reconcile_db(db);
+            verify_and_repair_db(db, loaded.count);
         }
     });
+}
+
+/// The index side of the [`LoadStats`] comparison, computed over `id_to_key`. Hashing only —
+/// holds the read lock without touching the keyspace or the GIL. Never `incomplete`: every
+/// entry here has both an id and a name by construction.
+fn read_indexed_stats(db: i32) -> LoadStats {
+    let index = get_db_index(db);
+    let postings = read_lock(&index.inner);
+    let mut stats = LoadStats::default();
+    for (id, key) in postings.id_to_key.iter() {
+        stats = stats.observe(Some(entry_hash(*id, key.as_ref())));
+    }
+    stats
+}
+
+fn read_indexed_count(db: i32) -> u64 {
+    let index = get_db_index(db);
+    let postings = read_lock(&index.inner);
+    postings.count() as u64
 }
 
 /// Post-sweep verification for a preloaded db. `reconcile_db` has just established that every
@@ -446,11 +598,7 @@ fn reconcile_preloaded_indexes() {
 /// makes the scan fire spuriously — `index_series_by_key` is guarded, so the scan is always
 /// safe, just not free.
 fn verify_and_repair_db(db: i32, loaded_count: u64) {
-    let indexed_count = {
-        let index = get_db_index(db);
-        let postings = read_lock(&index.inner);
-        postings.count() as u64
-    };
+    let indexed_count = read_indexed_count(db);
 
     if indexed_count == loaded_count {
         log_debug(format!(
@@ -484,11 +632,7 @@ fn verify_and_repair_db(db: i32, loaded_count: u64) {
         set_current_db(&ctx, save_db);
     }
 
-    let repaired_count = {
-        let index = get_db_index(db);
-        let postings = read_lock(&index.inner);
-        postings.count() as u64
-    };
+    let repaired_count = read_indexed_count(db);
     log_notice(format!(
         "Postings index repair scan for db {db} finished: {indexed_count} -> {repaired_count} indexed series"
     ));
@@ -798,9 +942,9 @@ mod tests {
 
         // Simulate aux preload of DB_A and some rdb_load traffic.
         PRELOADED_DBS.pin().insert(DB_A);
-        note_series_loaded(DB_A);
-        note_series_loaded(DB_A);
-        note_series_loaded(DB_B);
+        note_series_loaded(DB_A, Some(entry_hash(1, b"ts:one")));
+        note_series_loaded(DB_A, Some(entry_hash(2, b"ts:two")));
+        note_series_loaded(DB_B, Some(entry_hash(3, b"ts:three")));
 
         assert!(should_skip_load_indexing(DB_A));
         assert!(
@@ -808,13 +952,17 @@ mod tests {
             "dbs without a preloaded index keep the per-key path"
         );
 
-        let mut counts = take_loaded_counts();
-        counts.sort_unstable();
+        let mut stats = take_loaded_stats();
+        stats.sort_unstable_by_key(|(db, _)| *db);
+        let counts: Vec<(i32, u64)> = stats.iter().map(|(db, st)| (*db, st.count)).collect();
         assert_eq!(counts, vec![(DB_A, 2), (DB_B, 1)]);
-        assert!(
-            take_loaded_counts().is_empty(),
-            "counts are consumed on take"
+        // Digest accumulation is order-independent and matches the index-side computation.
+        assert_eq!(
+            stats[0].1.digest,
+            entry_hash(2, b"ts:two").wrapping_add(entry_hash(1, b"ts:one"))
         );
+        assert!(stats.iter().all(|(_, st)| !st.incomplete));
+        assert!(take_loaded_stats().is_empty(), "stats are consumed on take");
 
         // Failure path: window closes, preloaded state is dropped.
         on_loading_failed();
@@ -825,10 +973,59 @@ mod tests {
         assert!(PRELOADED_DBS.pin().is_empty());
 
         // A new load window starts clean.
-        note_series_loaded(DB_A);
+        note_series_loaded(DB_A, Some(entry_hash(1, b"ts:one")));
         on_loading_started();
-        assert!(take_loaded_counts().is_empty());
+        assert!(take_loaded_stats().is_empty());
         LOADING_ACTIVE.store(false, Ordering::SeqCst);
+    }
+
+    /// The property the digest exists for: a key that loads under a different name than the
+    /// index believes leaves the counts equal, so only the digest can catch it. This is the
+    /// unit-level analogue of `test_dangling_id_triggers_reconciliation_and_repair_scan`.
+    #[test]
+    fn digest_detects_rename_that_count_alone_misses() {
+        let indexed = [(1u64, &b"ts:one"[..]), (2, b"ts:two"), (3, b"ts:three")];
+        // Same ids, same cardinality, one key loaded under a different name.
+        let loaded = [(1u64, &b"ts:one"[..]), (2, b"ts:two"), (3, b"tz:three")];
+
+        let summarize = |entries: &[(u64, &[u8])]| {
+            entries.iter().fold(LoadStats::default(), |st, (id, key)| {
+                st.observe(Some(entry_hash(*id, key)))
+            })
+        };
+
+        let a = summarize(&indexed);
+        let b = summarize(&loaded);
+        assert_eq!(a.count, b.count, "cardinality is blind to the rename");
+        assert_ne!(a.digest, b.digest, "digest must catch the rename");
+        assert_ne!(a, b);
+    }
+
+    /// Digest accumulation must not depend on the order entries are observed in: the loader
+    /// walks the RDB stream, the index side walks `id_to_key` in id order.
+    #[test]
+    fn digest_is_order_independent() {
+        let forward = [(1u64, &b"ts:one"[..]), (2, b"ts:two"), (3, b"ts:three")];
+        let mut reversed = forward;
+        reversed.reverse();
+
+        let summarize = |entries: &[(u64, &[u8])]| {
+            entries.iter().fold(LoadStats::default(), |st, (id, key)| {
+                st.observe(Some(entry_hash(*id, key)))
+            })
+        };
+        assert_eq!(summarize(&forward), summarize(&reversed));
+    }
+
+    /// An unreadable key name must poison the digest rather than silently contributing zero,
+    /// so the gate falls back to the sweep instead of comparing an incomplete digest.
+    #[test]
+    fn missing_key_name_marks_stats_incomplete() {
+        let stats = LoadStats::default()
+            .observe(Some(entry_hash(1, b"ts:one")))
+            .observe(None);
+        assert_eq!(stats.count, 2, "the series still counts");
+        assert!(stats.incomplete);
     }
 
     #[test]

--- a/src/series/index/querier.rs
+++ b/src/series/index/querier.rs
@@ -34,8 +34,14 @@ use crate::series::request_types::MetaDateRangeFilter;
 use crate::series::{SeriesGuard, SeriesRef, TimeSeries, get_timeseries};
 use blart::AsBytes;
 use orx_parallel::{IterIntoParIter, ParIter};
+use smallvec::SmallVec;
 use std::borrow::Cow;
 use valkey_module::{AclPermissions, Context, ValkeyError, ValkeyResult, ValkeyString};
+
+/// Series IDs found to have no backing key during a query, accumulated under the postings
+/// read lock and flushed once the guard is released. Stale IDs are rare, so the inline
+/// capacity keeps the common (empty) case off the heap.
+type StaleIds = SmallVec<[SeriesRef; 8]>;
 
 pub fn series_by_selectors<'a>(
     ctx: &'a Context,
@@ -50,8 +56,17 @@ pub fn series_by_selectors<'a>(
     let index = get_db_index(db);
     let postings = index.get_postings();
 
-    let series_refs = postings.postings_for_selectors(selectors)?;
-    collect_series_from_postings(ctx, &postings, series_refs.iter(), range)
+    let mut stale = StaleIds::new();
+    // Scoped so the read guard (and the bitmap borrowed from it) is released before we
+    // take the write lock to record stale IDs.
+    let result = {
+        let series_refs = postings.postings_for_selectors(selectors)?;
+        collect_series_from_postings(ctx, &postings, series_refs.iter(), range, &mut stale)
+    };
+
+    drop(postings);
+    index.mark_ids_as_stale(&stale);
+    result
 }
 
 #[allow(dead_code)]
@@ -67,17 +82,23 @@ pub(super) fn series_posting_ids_by_selectors<'a>(
     let index = get_db_index(db);
     let postings = index.get_postings();
 
-    let series_ids = postings.postings_for_selectors(selectors)?;
-    if series_ids.is_empty() {
-        return Ok(Cow::Borrowed(&*EMPTY_BITMAP));
-    }
-    if date_range.is_none() {
-        return Ok(Cow::Owned(series_ids.into_owned()));
-    }
-    let series = collect_series_from_postings(ctx, &postings, series_ids.iter(), date_range)?;
-    let id_iter = series.into_iter().map(|(guard, _)| guard.id);
-    let bitmap = PostingsBitmap::from_iter(id_iter);
-    Ok(Cow::Owned(bitmap))
+    let mut stale = StaleIds::new();
+    let result = {
+        let series_ids = postings.postings_for_selectors(selectors)?;
+        if series_ids.is_empty() {
+            return Ok(Cow::Borrowed(&*EMPTY_BITMAP));
+        }
+        if date_range.is_none() {
+            return Ok(Cow::Owned(series_ids.into_owned()));
+        }
+        collect_series_from_postings(ctx, &postings, series_ids.iter(), date_range, &mut stale)
+    };
+
+    drop(postings);
+    index.mark_ids_as_stale(&stale);
+
+    let id_iter = result?.into_iter().map(|(guard, _)| guard.id);
+    Ok(Cow::Owned(PostingsBitmap::from_iter(id_iter)))
 }
 
 pub fn series_keys_by_selectors(
@@ -93,8 +114,15 @@ pub fn series_keys_by_selectors(
     let index = get_db_index(db);
     let postings = index.get_postings();
 
-    let series_refs = postings.postings_for_selectors(selectors)?;
-    collect_series_keys(ctx, &postings, series_refs.iter(), range)
+    let mut stale = StaleIds::new();
+    let result = {
+        let series_refs = postings.postings_for_selectors(selectors)?;
+        collect_series_keys(ctx, &postings, series_refs.iter(), range, &mut stale)
+    };
+
+    drop(postings);
+    index.mark_ids_as_stale(&stale);
+    result
 }
 
 fn collect_series_keys(
@@ -102,34 +130,40 @@ fn collect_series_keys(
     postings: &Postings,
     ids: impl Iterator<Item = SeriesRef>,
     date_range: Option<MetaDateRangeFilter>,
+    stale: &mut StaleIds,
 ) -> ValkeyResult<Vec<ValkeyString>> {
     if let Some(date_range) = date_range {
-        let series = collect_series_from_postings(ctx, postings, ids, Some(date_range))?;
+        let series = collect_series_from_postings(ctx, postings, ids, Some(date_range), stale)?;
         let keys = series.into_iter().map(|g| g.1).collect();
         return Ok(keys);
     }
 
-    // TS.QUERYINDEX is a pure index lookup: it reveals every series matching the
+    // TS.QUERYINDEX is a pure index lookup: it returns every series matching the
     // filter regardless of the caller's per-key read access. Command-level ACL
     // (can the user run TS.QUERYINDEX at all) is already enforced by the server,
     // so we must NOT drop keys the caller lacks read (ACCESS) permission on here.
     let keys = ids
         .filter_map(|id| {
-            let key = postings.get_key_by_id(id)?;
-            Some(ctx.create_string(key.as_bytes()))
+            if let Some(key) = postings.get_key_by_id(id) {
+                Some(ctx.create_string(key.as_bytes()))
+            } else {
+                stale.push(id);
+                None
+            }
         })
         .collect();
 
     Ok(keys)
 }
 
-pub(super) fn collect_series_from_postings<'a>(
+fn collect_series_from_postings<'a>(
     ctx: &'a Context,
     postings: &Postings,
     ids: impl Iterator<Item = SeriesRef>,
     date_range: Option<MetaDateRangeFilter>,
+    stale: &mut StaleIds,
 ) -> ValkeyResult<Vec<(SeriesGuard<'a>, ValkeyString)>> {
-    let result = get_multi_series_by_id(ctx, postings, ids)?;
+    let result = get_multi_series_by_id(ctx, postings, ids, stale)?;
 
     if result.is_empty() {
         return Ok(result);
@@ -147,6 +181,7 @@ fn get_multi_series_by_id<'a>(
     ctx: &'a Context,
     postings: &Postings,
     ids: impl Iterator<Item = SeriesRef>,
+    stale: &mut StaleIds,
 ) -> ValkeyResult<Vec<(SeriesGuard<'a>, ValkeyString)>> {
     let capacity_estimate = ids.size_hint().1.unwrap_or(8);
     let mut result = Vec::with_capacity(capacity_estimate);
@@ -158,6 +193,8 @@ fn get_multi_series_by_id<'a>(
         let perms = Some(AclPermissions::ACCESS);
         if let Some(guard) = get_timeseries(ctx, &k, perms, false)? {
             result.push((guard, k));
+        } else {
+            stale.push(id);
         }
     }
     Ok(result)

--- a/src/series/index/timeseries_index.rs
+++ b/src/series/index/timeseries_index.rs
@@ -515,6 +515,14 @@ impl TimeSeriesIndex {
         inner.mark_id_as_stale(id);
     }
 
+    pub fn mark_ids_as_stale(&self, ids: &[SeriesRef]) {
+        if ids.is_empty() {
+            return;
+        }
+        let mut inner = write_lock(&self.inner);
+        inner.mark_ids_as_stale(ids);
+    }
+
     pub fn remove_stale_ids(&self) -> usize {
         const BATCH_SIZE: usize = 100;
 

--- a/tests/test_ts_index_persistence.py
+++ b/tests/test_ts_index_persistence.py
@@ -19,6 +19,7 @@ PRELOADED_LOG = "Preloaded postings index"
 DISABLED_LOG = "ts-index-persist is disabled; discarding persisted postings index and rebuilding"
 DANGLING_LOG = "dangling ids marked stale"
 REPAIR_LOG = "scanning keyspace to repair"
+SKIP_SWEEP_LOG = "skipping reconciliation sweep"
 
 
 class TestIndexPersistenceBasic(ValkeyTimeSeriesTestCaseBase):
@@ -51,10 +52,11 @@ class TestIndexPersistenceBasic(ValkeyTimeSeriesTestCaseBase):
         assert self.server.is_alive()
         wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
 
-        # "none dangling" / "match the loaded count" are log_debug and not visible at the
-        # harness's default loglevel; absence of a repair-scan (log_warning) is the
-        # externally-observable proxy for "reconciliation found no drift".
         assert self.server.verify_string_in_logfile(PRELOADED_LOG)
+        # On a clean load the per-(id, key_name) digests agree, so the O(N) keyspace-probing
+        # sweep is skipped entirely and nothing needs repairing.
+        assert self.server.verify_string_in_logfile(SKIP_SWEEP_LOG)
+        assert not self.server.verify_string_in_logfile(DANGLING_LOG)
         assert not self.server.verify_string_in_logfile(REPAIR_LOG)
 
         post_card = client.execute_command("TS.CARD", "FILTER", "service=api")
@@ -221,6 +223,9 @@ class TestIndexPersistenceDanglingRepair(ValkeyTimeSeriesTestCaseBase):
         wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
 
         assert self.server.verify_string_in_logfile(PRELOADED_LOG)
+        # The renamed key leaves the cardinalities equal (7 loaded, 7 indexed), so a count-only
+        # check would wave this through; the (id, key_name) digest is what forces the sweep.
+        assert not self.server.verify_string_in_logfile(SKIP_SWEEP_LOG)
         assert self.server.verify_string_in_logfile(DANGLING_LOG)
         assert self.server.verify_string_in_logfile(REPAIR_LOG)
 


### PR DESCRIPTION
This pull request introduces several improvements to cluster map management, parsing efficiency, and system robustness. The main changes include making cluster map expiration adaptive, optimizing cluster node parsing, and ensuring required module APIs are present at load time. Additionally, dependency versions have been updated for better stability.

**Cluster map expiration and refresh improvements:**

* The `expiration_ts` field in `ClusterMap` is now an `AtomicI64`, allowing expiration to be extended in place when the topology is unchanged, avoiding unnecessary swaps and preserving caches (`src/fanout/cluster_map.rs`, `src/fanout/mod.rs`). (F5feb9faL530R530, F5feb9faL846R846, [[1]](diffhunk://#diff-442866b1f3c8ef64d72b0382d127647ce33e4d7d349e162fd2e61ae2e46e5a2fL844-R876) [[2]](diffhunk://#diff-442866b1f3c8ef64d72b0382d127647ce33e4d7d349e162fd2e61ae2e46e5a2fR941-R945) [[3]](diffhunk://#diff-1c0e41a8806c6fc6bd3ded612152b124b6069d0dd6e6c0de5d695a0429863bf1L96-R155)
* An adaptive refresh interval is introduced: when the cluster topology is unchanged, the refresh interval doubles up to a cap, reducing the frequency of cluster state polling in stable clusters (`src/fanout/mod.rs`). [[1]](diffhunk://#diff-1c0e41a8806c6fc6bd3ded612152b124b6069d0dd6e6c0de5d695a0429863bf1R46-R79) [[2]](diffhunk://#diff-1c0e41a8806c6fc6bd3ded612152b124b6069d0dd6e6c0de5d695a0429863bf1L96-R155) [[3]](diffhunk://#diff-1c0e41a8806c6fc6bd3ded612152b124b6069d0dd6e6c0de5d695a0429863bf1R178-R218)

**Cluster node parsing and efficiency:**

* Parsing of `CLUSTER NODES` lines is optimized by using a stack-allocated `SmallVec` for slot ranges and iterating fields directly, reducing heap allocations and improving performance (`src/fanout/cluster_map.rs`). [[1]](diffhunk://#diff-442866b1f3c8ef64d72b0382d127647ce33e4d7d349e162fd2e61ae2e46e5a2fR7) [[2]](diffhunk://#diff-442866b1f3c8ef64d72b0382d127647ce33e4d7d349e162fd2e61ae2e46e5a2fL928-R957) [[3]](diffhunk://#diff-442866b1f3c8ef64d72b0382d127647ce33e4d7d349e162fd2e61ae2e46e5a2fL947-L952) [[4]](diffhunk://#diff-442866b1f3c8ef64d72b0382d127647ce33e4d7d349e162fd2e61ae2e46e5a2fL962-R997) [[5]](diffhunk://#diff-442866b1f3c8ef64d72b0382d127647ce33e4d7d349e162fd2e61ae2e46e5a2fL977-R1023) [[6]](diffhunk://#diff-442866b1f3c8ef64d72b0382d127647ce33e4d7d349e162fd2e61ae2e46e5a2fR941-R945)

**Robustness and correctness:**

* The module now checks for required Valkey module APIs at load time and refuses to load if any are missing, preventing runtime errors due to missing symbols (`src/lib.rs`, `src/series/index/persistence.rs`). [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R39) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R99-R105) [[3]](diffhunk://#diff-965f9e5cbc6ef7abd3c288d323e4e8a1550ed057148a5f364291285f97a839eaL20-R20)
* The cluster map is marked stale on atomic slot migration events to ensure timely refresh after topology changes (`src/fanout/cluster_migrations.rs`). [[1]](diffhunk://#diff-97efe4d6502d241377d37800530dbd33c6fb9cc45c2192436d6a7053b77363f2R4) [[2]](diffhunk://#diff-97efe4d6502d241377d37800530dbd33c6fb9cc45c2192436d6a7053b77363f2R323-R335)

**Dependency updates:**

* Updated `get-size2` to version 0.10.2 and `range-set-blaze` to version 0.6.1 for bug fixes and improvements (`Cargo.toml`). [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L21-R21) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L41-R41)

**Testing:**

* Added and improved tests for adaptive refresh interval logic, topology comparison, and expiration extension to verify new behaviors (`src/fanout/cluster_map.rs`, `src/fanout/mod.rs`). [[1]](diffhunk://#diff-442866b1f3c8ef64d72b0382d127647ce33e4d7d349e162fd2e61ae2e46e5a2fR1265-R1324) [[2]](diffhunk://#diff-1c0e41a8806c6fc6bd3ded612152b124b6069d0dd6e6c0de5d695a0429863bf1R178-R218)

These changes collectively make cluster management more efficient, responsive to topology changes, and robust against missing dependencies.