### PR TITLE
Add command info attributes to each user-facing command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -36,32 +36,15 @@ mod ts_queryindex_fanout_command;
 mod ts_range;
 mod utils;
 
+// Command handlers are registered through the `#[valkey_module_macros::command]` attribute on
+// each `ts_*_cmd` function (see the individual `ts_*` modules), so they no longer need to be
+// re-exported here for the positional command table. Cross-module parser helpers are imported
+// via their defining module path (e.g. `crate::commands::ts_create::parse_series_options`).
+// Only modules whose items are consumed through `crate::commands::*` are re-exported below.
 pub use command_parser::*;
-pub use ts_add::*;
-pub use ts_addbulk::*;
-pub use ts_alter::*;
 pub use ts_asm_restore::*;
-pub use ts_card::*;
-pub use ts_create::*;
-pub use ts_createrule::*;
 pub use ts_debug::*;
-pub use ts_del::*;
-pub use ts_deleterule::*;
-pub use ts_get::*;
-pub use ts_incr_decr_by::*;
-pub use ts_info::*;
-pub use ts_join::*;
-pub use ts_labelnames::*;
-pub use ts_labelstats::*;
-pub use ts_labelvalues::*;
-pub use ts_madd::*;
-pub use ts_mdel::*;
-pub use ts_metricnames::*;
 pub use ts_mget::*;
-pub use ts_mrange::*;
-pub use ts_outliers::*;
-pub use ts_queryindex::*;
-pub use ts_range::*;
 use valkey_module::ValkeyResult;
 
 use crate::fanout::register_fanout_operation;

--- a/src/commands/ts_add.rs
+++ b/src/commands/ts_add.rs
@@ -18,6 +18,19 @@ use valkey_module::{
 ///     [SIGNIFICANT_DIGITS significantDigits | DECIMAL_DIGITS decimalDigits]
 ///     [LABELS label1=value1 label2=value2 ...]
 ///
+#[valkey_module_macros::command({
+    name: "TS.ADD",
+    flags: [Write, DenyOOM],
+    summary: "Append a sample to a time series, creating it if it does not exist.",
+    complexity: "O(1)",
+    since: "1.0.0",
+    arity: -4,
+    key_spec: [{
+        flags: [ReadWrite, Update],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 0, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_add_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     if args.len() < 4 {
         return Err(ValkeyError::WrongArity);

--- a/src/commands/ts_addbulk.rs
+++ b/src/commands/ts_addbulk.rs
@@ -17,6 +17,19 @@ use valkey_module::{AclPermissions, Context, ValkeyResult, ValkeyString, ValkeyV
 ///     [IGNORE ignoreMaxTimediff ignoreMaxValDiff]
 ///     [SIGNIFICANT_DIGITS significantDigits | DECIMAL_DIGITS decimalDigits]
 ///
+#[valkey_module_macros::command({
+    name: "TS.ADDBULK",
+    flags: [Write, DenyOOM],
+    summary: "Append multiple samples supplied as a JSON payload to a time series.",
+    complexity: "O(N) where N is the number of samples in the payload.",
+    since: "1.0.0",
+    arity: -3,
+    key_spec: [{
+        flags: [ReadWrite, Update],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 0, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_addbulk_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     if args.len() < 3 {
         return Err(valkey_module::ValkeyError::WrongArity);

--- a/src/commands/ts_alter.rs
+++ b/src/commands/ts_alter.rs
@@ -16,6 +16,19 @@ use valkey_module::{
 ///   [SIGNIFICANT_DIGITS significantDigits | DECIMAL_DIGITS decimalDigits]
 ///   [IGNORE ignoreMaxTimediff ignoreMaxValDiff]
 ///   [LABELS label1=value1 label2=value2 ...]
+#[valkey_module_macros::command({
+    name: "TS.ALTER",
+    flags: [Write, DenyOOM],
+    summary: "Update the configuration of an existing time series.",
+    complexity: "O(1)",
+    since: "1.0.0",
+    arity: -2,
+    key_spec: [{
+        flags: [ReadWrite, Update],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 0, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_alter_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     if args.len() < 2 {
         return Err(ValkeyError::WrongArity);

--- a/src/commands/ts_card.rs
+++ b/src/commands/ts_card.rs
@@ -8,6 +8,15 @@ use valkey_module::{Context, ValkeyError, ValkeyResult, ValkeyString, ValkeyValu
 /// TS.CARD [FILTER_BY_RANGE fromTimestamp toTimestamp] [FILTER filter...]
 ///
 /// returns the number of unique time series that match a certain label set.
+#[valkey_module_macros::command({
+    name: "TS.CARD",
+    flags: [ReadOnly],
+    summary: "Count the time series matching a filter.",
+    complexity: "O(N) where N is the number of time series that match the filters.",
+    since: "1.0.0",
+    arity: -1,
+    key_spec: []
+})]
 pub fn ts_card_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     let mut args = args.into_iter().skip(1).peekable();
     let options = parse_metadata_command_args(&mut args, false)?;

--- a/src/commands/ts_create.rs
+++ b/src/commands/ts_create.rs
@@ -19,6 +19,19 @@ use valkey_module::{Context, NextArg, VALKEY_OK, ValkeyError, ValkeyResult, Valk
 ///   [SIGNIFICANT_DIGITS significantDigits | DECIMAL_DIGITS decimalDigits]
 ///   [IGNORE ignoreMaxTimediff ignoreMaxValDiff]
 ///   [LABELS label1=value1 label2=value2 ...]
+#[valkey_module_macros::command({
+    name: "TS.CREATE",
+    flags: [Write, DenyOOM],
+    summary: "Create a new time series.",
+    complexity: "O(1)",
+    since: "1.0.0",
+    arity: -2,
+    key_spec: [{
+        flags: [ReadWrite, Insert],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 0, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_create_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     let (parsed_key, options) = parse_create_options(args)?;
 

--- a/src/commands/ts_createrule.rs
+++ b/src/commands/ts_createrule.rs
@@ -18,6 +18,19 @@ use valkey_module::{
 /// Creates a compaction rule from sourceKey to destKey with a specific aggregator and bucket duration.
 /// sourceKey must be different from destKey, and the user must be authorized to read from sourceKey and write to destKey.
 ///
+#[valkey_module_macros::command({
+    name: "TS.CREATERULE",
+    flags: [Write, DenyOOM],
+    summary: "Create a compaction rule from a source time series to a destination series.",
+    complexity: "O(1)",
+    since: "1.0.0",
+    arity: -6,
+    key_spec: [{
+        flags: [ReadWrite, Update],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 1, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_createrule_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     // Check for minimum number of arguments: command, sourceKey, destKey, AGGREGATION, aggregator, bucketDuration
     if args.len() < 6 {

--- a/src/commands/ts_del.rs
+++ b/src/commands/ts_del.rs
@@ -8,6 +8,19 @@ use valkey_module::{
 ///
 /// TS.DEL key fromTimestamp toTimestamp
 ///
+#[valkey_module_macros::command({
+    name: "TS.DEL",
+    flags: [Write, DenyOOM],
+    summary: "Delete samples of a time series within a timestamp range.",
+    complexity: "O(N) where N is the number of samples removed.",
+    since: "1.0.0",
+    arity: -3,
+    key_spec: [{
+        flags: [ReadWrite, Delete],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 0, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_del_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     let mut args = args.into_iter().skip(1).peekable();
     let key = args.next_arg()?;

--- a/src/commands/ts_deleterule.rs
+++ b/src/commands/ts_deleterule.rs
@@ -12,6 +12,19 @@ use valkey_module::{
 /// The rule is removed from the sourceKey, and the src_series field in destKey is cleared, but
 /// the destination series is not deleted.
 ///
+#[valkey_module_macros::command({
+    name: "TS.DELETERULE",
+    flags: [Write, DenyOOM],
+    summary: "Delete a compaction rule between a source and destination time series.",
+    complexity: "O(1)",
+    since: "1.0.0",
+    arity: 3,
+    key_spec: [{
+        flags: [ReadWrite, Update],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 1, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_deleterule_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     // Check for minimum number of arguments: command, sourceKey, destKey
     if args.len() != 3 {

--- a/src/commands/ts_get.rs
+++ b/src/commands/ts_get.rs
@@ -3,6 +3,19 @@ use valkey_module::ValkeyError::WrongArity;
 use valkey_module::{Context, ValkeyError, ValkeyResult, ValkeyString, ValkeyValue};
 
 /// TS.GET key [LATEST]
+#[valkey_module_macros::command({
+    name: "TS.GET",
+    flags: [ReadOnly, Fast],
+    summary: "Get the last sample of a time series.",
+    complexity: "O(1)",
+    since: "1.0.0",
+    arity: -2,
+    key_spec: [{
+        flags: [ReadOnly, Access],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 0, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_get_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     if args.len() < 2 || args.len() > 3 {
         return Err(WrongArity);

--- a/src/commands/ts_incr_decr_by.rs
+++ b/src/commands/ts_incr_decr_by.rs
@@ -8,10 +8,36 @@ use valkey_module::{
     AclPermissions, Context, NotifyEvent, ValkeyError, ValkeyResult, ValkeyString, ValkeyValue,
 };
 
+#[valkey_module_macros::command({
+    name: "TS.INCRBY",
+    flags: [Write, DenyOOM],
+    summary: "Increase the value of the last sample, creating the series if needed.",
+    complexity: "O(1)",
+    since: "1.0.0",
+    arity: -3,
+    key_spec: [{
+        flags: [ReadWrite, Update],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 0, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_incrby_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     incr_decr(ctx, args, true)
 }
 
+#[valkey_module_macros::command({
+    name: "TS.DECRBY",
+    flags: [Write, DenyOOM],
+    summary: "Decrease the value of the last sample, creating the series if needed.",
+    complexity: "O(1)",
+    since: "1.0.0",
+    arity: -3,
+    key_spec: [{
+        flags: [ReadWrite, Update],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 0, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_decrby_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     incr_decr(ctx, args, false)
 }

--- a/src/commands/ts_info.rs
+++ b/src/commands/ts_info.rs
@@ -12,6 +12,19 @@ use std::collections::HashMap;
 use valkey_module::redisvalue::ValkeyValueKey;
 use valkey_module::{AclPermissions, Context, NextArg, ValkeyResult, ValkeyString, ValkeyValue};
 
+#[valkey_module_macros::command({
+    name: "TS.INFO",
+    flags: [ReadOnly],
+    summary: "Return information and statistics for a time series.",
+    complexity: "O(1)",
+    since: "1.0.0",
+    arity: -2,
+    key_spec: [{
+        flags: [ReadOnly, Access],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 0, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_info_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     let mut args = args.into_iter().skip(1);
     let key = args.next_arg()?;

--- a/src/commands/ts_join.rs
+++ b/src/commands/ts_join.rs
@@ -15,6 +15,19 @@ use valkey_module::{
 ///   [COUNT count]
 ///   [REDUCE op]
 ///   [AGGREGATION aggregator bucket_duration [ALIGN align] [BUCKETTIMESTAMP timestamp] [EMPTY]]
+#[valkey_module_macros::command({
+    name: "TS.JOIN",
+    flags: [ReadOnly],
+    summary: "Join the samples of two time series over a timestamp range.",
+    complexity: "O(N+M) where N and M are the number of samples in each series within the range.",
+    since: "1.0.0",
+    arity: -4,
+    key_spec: [{
+        flags: [ReadOnly, Access],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 1, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_join_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     let mut args = args.into_iter().skip(1).peekable();
 

--- a/src/commands/ts_labelnames.rs
+++ b/src/commands/ts_labelnames.rs
@@ -14,6 +14,15 @@ use valkey_module::{Context, ValkeyResult, ValkeyString};
 /// [FILTER_BY_RANGE [NOT] fromTimestamp toTimestamp]
 /// [LIMIT limit]
 /// [FILTER seriesMatcher...]
+#[valkey_module_macros::command({
+    name: "TS.LABELNAMES",
+    flags: [ReadOnly],
+    summary: "Return label names across time series, optionally filtered.",
+    complexity: "O(N) where N is the number of label names in the index.",
+    since: "1.0.0",
+    arity: -1,
+    key_spec: []
+})]
 pub fn ts_labelnames_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     run_label_search(ctx, args, LabelSearchType::Name)
 }

--- a/src/commands/ts_labelstats.rs
+++ b/src/commands/ts_labelstats.rs
@@ -6,6 +6,15 @@ use crate::series::index::{PostingStat, PostingsStats, get_timeseries_index};
 use valkey_module::{Context, ValkeyError, ValkeyResult, ValkeyString, ValkeyValue};
 
 /// https://prometheus.io/docs/prometheus/latest/querying/api/#tsdb-stats
+#[valkey_module_macros::command({
+    name: "TS.LABELSTATS",
+    flags: [ReadOnly],
+    summary: "Return cardinality statistics about labels and metric names.",
+    complexity: "O(N) where N is the number of indexed label-value pairs.",
+    since: "1.0.0",
+    arity: -1,
+    key_spec: []
+})]
 pub fn ts_labelstats_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     if args.len() > 5 {
         return Err(ValkeyError::WrongArity);

--- a/src/commands/ts_labelvalues.rs
+++ b/src/commands/ts_labelvalues.rs
@@ -15,6 +15,15 @@ use valkey_module::{Context, ValkeyResult, ValkeyString};
 /// [FILTER_BY_RANGE [NOT] fromTimestamp toTimestamp]
 /// [LIMIT limit]
 /// [FILTER seriesMatcher...]
+#[valkey_module_macros::command({
+    name: "TS.LABELVALUES",
+    flags: [ReadOnly],
+    summary: "Return the values of a label across time series, optionally filtered.",
+    complexity: "O(N) where N is the number of values for the label.",
+    since: "1.0.0",
+    arity: -2,
+    key_spec: []
+})]
 pub fn ts_labelvalues_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     if args.len() < 2 {
         return Err(WrongArity);

--- a/src/commands/ts_madd.rs
+++ b/src/commands/ts_madd.rs
@@ -39,6 +39,19 @@ struct SeriesSamples<'a> {
 /// allows us to add multiple samples at once per series, while parallelizing across series blocks.
 /// Because of that there is extra bookkeeping to do, including mapping results back to the
 /// original input and returning results in input order.
+#[valkey_module_macros::command({
+    name: "TS.MADD",
+    flags: [Write, DenyOOM],
+    summary: "Append new samples to one or more time series.",
+    complexity: "O(N) where N is the number of samples added.",
+    since: "1.0.0",
+    arity: -4,
+    key_spec: [{
+        flags: [ReadWrite, Update],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: -1, steps: 3, limit: 0 })
+    }]
+})]
 pub fn ts_madd_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     let arg_count = args.len() - 1;
 

--- a/src/commands/ts_mdel.rs
+++ b/src/commands/ts_mdel.rs
@@ -16,6 +16,15 @@ use valkey_module::{Context, ValkeyError, ValkeyResult, ValkeyString, ValkeyValu
 ///    - Removes samples in [fromTimestamp, toTimestamp] for matching series
 /// 2. Series deletion: TS.MDEL FILTER label=value
 ///    - Removes entire time series matching the filter
+#[valkey_module_macros::command({
+    name: "TS.MDEL",
+    flags: [Write, DenyOOM],
+    summary: "Delete samples or entire time series matching a filter.",
+    complexity: "O(N*M) where N is the number of matching series and M the number of samples removed per series.",
+    since: "1.0.0",
+    arity: -2,
+    key_spec: []
+})]
 pub fn ts_mdel_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     let mut args = args.into_iter().skip(1).peekable();
 

--- a/src/commands/ts_metricnames.rs
+++ b/src/commands/ts_metricnames.rs
@@ -12,6 +12,15 @@ use valkey_module::{Context, ValkeyResult, ValkeyString};
 /// [FILTER_BY_RANGE [NOT] fromTimestamp toTimestamp]
 /// [LIMIT limit]
 /// [FILTER seriesMatcher...]
+#[valkey_module_macros::command({
+    name: "TS.METRICNAMES",
+    flags: [ReadOnly],
+    summary: "Return metric names across time series, optionally filtered.",
+    complexity: "O(N) where N is the number of metric names in the index.",
+    since: "1.0.0",
+    arity: -1,
+    key_spec: []
+})]
 pub fn ts_metricnames_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     run_label_search(ctx, args, LabelSearchType::MetricName)
 }

--- a/src/commands/ts_mget.rs
+++ b/src/commands/ts_mget.rs
@@ -15,6 +15,15 @@ use valkey_module::{Context, NextArg, ValkeyError, ValkeyResult, ValkeyString};
 ///   [LATEST]
 ///   [WITHLABELS | SELECTED_LABELS label...]
 ///   [FILTER filterExpr...]
+#[valkey_module_macros::command({
+    name: "TS.MGET",
+    flags: [ReadOnly, Fast],
+    summary: "Get the last sample of each time series matching a filter.",
+    complexity: "O(N) where N is the number of time series that match the filters.",
+    since: "1.0.0",
+    arity: -2,
+    key_spec: []
+})]
 pub fn ts_mget_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     if args.len() < 2 {
         return Err(ValkeyError::WrongArity);

--- a/src/commands/ts_mrange.rs
+++ b/src/commands/ts_mrange.rs
@@ -15,10 +15,28 @@ use valkey_module::{Context, NextArg, ValkeyError, ValkeyResult, ValkeyString};
 //   [[ALIGN align] AGGREGATION aggregator bucketDuration [CONDITION op value] [BUCKETTIMESTAMP bt] [EMPTY]]
 //   FILTER filterExpr...
 //   [GROUPBY label REDUCE reducer]
+#[valkey_module_macros::command({
+    name: "TS.MRANGE",
+    flags: [ReadOnly],
+    summary: "Query a range across multiple time series selected by a filter, in forward order.",
+    complexity: "O(N*M) where N is the number of matching series and M the number of samples in the range.",
+    since: "1.0.0",
+    arity: -4,
+    key_spec: []
+})]
 pub fn ts_mrange_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     mrange_internal(ctx, args, false)
 }
 
+#[valkey_module_macros::command({
+    name: "TS.MREVRANGE",
+    flags: [ReadOnly],
+    summary: "Query a range across multiple time series selected by a filter, in reverse order.",
+    complexity: "O(N*M) where N is the number of matching series and M the number of samples in the range.",
+    since: "1.0.0",
+    arity: -4,
+    key_spec: []
+})]
 pub fn ts_mrevrange_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     mrange_internal(ctx, args, true)
 }

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -47,6 +47,19 @@ enum ZScoreType {
 ///     [OUTPUT <full|simple|cleaned>]
 ///     [DIRECTION <positive|negative|both>]
 ///     [SEASONALITY <period1> [period2] ...]
+#[valkey_module_macros::command({
+    name: "TS.OUTLIERS",
+    flags: [ReadOnly, DenyOOM],
+    summary: "Detect outlier samples in a time series over a timestamp range.",
+    complexity: "O(N) where N is the number of samples in the requested range.",
+    since: "1.0.0",
+    arity: -6,
+    key_spec: [{
+        flags: [ReadOnly, Access],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 0, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_outliers_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     if args.len() < 6 {
         return Err(ValkeyError::WrongArity);

--- a/src/commands/ts_queryindex.rs
+++ b/src/commands/ts_queryindex.rs
@@ -6,6 +6,15 @@ use crate::series::index::series_keys_by_selectors;
 use valkey_module::ValkeyError::WrongArity;
 use valkey_module::{Context, ValkeyResult, ValkeyString, ValkeyValue};
 
+#[valkey_module_macros::command({
+    name: "TS.QUERYINDEX",
+    flags: [ReadOnly],
+    summary: "Return the keys of time series matching a filter.",
+    complexity: "O(N) where N is the number of time series that match the filters.",
+    since: "1.0.0",
+    arity: -2,
+    key_spec: []
+})]
 pub fn ts_queryindex_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     if args.len() < 2 {
         return Err(WrongArity);

--- a/src/commands/ts_range.rs
+++ b/src/commands/ts_range.rs
@@ -12,6 +12,19 @@ use valkey_module::{
 //   [FILTER_BY_VALUE min max]
 //   [COUNT count]
 //   [[ALIGN align] AGGREGATION aggregator bucketDuration [CONDITION op value] [BUCKETTIMESTAMP bt] [EMPTY]]
+#[valkey_module_macros::command({
+    name: "TS.RANGE",
+    flags: [ReadOnly],
+    summary: "Query a range of samples from a time series in forward order.",
+    complexity: "O(N) where N is the number of samples in the requested range.",
+    since: "1.0.0",
+    arity: -4,
+    key_spec: [{
+        flags: [ReadOnly, Access],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 0, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_range_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     range_internal(ctx, args, false)
 }
@@ -22,6 +35,19 @@ pub fn ts_range_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
 //   [FILTER_BY_VALUE min max]
 //   [COUNT count]
 //   [[ALIGN align] AGGREGATION aggregator bucket_duration [CONDITION op value] [BUCKETTIMESTAMP bt] [EMPTY]]
+#[valkey_module_macros::command({
+    name: "TS.REVRANGE",
+    flags: [ReadOnly],
+    summary: "Query a range of samples from a time series in reverse order.",
+    complexity: "O(N) where N is the number of samples in the requested range.",
+    since: "1.0.0",
+    arity: -4,
+    key_spec: [{
+        flags: [ReadOnly, Access],
+        begin_search: Index({ index: 1 }),
+        find_keys: Range({ last_key: 0, steps: 1, limit: 0 })
+    }]
+})]
 pub fn ts_revrange_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
     range_internal(ctx, args, true)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,58 @@ fn preload(ctx: &Context, args: &[ValkeyString]) -> Status {
     Status::Ok
 }
 
+/// ACL categories for the commands registered through the `#[valkey_module_macros::command]`
+/// command-info path, keyed by command name. That path (via `register_commands`) does not
+/// assign ACL categories the way the positional command table does, so we (re-)apply them at
+/// load time in [`assign_command_acl_categories`]. Keep this in sync with the `#[command]`
+/// annotations in `src/commands/*`.
+#[cfg(feature = "min-valkey-compatibility-version-8-0")]
+const COMMAND_ACL_CATEGORIES: &[(&str, &str)] = &[
+    ("TS.CREATE", "write fast timeseries"),
+    ("TS.ALTER", "write timeseries"),
+    ("TS.ADD", "write timeseries"),
+    ("TS.ADDBULK", "write timeseries"),
+    ("TS.GET", "fast read timeseries"),
+    ("TS.MGET", "fast read timeseries"),
+    ("TS.MADD", "fast write timeseries"),
+    ("TS.DEL", "write timeseries"),
+    ("TS.DECRBY", "write timeseries"),
+    ("TS.INCRBY", "write timeseries"),
+    ("TS.JOIN", "read timeseries"),
+    ("TS.MDEL", "write timeseries"),
+    ("TS.MRANGE", "read timeseries"),
+    ("TS.MREVRANGE", "read timeseries"),
+    ("TS.RANGE", "read timeseries"),
+    ("TS.REVRANGE", "read timeseries"),
+    ("TS.INFO", "read fast timeseries"),
+    ("TS.QUERYINDEX", "read timeseries"),
+    ("TS.CARD", "read timeseries"),
+    ("TS.LABELNAMES", "read timeseries"),
+    ("TS.LABELVALUES", "read timeseries"),
+    ("TS.METRICNAMES", "read timeseries"),
+    ("TS.LABELSTATS", "read timeseries"),
+    ("TS.CREATERULE", "write timeseries"),
+    ("TS.DELETERULE", "write timeseries"),
+    ("TS.OUTLIERS", "fast read timeseries"),
+];
+
+/// Assign ACL categories to the commands registered via the command-info path. The
+/// `#[command]`-based registration performed by `register_commands` does not set ACL
+/// categories, so we apply them here to keep the custom `@timeseries` category (and the
+/// built-in read/write/fast categories) associated with each command.
+#[cfg(feature = "min-valkey-compatibility-version-8-0")]
+fn assign_command_acl_categories(ctx: &Context) {
+    use std::ffi::CString;
+    for (name, categories) in COMMAND_ACL_CATEGORIES {
+        if let (Ok(command), Ok(acl)) = (CString::new(*name), CString::new(*categories)) {
+            let _ = ctx.set_acl_category(command.as_ptr(), acl.as_ptr());
+        }
+    }
+}
+
+#[cfg(not(feature = "min-valkey-compatibility-version-8-0"))]
+fn assign_command_acl_categories(_ctx: &Context) {}
+
 fn initialize(ctx: &Context, args: &[ValkeyString]) -> Status {
     init_croaring_allocator();
 
@@ -114,6 +166,8 @@ fn initialize(ctx: &Context, args: &[ValkeyString]) -> Status {
         ctx.log_warning(&msg);
         return Status::Err;
     }
+
+    assign_command_acl_categories(ctx);
 
     if let Err(e) = register_server_event_handlers(ctx) {
         let msg = format!("Failed to register server event handlers: {e}");
@@ -180,32 +234,12 @@ valkey_module! {
         "timeseries",
     ]
     commands: [
-        ["TS.CREATE", commands::ts_create_cmd, "write deny-oom", 1, 1, 1, "write fast timeseries"],
-        ["TS.ALTER", commands::ts_alter_cmd, "write deny-oom", 1, 1, 1, "write timeseries"],
-        ["TS.ADD", commands::ts_add_cmd, "write deny-oom", 1, 1, 1, "write timeseries"],
-        ["TS.ADDBULK", commands::ts_addbulk_cmd, "write deny-oom", 1, 1, 1, "write timeseries"],
-        ["TS.GET", commands::ts_get_cmd, "readonly fast", 1, 1, 1, "fast read timeseries"],
-        ["TS.MGET", commands::ts_mget_cmd, "readonly fast", 0, 0, -1, "fast read timeseries"],
-        ["TS.MADD", commands::ts_madd_cmd, "write deny-oom", 1, -1, 3, "fast write timeseries"],
-        ["TS.DEL", commands::ts_del_cmd, "write deny-oom", 1, 1, 1, "write timeseries"],
-        ["TS.DECRBY", commands::ts_decrby_cmd, "write deny-oom", 1, 1, 1, "write timeseries"],
-        ["TS.INCRBY", commands::ts_incrby_cmd, "write deny-oom", 1, 1, 1, "write timeseries"],
-        ["TS.JOIN", commands::ts_join_cmd, "readonly", 1, 2, 1, "read timeseries"],
-        ["TS.MDEL", commands::ts_mdel_cmd, "write deny-oom", 0, 0, -1, "write timeseries"],
-        ["TS.MRANGE", commands::ts_mrange_cmd, "readonly", 0, 0, -1, "read timeseries"],
-        ["TS.MREVRANGE", commands::ts_mrevrange_cmd, "readonly", 0, 0, -1, "read timeseries"],
-        ["TS.RANGE", commands::ts_range_cmd, "readonly", 1, 1, 1, "read timeseries"],
-        ["TS.REVRANGE", commands::ts_revrange_cmd, "readonly", 1, 1, 1, "read timeseries"],
-        ["TS.INFO", commands::ts_info_cmd, "readonly", 0, 0, 0, "read fast timeseries"],
-        ["TS.QUERYINDEX", commands::ts_queryindex_cmd, "readonly", 0, 0, 0, "read timeseries"],
-        ["TS.CARD", commands::ts_card_cmd, "readonly", 0, 0, 0, "read timeseries"],
-        ["TS.LABELNAMES", commands::ts_labelnames_cmd, "readonly", 0, 0, 0, "read timeseries"],
-        ["TS.LABELVALUES", commands::ts_labelvalues_cmd, "readonly", 0, 0, 0, "read timeseries"],
-        ["TS.METRICNAMES", commands::ts_metricnames_cmd, "readonly", 0, 0, 0, "read timeseries"],
-        ["TS.LABELSTATS", commands::ts_labelstats_cmd, "readonly", 0, 0, 0, "read timeseries"],
-        ["TS.CREATERULE", commands::ts_createrule_cmd, "write deny-oom", 1, 1, 1, "write timeseries"],
-        ["TS.DELETERULE", commands::ts_deleterule_cmd, "write deny-oom", 1, 1, 1, "write timeseries"],
-        ["TS.OUTLIERS", commands::ts_outliers_cmd, "readonly deny-oom", 1, 1, 1, "fast read timeseries"],
+        // User-facing commands are registered with full command info (summary, complexity,
+        // arity, and key specs) through the `#[valkey_module_macros::command]` attribute on
+        // each handler in `src/commands/*`; the `valkey_module!` macro registers them via
+        // `register_commands`. Only internal/admin commands remain in this positional table.
+        // ACL categories for the annotated commands are (re-)applied by
+        // `assign_command_acl_categories`, since the command-info path does not set them.
         ["TS._DEBUG", commands::ts_debug_cmd, "readonly", 0, 0, 0, "read timeseries admin"],
         ["TS._RESTORE", commands::ts_asm_restore_cmd, "write deny-oom", 1, 1, 1, "write timeseries admin"],
     ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,11 +149,11 @@ const COMMAND_ACL_CATEGORIES: &[(&str, &str)] = &[
 fn assign_command_acl_categories(ctx: &Context) {
     use std::ffi::CString;
     for (name, categories) in COMMAND_ACL_CATEGORIES {
-        if let (Ok(command), Ok(acl)) = (CString::new(*name), CString::new(*categories)) {
-            if Status::Err == ctx.set_acl_category(command.as_ptr(), acl.as_ptr()) {
-                // Handle the result if necessary, e.g., log errors or assert success
-                ctx.log_warning(&format!("Failed to set ACL category for command {name}"));
-            }
+        if let (Ok(command), Ok(acl)) = (CString::new(*name), CString::new(*categories))
+            && Status::Err == ctx.set_acl_category(command.as_ptr(), acl.as_ptr())
+        {
+            // Handle the result if necessary, e.g., log errors or assert success
+            ctx.log_warning(&format!("Failed to set ACL category for command {name}"));
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,10 @@ fn assign_command_acl_categories(ctx: &Context) {
     use std::ffi::CString;
     for (name, categories) in COMMAND_ACL_CATEGORIES {
         if let (Ok(command), Ok(acl)) = (CString::new(*name), CString::new(*categories)) {
-            let _ = ctx.set_acl_category(command.as_ptr(), acl.as_ptr());
+            if Status::Err == ctx.set_acl_category(command.as_ptr(), acl.as_ptr()) {
+                // Handle the result if necessary, e.g., log errors or assert success
+                ctx.log_warning(&format!("Failed to set ACL category for command {name}"));
+            }
         }
     }
 }

--- a/tests/test_acls.py
+++ b/tests/test_acls.py
@@ -283,9 +283,12 @@ class TestTimeSeriesACL(ValkeyTimeSeriesTestCaseBase):
         assert isinstance(result, list)
         assert len(result) > 0
 
-        # User without info permissions gets denied
+        # User without key access gets denied. TS.INFO declares a key spec (key at
+        # position 1), so the denial is enforced by the server's core ACL layer -- the same
+        # "No permissions to access a key" path as the other keyed read commands above --
+        # rather than by the module's own permission check.
         no_info_client = self.get_user_client('no_info', 'password123')
-        with pytest.raises(Exception, match="user doesn't have read permission"):
+        with pytest.raises(Exception, match="No permissions to access a key"):
             no_info_client.execute_command('TS.INFO', 'ts:acl:info_test')
 
     def test_acl_queryindex_permissions(self):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,24 +1,90 @@
 import pytest
+from valkey import ResponseError
 
 from valkey_timeseries_test_case import ValkeyTimeSeriesTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker
 
 
-class TestTimeSeriesCommand(ValkeyTimeSeriesTestCaseBase):
+class TestTimeSeriesCommandKeys(ValkeyTimeSeriesTestCaseBase):
+    """Verifies key extraction (``COMMAND GETKEYS``) and documentation (``COMMAND DOCS``) for
+    the module's commands.
 
-    def verify_command_arity(self, command, expected_arity):
-        command_info = self.client.execute_command('COMMAND', 'INFO', command)
-        actual_arity = command_info.get(command).get('arity')
-        assert actual_arity == expected_arity, f"Arity mismatch for command '{command}'"
+    These expectations mirror the key specs and summaries declared via the
+    ``#[valkey_module_macros::command(...)]`` annotations on each handler in ``src/commands/*``
+    and were confirmed against a running server. Keyed commands must report their key
+    positions through ``COMMAND GETKEYS``; selector-based commands carry no key specs and must
+    report that they have no key arguments.
+    """
 
-    def test_command_arity(self):
-        self.verify_command_arity('TS.CREATE', -1)
-        self.verify_command_arity('TS.ADD', -1)
-        self.verify_command_arity('TS.MADD', -1)
-        self.verify_command_arity('TS.DEL', -1)
-        self.verify_command_arity('TS.CARD', -1)
-        self.verify_command_arity('TS.INFO', -1)
-        self.verify_command_arity('TS.ALTER', -1)
-        self.verify_command_arity('TS.JOIN', -1)
-        self.verify_command_arity('TS.RANGE', -1)
-        self.verify_command_arity('TS.MRANGE', -1)
+    # (argv after the command name is appended) -> keys COMMAND GETKEYS must return.
+    # Argument values only need to satisfy the declared arity; GETKEYS relies solely on the
+    # key specs, so payloads are placeholders.
+    KEYED_COMMANDS = [
+        (["TS.CREATE", "k"], [b"k"]),
+        (["TS.ALTER", "k"], [b"k"]),
+        (["TS.ADD", "k", "1000", "1.0"], [b"k"]),
+        (["TS.ADDBULK", "k", "data"], [b"k"]),
+        (["TS.GET", "k"], [b"k"]),
+        (["TS.INFO", "k"], [b"k"]),
+        (["TS.DEL", "k", "1", "2"], [b"k"]),
+        (["TS.INCRBY", "k", "1"], [b"k"]),
+        (["TS.DECRBY", "k", "1"], [b"k"]),
+        (["TS.RANGE", "k", "-", "+"], [b"k"]),
+        (["TS.REVRANGE", "k", "-", "+"], [b"k"]),
+        (["TS.OUTLIERS", "k", "-", "+", "MAD", "3"], [b"k"]),
+        (["TS.MADD", "k1", "1", "1.0", "k2", "2", "2.0"], [b"k1", b"k2"]),
+        (["TS.JOIN", "k1", "k2", "-", "+"], [b"k1", b"k2"]),
+        (["TS.CREATERULE", "src", "dst", "AGGREGATION", "avg", "60000"], [b"src", b"dst"]),
+        (["TS.DELETERULE", "src", "dst"], [b"src", b"dst"]),
+    ]
+
+    # Selector-based commands take no keys; COMMAND GETKEYS must report that.
+    KEYLESS_COMMANDS = [
+        ["TS.MGET", "FILTER", "a=b"],
+        ["TS.MRANGE", "-", "+", "FILTER", "a=b"],
+        ["TS.MREVRANGE", "-", "+", "FILTER", "a=b"],
+        ["TS.MDEL", "FILTER", "a=b"],
+        ["TS.QUERYINDEX", "FILTER", "a=b"],
+        ["TS.CARD", "FILTER", "a=b"],
+        ["TS.LABELNAMES", "FILTER", "a=b"],
+        ["TS.LABELVALUES", "label", "FILTER", "a=b"],
+        ["TS.METRICNAMES", "FILTER", "a=b"],
+        ["TS.LABELSTATS"],
+    ]
+
+    def getkeys(self, argv):
+        # Single-string form bypasses the client's COMMAND response callback, which does not
+        # understand the GETKEYS reply shape.
+        return self.client.execute_command("COMMAND GETKEYS " + " ".join(argv))
+
+    def test_getkeys_for_keyed_commands(self):
+        for argv, expected in self.KEYED_COMMANDS:
+            keys = self.getkeys(argv)
+            assert keys == expected, (
+                f"GETKEYS for '{argv[0]}' expected {expected}, got {keys}"
+            )
+
+    def test_getkeys_for_keyless_commands(self):
+        for argv in self.KEYLESS_COMMANDS:
+            with pytest.raises(ResponseError) as exc_info:
+                self.getkeys(argv)
+            assert "no key arguments" in str(exc_info.value).lower(), (
+                f"GETKEYS for '{argv[0]}' should report no key arguments, got: {exc_info.value}"
+            )
+
+    def test_command_docs_metadata(self):
+        # Every user-facing command is registered with a summary, complexity and since via the
+        # command-info annotations. Spot-check a representative set across the read/write and
+        # keyed/keyless categories.
+        for command in ["TS.CREATE", "TS.ADD", "TS.RANGE", "TS.MGET", "TS.CREATERULE"]:
+            docs = self.client.execute_command(f"COMMAND DOCS {command}")
+            assert docs and docs[0].decode().upper() == command, (
+                f"COMMAND DOCS did not return an entry for {command}"
+            )
+            fields = docs[1]
+            meta = {
+                fields[i].decode(): fields[i + 1] for i in range(0, len(fields), 2)
+            }
+            assert meta.get("summary"), f"{command} is missing a COMMAND DOCS summary"
+            assert meta.get("complexity"), f"{command} is missing a COMMAND DOCS complexity"
+            assert meta.get("since"), f"{command} is missing a COMMAND DOCS since"

--- a/tests/test_ts_acls.py
+++ b/tests/test_ts_acls.py
@@ -283,9 +283,12 @@ class TestTimeSeriesACL(ValkeyTimeSeriesTestCaseBase):
         assert isinstance(result, list)
         assert len(result) > 0
 
-        # User without info permissions gets denied
+        # User without key access gets denied. TS.INFO declares a key spec (key at
+        # position 1), so the denial is enforced by the server's core ACL layer -- the same
+        # "No permissions to access a key" path as the other keyed read commands above --
+        # rather than by the module's own permission check.
         no_info_client = self.get_user_client('no_info', 'password123')
-        with pytest.raises(Exception, match="user doesn't have read permission"):
+        with pytest.raises(Exception, match="No permissions to access a key"):
             no_info_client.execute_command('TS.INFO', 'ts:acl:info_test')
 
     def test_acl_queryindex_permissions(self):

--- a/tests/test_ts_command.py
+++ b/tests/test_ts_command.py
@@ -5,20 +5,78 @@ from valkeytestframework.conftest import resource_port_tracker
 
 
 class TestTimeSeriesCommand(ValkeyTimeSeriesTestCaseBase):
+    """Verifies the ``COMMAND INFO`` metadata (arity, flags and legacy key range) that the
+    module registers for every user-facing ``TS.*`` command.
 
-    def verify_command_arity(self, command, expected_arity):
-        command_info = self.client.execute_command('COMMAND', 'INFO', command)
-        actual_arity = command_info.get(command).get('arity')
-        assert actual_arity == expected_arity, f"Arity mismatch for command '{command}'"
+    The expectations below are derived directly from the
+    ``#[valkey_module_macros::command(...)]`` annotations on each command handler in
+    ``src/commands/*`` and were confirmed against a running server. They intentionally mirror
+    the observed code rather than any prior assumption about the metadata.
+    """
+
+    # command -> (arity, first_key, last_key, step, flags)
+    #
+    # Selector-based commands (MGET, MRANGE, QUERYINDEX, CARD, the LABEL* family, ...) match
+    # series by FILTER expressions rather than positional keys, so they expose no key range
+    # (0, 0, 0). MADD takes a key every third argument (1, -1, 3); JOIN/CREATERULE/DELETERULE
+    # take two adjacent keys (1, 2, 1); the remaining keyed commands take a single key at
+    # position 1 (1, 1, 1).
+    COMMAND_INFO = {
+        "TS.CREATE":      (-2, 1,  1, 1, [b"write", b"denyoom", b"module"]),
+        "TS.ALTER":       (-2, 1,  1, 1, [b"write", b"denyoom", b"module"]),
+        "TS.ADD":         (-4, 1,  1, 1, [b"write", b"denyoom", b"module"]),
+        "TS.ADDBULK":     (-3, 1,  1, 1, [b"write", b"denyoom", b"module"]),
+        "TS.GET":         (-2, 1,  1, 1, [b"readonly", b"module", b"fast"]),
+        "TS.MGET":        (-2, 0,  0, 0, [b"readonly", b"module", b"fast"]),
+        "TS.MADD":        (-4, 1, -1, 3, [b"write", b"denyoom", b"module"]),
+        "TS.DEL":         (-3, 1,  1, 1, [b"write", b"denyoom", b"module"]),
+        "TS.DECRBY":      (-3, 1,  1, 1, [b"write", b"denyoom", b"module"]),
+        "TS.INCRBY":      (-3, 1,  1, 1, [b"write", b"denyoom", b"module"]),
+        "TS.JOIN":        (-4, 1,  2, 1, [b"readonly", b"module"]),
+        "TS.MDEL":        (-2, 0,  0, 0, [b"write", b"denyoom", b"module"]),
+        "TS.MRANGE":      (-4, 0,  0, 0, [b"readonly", b"module"]),
+        "TS.MREVRANGE":   (-4, 0,  0, 0, [b"readonly", b"module"]),
+        "TS.RANGE":       (-4, 1,  1, 1, [b"readonly", b"module"]),
+        "TS.REVRANGE":    (-4, 1,  1, 1, [b"readonly", b"module"]),
+        "TS.INFO":        (-2, 1,  1, 1, [b"readonly", b"module"]),
+        "TS.QUERYINDEX":  (-2, 0,  0, 0, [b"readonly", b"module"]),
+        "TS.CARD":        (-1, 0,  0, 0, [b"readonly", b"module"]),
+        "TS.LABELNAMES":  (-1, 0,  0, 0, [b"readonly", b"module"]),
+        "TS.LABELVALUES": (-2, 0,  0, 0, [b"readonly", b"module"]),
+        "TS.METRICNAMES": (-1, 0,  0, 0, [b"readonly", b"module"]),
+        "TS.LABELSTATS":  (-1, 0,  0, 0, [b"readonly", b"module"]),
+        "TS.CREATERULE":  (-6, 1,  2, 1, [b"write", b"denyoom", b"module"]),
+        "TS.DELETERULE":   (3, 1,  2, 1, [b"write", b"denyoom", b"module"]),
+        "TS.OUTLIERS":    (-6, 1,  1, 1, [b"readonly", b"denyoom", b"module"]),
+    }
+
+    def command_info(self, command):
+        # Use the single-string form so the raw reply is returned unmodified. The multi-arg
+        # form ('COMMAND', 'INFO', command) triggers the client's COMMAND response callback,
+        # which reshapes the reply.
+        info = self.client.execute_command(f"COMMAND INFO {command}")
+        assert info and info[0] is not None, f"Command {command} is not registered"
+        return info[0]
 
     def test_command_arity(self):
-        self.verify_command_arity('TS.CREATE', -1)
-        self.verify_command_arity('TS.ADD', -1)
-        self.verify_command_arity('TS.MADD', -1)
-        self.verify_command_arity('TS.DEL', -1)
-        self.verify_command_arity('TS.CARD', -1)
-        self.verify_command_arity('TS.INFO', -1)
-        self.verify_command_arity('TS.ALTER', -1)
-        self.verify_command_arity('TS.JOIN', -1)
-        self.verify_command_arity('TS.RANGE', -1)
-        self.verify_command_arity('TS.MRANGE', -1)
+        for command, expected in self.COMMAND_INFO.items():
+            info = self.command_info(command)
+            assert info[1] == expected[0], (
+                f"Arity mismatch for '{command}': expected {expected[0]}, got {info[1]}"
+            )
+
+    def test_command_flags(self):
+        for command, expected in self.COMMAND_INFO.items():
+            info = self.command_info(command)
+            assert info[2] == expected[4], (
+                f"Flags mismatch for '{command}': expected {expected[4]}, got {info[2]}"
+            )
+
+    def test_command_key_range(self):
+        for command, expected in self.COMMAND_INFO.items():
+            info = self.command_info(command)
+            first, last, step = info[3], info[4], info[5]
+            assert (first, last, step) == (expected[1], expected[2], expected[3]), (
+                f"Key range mismatch for '{command}': expected "
+                f"{(expected[1], expected[2], expected[3])}, got {(first, last, step)}"
+            )

--- a/tests/test_ts_command.py
+++ b/tests/test_ts_command.py
@@ -1,3 +1,5 @@
+from multiprocessing.util import info
+
 import pytest
 
 from valkey_timeseries_test_case import ValkeyTimeSeriesTestCaseBase
@@ -68,7 +70,7 @@ class TestTimeSeriesCommand(ValkeyTimeSeriesTestCaseBase):
     def test_command_flags(self):
         for command, expected in self.COMMAND_INFO.items():
             info = self.command_info(command)
-            assert info[2] == expected[4], (
+            assert sorted(info[2]) == sorted(expected[4]), (
                 f"Flags mismatch for '{command}': expected {expected[4]}, got {info[2]}"
             )
 


### PR DESCRIPTION
This pull request refactors how command handlers are registered and re-exported in the `src/commands` module for the time series (TS) commands. The main improvement is the adoption of the `#[valkey_module_macros::command]` attribute for all TS command handler functions, which automates their registration and metadata specification. As a result, explicit re-exports of these handlers in `mod.rs` are no longer necessary, leading to a cleaner and more maintainable codebase.

The most important changes are:

**Command Registration and Metadata (via Macro Annotations):**
* Added the `#[valkey_module_macros::command]` attribute to all TS command handler functions (e.g., `ts_add_cmd`, `ts_create_cmd`, `ts_get_cmd`, etc.), specifying command name, flags, summary, complexity, version, arity, and key specification inline with each function. This standardizes and centralizes command metadata. [[1]](diffhunk://#diff-acf65a46c4c21e30d72f31e17e0bd429cee50fe22c7c9d018d62a5e0593f92cdR21-R33) [[2]](diffhunk://#diff-692e453cb260ee9631f7cc269635cb62896b6c35f10284464b2cd48aa48c688cR20-R32) [[3]](diffhunk://#diff-15bff838fe7e5f7bcf9cb626f9a57d15e4af7113289e09b990fc1d447e1e3cd4R19-R31) [[4]](diffhunk://#diff-7faf5bc32902dd2bc771263fa6e452bdfcccf58fdfc0c3a3a7b3d5d062d66d6aR11-R19) [[5]](diffhunk://#diff-d6e2bd02fcb219e0e3189676eb1e4e9b9c98d33128f20176876f11914c33141aR22-R34) [[6]](diffhunk://#diff-98bef586d26bf81ae014f2fffe76e0ced6e892b83a186894b5cb2d0b3e61d325R21-R33) [[7]](diffhunk://#diff-292ddadc5ff49fd37d50e66c7fd6e321d74091fb237f7d023ec32c005086f57eR11-R23) [[8]](diffhunk://#diff-e242510f6e1a09905fbc6c38828be1075ca327e84cee1ca68ebf27c81bc713c3R15-R27) [[9]](diffhunk://#diff-696ec490d9e8de8215d846d6b6355e227132bbbf7ea6d668188cb600d76f0967R6-R18) [[10]](diffhunk://#diff-3671dd20dc955769ae8c4517a67c1410a4e685442749b9e8f7914867603072d4R11-R40) [[11]](diffhunk://#diff-092dc24679c2578a3ba7221c42ae34cdc4df55c06968d4a586b530dd5cd22af6R15-R27) [[12]](diffhunk://#diff-c3ecd9ce479d0fbf54468b526f3bd8d142a9d8744681067ae1ed05c834b9170dR18-R30) [[13]](diffhunk://#diff-da13f24363630fc2c80665349fea029abc06da6df471f25030a7b87a8cc11d28R17-R25) [[14]](diffhunk://#diff-ac1f886744830717ccd7dcfe5fc0ed4168c80efc6c070edd6b70a92f83bfd0ebR9-R17) [[15]](diffhunk://#diff-9684a07a29c553c36cf2b3a898f285c69a0e34c17c818ab9abdc8f12d3437117R18-R26) [[16]](diffhunk://#diff-5008a9796ac82fc37ed1c9583cfb5cf28520e2f8c346264abe886378d8457e79R42-R54) [[17]](diffhunk://#diff-1d92250b426fad5ff360a756be52aaffc4c86060405ebad249000608a2bf6819R19-R27) [[18]](diffhunk://#diff-ecbc2aada0faf3c144f6c27a1333637573c8c84716e15497fe6675df0e9e801dR15-R23) [[19]](diffhunk://#diff-4295414f5744ba729f050229291b80af7fcfdca56cb06061add1b16eb9c572e4R18-R26)

**Module Re-exports Simplification:**
* Updated `src/commands/mod.rs` to stop re-exporting individual TS command handler functions. The macro-based registration makes these re-exports unnecessary, reducing boilerplate and potential for errors. Only items consumed through `crate::commands::*` are now re-exported.

These changes modernize the command registration process, improve maintainability, and ensure that command metadata is always up-to-date and close to the implementation.Replaced positional re-exports and manual registration of `TS.*` commands with the `#[valkey_module_macros::command]` attribute. This centralizes command metadata, including arity, flags, summaries, complexity, and key specs, improving maintainability.