### PR TITLE
[BUG] Anomaly scores were not consistently normalized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ strum = { version = "0.28", features = ["derive"] }
 strum_macros = "0.28"
 simd-json = "0.17.0"
 log = "0.4"
-statrs = "0.18"
+statrs = "0.19.0"
 welch-sde = "0.1.0"
 regex-syntax = "0.8.10"
 crc16 = "0.4.0"

--- a/docs/commands/ts.outliers.md
+++ b/docs/commands/ts.outliers.md
@@ -283,7 +283,8 @@ Returns anomaly information based on the `OUTPUT` format:
 * `timestamp` - Sample timestamp (integer)
 * `value` - Sample value (float)
 * `signal` - Anomaly direction: `1` (positive) or `-1` (negative)
-* `score` - Anomaly score (0.0-1.0, higher = stronger anomaly)
+* `score` - Anomaly score (0.0-1.0, higher = stronger anomaly). A sample scores exactly `0.5` at the method's detection
+  boundary, so every score reported here is above `0.5`. See [Anomaly scores](#anomaly-scores).
 
 #### FULL format
 
@@ -294,7 +295,8 @@ Returns anomaly information based on the `OUTPUT` format:
 * `samples` - Array of sample tuples: `[[timestamp, value, score, signal], ...]`
     * `timestamp` - Sample timestamp (integer)
     * `value` - Original sample value (double)
-    * `score` - Calculated anomaly score (0.0-1.0)
+    * `score` - Calculated anomaly score (0.0-1.0). `score > 0.5` for the samples the method flagged, `score <= 0.5` for
+      the rest. See [Anomaly scores](#anomaly-scores).
     * `signal` - Deviation direction (`-1`, `0`, `1`)
 * `parameters` - A map of the parameters used for the detection method.
 * `seasonality` - (optional) A map describing the seasonality parameters used.
@@ -307,6 +309,33 @@ Returns anomaly information based on the `OUTPUT` format:
 #### CLEANED format
 
 **Array reply:** Cleaned samples only, as `[[timestamp, value], ...]`
+
+## Anomaly scores
+
+Every method reports `score` on one scale, whatever `METHOD` and `THRESHOLD` were requested:
+
+> **A sample scores exactly `0.5` at the method's detection boundary.**
+> `score > 0.5` means the sample was flagged; `score <= 0.5` means it was not.
+
+The boundary belongs to the not-flagged side: a sample sitting *exactly* on the fence scores `0.5` and is not reported
+as an anomaly.
+
+This makes `score > 0.5` a valid anomaly test without knowing which method produced the number or what threshold it was
+given, and makes scores comparable across methods. `0.0` and `1.0` are asymptotic — a score approaches `1.0` as evidence
+grows, but only degenerate or non-finite input reaches it exactly:
+
+* An infinite sample value is maximally anomalous: score `1.0`, and flagged.
+* A `NaN` sample scores `0.0` and is never flagged — a missing reading is not evidence of an anomaly.
+* When a method's fitted scale collapses to zero (a robust estimator on a series that is more than half constant), any
+  deviation at all scores `1.0` and is flagged.
+
+The `THRESHOLD` echoed back in `parameters` stays on the **method's own** scale — standard deviations for `ZSCORE`, `k`
+for `MAD`, the decision interval for `CUSUM`, a fraction for `CONTAMINATION`. It is not on the score scale, and under
+this contract it is not needed as one: the score-scale boundary is always `0.5`.
+
+**With `SEASONALITY`**, detection runs on the seasonally adjusted residuals. Only the reported `value` is restored to the
+original observation — `score` stays in the adjusted domain, because it describes the residual, which is what was
+actually tested. Scores are comparable across methods only when computed over the same domain.
 
 ## Complexity
 
@@ -491,6 +520,8 @@ Detect pattern-based anomalies using a sliding window:
 * **Score normalization:**
     * All anomaly scores normalized to [0.0, 1.0] range
     * Higher scores indicate stronger anomalies
+    * `0.5` is the detection boundary for every method — see [Anomaly scores](#anomaly-scores)
+    * With `SEASONALITY`, scores describe the seasonally adjusted residual, not the original value
 * **Timestamp preservation:**
     * Output timestamps match original series timestamps
 * **Performance tips:**

--- a/docs/commands/ts.outliers.md
+++ b/docs/commands/ts.outliers.md
@@ -100,6 +100,41 @@ Detects shifts in the mean by accumulating deviations from the target. No additi
 
 ---
 
+#### ESD
+
+Generalized Extreme Studentized Deviate test (Rosner, 1983).
+
+```
+METHOD ESD [ALPHA alpha] [MAX_OUTLIERS max] [HYBRID | CLASSIC]
+```
+
+**Options:**
+
+* `ALPHA` - Significance level for the test, in the range `(0, 1)`. Default: `0.05`. Lower values are more conservative
+  and report fewer outliers.
+* `MAX_OUTLIERS` - Upper bound on how many outliers to search for. Must be less than half the number of samples in the
+  range. Default: `n/2`.
+* `HYBRID` - Studentize against the median and a normal-consistent MAD. **Default.** Robust: the reference point barely
+  moves as outliers are removed.
+* `CLASSIC` - Studentize against the mean and sample standard deviation, as in Rosner's original procedure. Both are
+  themselves pulled by the outliers under test.
+
+Unlike the fence-based methods, ESD does not take a threshold. It works down from the most extreme observation,
+re-testing after each removal, and compares each test statistic against a critical value derived from `ALPHA` and the
+remaining sample size. The number of outliers is therefore an output of the test rather than a consequence of a
+threshold you picked — which makes ESD the method to reach for when you do not know how deviant "too deviant" is.
+
+`HYBRID` is preferred for most series. `CLASSIC` is available for reproducing published Rosner results and for data
+already known to be clean apart from the outliers being sought; on a series where the outliers are large, the mean and
+standard deviation are inflated by those same outliers and the test loses power against them (the masking effect).
+
+One caveat specific to `HYBRID`: when more than half the samples in the range share a single value, the MAD is zero,
+the test statistic is undefined, and no outliers are reported. Use `CLASSIC` on such series.
+
+ESD reports no `method_info` in `FULL` output — it fits no fences or control limits.
+
+---
+
 #### EWMA
 
 Exponentially Weighted Moving Average.
@@ -264,8 +299,10 @@ Returns anomaly information based on the `OUTPUT` format:
 * `parameters` - A map of the parameters used for the detection method.
 * `seasonality` - (optional) A map describing the seasonality parameters used.
 * `method_info` - Algorithm-specific metadata (map, if available):
-    * For IQR: `lower_fence`, `upper_fence`
+    * For the fence-based methods (ZSCORE, MODIFIED-ZSCORE, MAD, DOUBLE-MAD, IQR): `lower_fence`, `upper_fence`, and
+      `center_line` where the method defines one
     * For SPC methods (CUSUM, EWMA): `control_limits`, `center_line`
+    * Omitted for ESD, RCF, and SMOOTHED-ZSCORE, which fit no fences or control limits
 
 #### CLEANED format
 
@@ -383,6 +420,51 @@ Extract normal operating data with anomalies removed:
 </details>
 
 <details open>
+<summary><b>Detect an unknown number of outliers with ESD</b></summary>
+
+Find latency spikes without choosing a threshold — the test decides how many outliers there are:
+
+```valkey-cli
+127.0.0.1:6379> TS.OUTLIERS latency:p99 - + METHOD ESD
+1) 1) (integer) 1609603200000
+   2) "812.4"
+   3) (integer) 1
+   4) "0.9936787608707793"
+2) 1) (integer) 1609606800000
+   2) "655.1"
+   3) (integer) 1
+   4) "0.9919286813470485"
+```
+
+Tighten the significance level and cap the search to report only the most extreme few:
+
+```valkey-cli
+127.0.0.1:6379> TS.OUTLIERS latency:p99 - + METHOD ESD ALPHA 0.01 MAX_OUTLIERS 5 OUTPUT FULL
+1) "method"
+2) "esd"
+3) "direction"
+4) "both"
+5) "samples"
+6)  1) 1) (integer) 1609459200000
+       2) "98"
+       3) "0.28670901283740885"
+       4) (integer) 0
+    ...
+7) "parameters"
+8) 1) "alpha"
+   2) "0.01"
+   3) "hybrid"
+   4) (integer) 1
+   5) "max_outliers"
+   6) (integer) 5
+```
+
+Note the absence of a `method_info` key, and that `parameters` reports `hybrid` as a flag rather than echoing an
+estimator name.
+
+</details>
+
+<details open>
 <summary><b>Random Cut Forest for contextual anomalies</b></summary>
 
 Detect pattern-based anomalies using a sliding window:
@@ -415,6 +497,8 @@ Detect pattern-based anomalies using a sliding window:
     * Use `DIRECTION` to filter results when only interested in one type of anomaly
     * Single seasonality periods are faster than multiple
     * RCF is more computationally expensive but better for complex patterns
+    * ESD re-tests the sample after each removal, so its cost scales with `MAX_OUTLIERS`; lower that bound if you only
+      care about the few most extreme samples
 
 ## See also
 

--- a/docs/commands/ts.outliers.md
+++ b/docs/commands/ts.outliers.md
@@ -326,8 +326,10 @@ grows, but only degenerate or non-finite input reaches it exactly:
 
 * An infinite sample value is maximally anomalous: score `1.0`, and flagged.
 * A `NaN` sample scores `0.0` and is never flagged — a missing reading is not evidence of an anomaly.
-* When a method's fitted scale collapses to zero (a robust estimator on a series that is more than half constant), any
-  deviation at all scores `1.0` and is flagged.
+* When a method's fitted scale collapses to zero (a robust estimator on a series that is more than half constant), the
+  outcome depends on the method: `MAD`, `DOUBLE-MAD`, and `IQR` treat the collapsed fence as zero-width, so any deviation
+  at all scores `1.0` and is flagged; `ZSCORE`, `MODIFIED-ZSCORE`, `CUSUM`, and `EWMA` treat a collapsed scale as having
+  no boundary to test against, so every sample scores `0.0` and stays unflagged.
 
 The `THRESHOLD` echoed back in `parameters` stays on the **method's own** scale — standard deviations for `ZSCORE`, `k`
 for `MAD`, the decision interval for `CUSUM`, a fraction for `CONTAMINATION`. It is not on the score scale, and under

--- a/src/analysis/outliers/cusum_outlier_detector.rs
+++ b/src/analysis/outliers/cusum_outlier_detector.rs
@@ -1,4 +1,4 @@
-use super::utils::{normalize_unbounded_score, normalize_value};
+use super::utils::{normalize_evidence, normalize_value};
 use crate::analysis::TimeSeriesAnalysisResult;
 use crate::analysis::math::calculate_mean_std_dev;
 use crate::analysis::outliers::{
@@ -93,8 +93,10 @@ impl CusumOutlierDetector {
             cusum_pos = f64::max(0.0, cusum_pos + deviation - self.k);
             cusum_neg = f64::max(0.0, cusum_neg - deviation - self.k);
 
-            // Already in sigmas; normalize straight to [0, 1].
-            let score = normalize_unbounded_score(f64::max(cusum_pos, cusum_neg));
+            // Both arms and the decision interval are in sigmas, so the
+            // accumulated drift is the evidence and `h` is the boundary it is
+            // tested against — the same comparison the signal below makes.
+            let score = normalize_evidence(f64::max(cusum_pos, cusum_neg), threshold);
             scores.push(score);
 
             let signal = if cusum_pos > threshold {

--- a/src/analysis/outliers/detector.rs
+++ b/src/analysis/outliers/detector.rs
@@ -116,10 +116,10 @@ impl Detector {
             AnomalyDetectionMethodOptions::Esd(options) => {
                 let ESDOutlierOptions {
                     alpha,
-                    hybrid,
+                    estimator,
                     max_outliers,
                 } = options.clone().unwrap_or_default();
-                Detector::Esd(ESDOutlierDetector::new(alpha, hybrid, max_outliers))
+                Detector::Esd(ESDOutlierDetector::new(alpha, estimator, max_outliers))
             }
         };
 

--- a/src/analysis/outliers/double_mad_outlier_detector.rs
+++ b/src/analysis/outliers/double_mad_outlier_detector.rs
@@ -1,4 +1,4 @@
-use super::utils::normalize_evidence;
+use super::utils::{deviation_and_fence_distance, normalize_evidence};
 use crate::analysis::TimeSeriesAnalysisResult;
 use crate::analysis::outliers::mad_estimator::{
     HarrellDavisNormalizedEstimator, InvariantMADEstimator, MedianAbsoluteDeviationEstimator,
@@ -125,13 +125,14 @@ impl DoubleMadOutlierDetector {
     #[inline]
     fn deviation_and_boundary(&self, value: f64) -> Option<(f64, f64)> {
         let fitted = self.fitted?;
-        let deviation = value - fitted.median;
-        let boundary = if deviation >= 0.0 {
-            fitted.upper_fence(self.threshold) - fitted.median
-        } else {
-            fitted.median - fitted.lower_fence(self.threshold)
-        };
-        Some((deviation, boundary))
+        let lower_fence = fitted.lower_fence(self.threshold);
+        let upper_fence = fitted.upper_fence(self.threshold);
+        Some(deviation_and_fence_distance(
+            value,
+            fitted.median,
+            lower_fence,
+            upper_fence,
+        ))
     }
 
     /// Calculates a normalized anomaly score in [0, 1].

--- a/src/analysis/outliers/double_mad_outlier_detector.rs
+++ b/src/analysis/outliers/double_mad_outlier_detector.rs
@@ -1,4 +1,4 @@
-use super::utils::get_anomaly_direction;
+use super::utils::normalize_evidence;
 use crate::analysis::TimeSeriesAnalysisResult;
 use crate::analysis::outliers::mad_estimator::{
     HarrellDavisNormalizedEstimator, InvariantMADEstimator, MedianAbsoluteDeviationEstimator,
@@ -18,18 +18,31 @@ use crate::analysis::quantile_estimators::Samples;
 /// https://aakinshin.net/posts/harrell-davis-double-mad-outlier-detector/
 #[derive(Debug)]
 pub struct DoubleMadOutlierDetector {
-    /// Optional computed fences. They may be None when the detector is constructed
-    /// without data and will be computed when `train` is called (or on first detect).
-    lower_fence: Option<f64>,
-    upper_fence: Option<f64>,
+    /// Fitted location and the two one-sided scale estimates, or `None` until
+    /// the detector has been trained.
+    fitted: Option<Fitted>,
     /// Configured threshold (k)
     threshold: f64,
-    /// Midpoint between fences (optional until trained)
-    midpoint: Option<f64>,
-    /// Half range between fences (optional until trained)
-    half_range: Option<f64>,
     /// Options describing estimator (kept so the detector can be trained later)
     estimator: AnomalyMADEstimator,
+}
+
+/// What training produces: the median, and one MAD per side.
+#[derive(Debug, Clone, Copy)]
+struct Fitted {
+    median: f64,
+    lower_mad: f64,
+    upper_mad: f64,
+}
+
+impl Fitted {
+    fn lower_fence(&self, k: f64) -> f64 {
+        self.median - k * self.lower_mad
+    }
+
+    fn upper_fence(&self, k: f64) -> f64 {
+        self.median + k * self.upper_mad
+    }
 }
 
 impl DoubleMadOutlierDetector {
@@ -37,11 +50,8 @@ impl DoubleMadOutlierDetector {
 
     pub fn new(threshold: f64, estimator: AnomalyMADEstimator) -> Self {
         DoubleMadOutlierDetector {
-            lower_fence: None,
-            upper_fence: None,
+            fitted: None,
             threshold,
-            midpoint: None,
-            half_range: None,
             estimator,
         }
     }
@@ -55,25 +65,23 @@ impl DoubleMadOutlierDetector {
     /// Returns true when the detector has been trained and fences have been computed.
     /// Callers may use this to decide whether to call `train` prior to scoring/classifying.
     pub fn is_trained(&self) -> bool {
-        self.lower_fence.is_some()
-            && self.upper_fence.is_some()
-            && self.midpoint.is_some()
-            && self.half_range.is_some()
+        self.fitted.is_some()
     }
 
-    fn compute_fences(
-        estimator: impl MedianAbsoluteDeviationEstimator,
-        sample: &Samples,
-        k: f64,
-    ) -> (f64, f64, f64, f64) {
-        let median = estimator.quantile_estimator().median(sample);
-        let lower_mad = estimator.lower_mad(sample);
-        let upper_mad = estimator.upper_mad(sample);
-        let lower_fence = median - k * lower_mad;
-        let upper_fence = median + k * upper_mad;
-        let midpoint = (lower_fence + upper_fence) / 2.0;
-        let half_range = (upper_fence - lower_fence) / 2.0;
-        (lower_fence, upper_fence, midpoint, half_range)
+    pub fn lower_fence(&self) -> Option<f64> {
+        self.fitted.map(|f| f.lower_fence(self.threshold))
+    }
+
+    pub fn upper_fence(&self) -> Option<f64> {
+        self.fitted.map(|f| f.upper_fence(self.threshold))
+    }
+
+    fn fit(estimator: impl MedianAbsoluteDeviationEstimator, sample: &Samples) -> Fitted {
+        Fitted {
+            median: estimator.quantile_estimator().median(sample),
+            lower_mad: estimator.lower_mad(sample),
+            upper_mad: estimator.upper_mad(sample),
+        }
     }
 
     /// Train the detector using explicit Samples and optional estimator.
@@ -83,78 +91,63 @@ impl DoubleMadOutlierDetector {
         k: f64,
         estimator: Option<E>,
     ) {
-        let mut apply_fences = |(l, u, m, h): (f64, f64, f64, f64)| {
-            self.lower_fence = Some(l);
-            self.upper_fence = Some(u);
-            self.midpoint = Some(m);
-            self.half_range = Some(h);
-            self.threshold = k;
-        };
-
-        match estimator {
-            Some(est) => {
-                apply_fences(Self::compute_fences(est, samples, k));
-            }
+        self.fitted = Some(match estimator {
+            Some(est) => Self::fit(est, samples),
             None => match self.estimator {
                 AnomalyMADEstimator::Simple => {
-                    let est = SimpleNormalizedEstimator::default();
-                    apply_fences(Self::compute_fences(est, samples, k));
+                    Self::fit(SimpleNormalizedEstimator::default(), samples)
                 }
                 AnomalyMADEstimator::HarrellDavis => {
-                    let est = HarrellDavisNormalizedEstimator;
-                    apply_fences(Self::compute_fences(est, samples, k));
+                    Self::fit(HarrellDavisNormalizedEstimator, samples)
                 }
                 AnomalyMADEstimator::Invariant => {
-                    let est = InvariantMADEstimator::default();
-                    apply_fences(Self::compute_fences(est, samples, k));
+                    Self::fit(InvariantMADEstimator::default(), samples)
                 }
             },
-        }
+        });
+        self.threshold = k;
+    }
+
+    /// Deviation from the median, and the distance out to the fence on the
+    /// sample's *own* side.
+    ///
+    /// The fences are asymmetric by construction, so evidence has to be measured
+    /// against the one the value is actually approaching. `r = 1` at either
+    /// fence and `r = 0` at the median, whichever side the value falls on.
+    ///
+    /// The distance is taken as `fence - median` rather than the algebraically
+    /// equal `k * mad`, so that a value sitting exactly on a reported fence
+    /// produces evidence and boundary from the identical subtraction and scores
+    /// exactly `0.5`.
+    ///
+    /// Returns `None` when the detector has not been trained, in which case
+    /// there is no model to measure against.
+    #[inline]
+    fn deviation_and_boundary(&self, value: f64) -> Option<(f64, f64)> {
+        let fitted = self.fitted?;
+        let deviation = value - fitted.median;
+        let boundary = if deviation >= 0.0 {
+            fitted.upper_fence(self.threshold) - fitted.median
+        } else {
+            fitted.median - fitted.lower_fence(self.threshold)
+        };
+        Some((deviation, boundary))
     }
 
     /// Calculates a normalized anomaly score in [0, 1].
     ///
-    /// - Returns 0.0 when the value equals the midpoint between fences (least anomalous).
-    /// - Returns values approaching 1.0 as the value moves further beyond the fences.
-    /// - Values within fences return scores < 0.5, values outside return scores >= 0.5.
+    /// - `0.0` at the median (least anomalous).
+    /// - `0.5` exactly on the fence for the value's own side.
+    /// - approaching `1.0` as the value moves further beyond that fence.
     pub fn get_anomaly_score(&self, value: f64) -> f64 {
-        // If not trained (no fences), we cannot compute a meaningful score.
-        // Caller should ensure `train` is called before scoring. As a
-        // fallback, treat everything as non-anomalous (score 0.0).
-        let midpoint = match self.midpoint {
-            Some(m) => m,
-            None => return 0.0,
-        };
-
-        let half_range = match self.half_range {
-            Some(h) => h,
-            None => return 0.0,
-        };
-
-        // Guard against zero range (all values identical)
-        if half_range <= 0.0 {
-            return if (value - midpoint).abs() < f64::EPSILON {
-                0.0
-            } else {
-                1.0
-            };
+        match self.deviation_and_boundary(value) {
+            Some((deviation, boundary)) => normalize_evidence(deviation.abs(), boundary),
+            None => 0.0,
         }
-
-        // Calculate the distance from midpoint, normalized by half_range
-        let normalized_distance = (value - midpoint).abs() / half_range;
-
-        // Map to [0, 1] using a sigmoid-like transformation:
-        // - distance = 0 → score = 0
-        // - distance = 1 (at fence) → score = 0.5
-        // - distance → ∞ → score → 1
-        normalized_distance / (1.0 + normalized_distance)
     }
 
     pub fn is_outlier(&self, value: f64) -> bool {
-        match (self.lower_fence, self.upper_fence) {
-            (Some(l), Some(u)) => value < l || value > u,
-            _ => false,
-        }
+        self.classify(value).is_anomaly()
     }
 
     pub fn detect(&mut self, ts: &[f64]) -> TimeSeriesAnalysisResult<AnomalyResult> {
@@ -176,9 +169,9 @@ impl AnomalyDetector for DoubleMadOutlierDetector {
 
     fn model_info(&self) -> Option<MethodInfo> {
         Some(MethodInfo::Fenced {
-            lower_fence: self.lower_fence.unwrap_or(f64::NAN),
-            upper_fence: self.upper_fence.unwrap_or(f64::NAN),
-            center_line: None,
+            lower_fence: self.lower_fence().unwrap_or(f64::NAN),
+            upper_fence: self.upper_fence().unwrap_or(f64::NAN),
+            center_line: self.fitted.map(|f| f.median),
         })
     }
 
@@ -202,10 +195,20 @@ impl PointDetector for DoubleMadOutlierDetector {
     }
 
     fn classify(&self, value: f64) -> AnomalySignal {
-        // If fences are not computed yet, treat everything as non-anomalous
-        match (self.lower_fence, self.upper_fence) {
-            (Some(l), Some(u)) => get_anomaly_direction(l, u, value),
-            _ => AnomalySignal::None,
+        // If the detector is untrained, there is no fence to be outside of.
+        let Some((deviation, boundary)) = self.deviation_and_boundary(value) else {
+            return AnomalySignal::None;
+        };
+        // A NaN on either side — a missing reading, or a scale that was never
+        // fitted — fails this comparison, which is how it stays unflagged.
+        if deviation.abs() > boundary {
+            if deviation > 0.0 {
+                AnomalySignal::Positive
+            } else {
+                AnomalySignal::Negative
+            }
+        } else {
+            AnomalySignal::None
         }
     }
 }

--- a/src/analysis/outliers/double_mad_outlier_detector.rs
+++ b/src/analysis/outliers/double_mad_outlier_detector.rs
@@ -85,12 +85,25 @@ impl DoubleMadOutlierDetector {
     }
 
     /// Train the detector using explicit Samples and optional estimator.
+    ///
+    /// A `samples` that is empty after NaN filtering (e.g. every reading in
+    /// the window was missing) leaves `self.fitted` at `None` rather than
+    /// fitting: the quantile estimators index into `sample.values`
+    /// unconditionally and panic on an empty sample. `None` is the detector's
+    /// existing untrained/no-model state — every reader already treats it as
+    /// "nothing to measure against" (`classify` returns `None`, `score`
+    /// returns `0.0`, `model_info` reports NaN fences).
     fn train_from_samples<E: MedianAbsoluteDeviationEstimator>(
         &mut self,
         samples: &Samples,
         k: f64,
         estimator: Option<E>,
     ) {
+        self.threshold = k;
+        if samples.is_empty() {
+            self.fitted = None;
+            return;
+        }
         self.fitted = Some(match estimator {
             Some(est) => Self::fit(est, samples),
             None => match self.estimator {
@@ -105,7 +118,6 @@ impl DoubleMadOutlierDetector {
                 }
             },
         });
-        self.threshold = k;
     }
 
     /// Deviation from the median, and the distance out to the fence on the

--- a/src/analysis/outliers/double_mad_outlier_detector_tests.rs
+++ b/src/analysis/outliers/double_mad_outlier_detector_tests.rs
@@ -32,6 +32,22 @@ mod tests {
         assert_eq!(detector.score(median), 0.0);
     }
 
+    /// All-NaN training data (every reading in the window was missing) used to
+    /// panic: NaN filtering left `Samples` empty, and the quantile estimators
+    /// index into `sample.values` unconditionally. Training must instead leave
+    /// the detector in its existing untrained state (`fitted: None`), so
+    /// nothing is flagged.
+    #[test]
+    fn train_on_all_nan_data_does_not_panic() {
+        let data = [f64::NAN, f64::NAN, f64::NAN];
+        let mut detector = DoubleMadOutlierDetector::new(3.0, AnomalyMADEstimator::Simple);
+        detector.train(&data).unwrap();
+
+        assert!(!detector.is_trained());
+        assert_eq!(detector.classify(0.0), AnomalySignal::None);
+        assert_eq!(detector.score(0.0), 0.0);
+    }
+
     /// Data cases for SimpleQuantileEstimator
     fn simple_qe_test_data_map() -> HashMap<&'static str, TestData<'static>> {
         let mut map = HashMap::new();

--- a/src/analysis/outliers/double_mad_outlier_detector_tests.rs
+++ b/src/analysis/outliers/double_mad_outlier_detector_tests.rs
@@ -6,7 +6,31 @@ mod tests {
         EMPTY_DATASET, SAME_DATASET, TestData, beta_data_set, check_outliers,
         modified_beta_data_set, real_data_set,
     };
+    use crate::analysis::outliers::{AnomalyDetector, AnomalySignal, MethodInfo, PointDetector};
     use std::collections::HashMap;
+
+    /// A negative threshold inverts the fences. Before `deviation_and_boundary`
+    /// mapped a negative fence distance to NaN, this flagged essentially every
+    /// point — including the median itself — while still scoring it `0.0`,
+    /// since `normalize_evidence` already treated the negative boundary as
+    /// unusable. Both must now agree that there is nothing to be past.
+    #[test]
+    fn negative_threshold_does_not_flag_the_median() {
+        let data = [1.0, 4.0, 4.0, 4.0, 5.0, 5.0, 5.0, 5.0, 7.0, 7.0, 8.0, 10.0];
+        let mut detector = DoubleMadOutlierDetector::new(-3.0, AnomalyMADEstimator::Simple);
+        detector.train(&data).unwrap();
+
+        let Some(MethodInfo::Fenced {
+            center_line: Some(median),
+            ..
+        }) = detector.model_info()
+        else {
+            panic!("expected a fitted center line");
+        };
+
+        assert_eq!(detector.classify(median), AnomalySignal::None);
+        assert_eq!(detector.score(median), 0.0);
+    }
 
     /// Data cases for SimpleQuantileEstimator
     fn simple_qe_test_data_map() -> HashMap<&'static str, TestData<'static>> {

--- a/src/analysis/outliers/esd_outlier_detector.rs
+++ b/src/analysis/outliers/esd_outlier_detector.rs
@@ -5,14 +5,49 @@ use crate::analysis::outliers::{
 use crate::analysis::{TimeSeriesAnalysisError, TimeSeriesAnalysisResult};
 use statrs::distribution::{ContinuousCDF, StudentsT};
 
+/// Which location/scale pair the studentized statistic is built from.
+///
+/// The distinction is the one the literature draws between Rosner's generalized
+/// ESD and the "hybrid" variant. Rosner's procedure studentizes against the
+/// mean and sample standard deviation; both are themselves pulled by the
+/// outliers under test, which is the masking effect ESD's step-down loop is
+/// trying to overcome. The hybrid form substitutes the median and a
+/// normal-consistent MAD, so the reference point barely moves as outliers are
+/// removed.
+///
+/// This was previously a `hybrid: bool` whose `true` arm selected *mean/std* —
+/// the opposite of what the name claims in Rosner and in Twitter's S-H-ESD.
+/// Naming the two variants removes the polarity that hid the inversion.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum EsdEstimator {
+    /// Median and normal-consistent MAD. Robust, and the default.
+    #[default]
+    Hybrid,
+    /// Mean and sample standard deviation, as in Rosner (1983).
+    Classic,
+}
+
+impl EsdEstimator {
+    pub fn is_hybrid(&self) -> bool {
+        *self == EsdEstimator::Hybrid
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            EsdEstimator::Hybrid => "hybrid",
+            EsdEstimator::Classic => "classic",
+        }
+    }
+}
+
 /// ESD (Extreme Studentized Deviate) anomaly detector
 /// https://www.itl.nist.gov/div898/handbook/eda/section3/eda35h3.htm
 #[derive(Clone, Debug)]
 pub struct ESDOutlierOptions {
     /// Significance level for the statistical test (e.g., 0.05)
     pub alpha: f64,
-    /// Whether to use the hybrid ESD test (mean/std if true; median/MAD if false)
-    pub hybrid: bool,
+    /// Location/scale pair backing the test statistic.
+    pub estimator: EsdEstimator,
     /// Maximum number of outliers to detect. Must be < n/2.
     pub max_outliers: Option<usize>,
 }
@@ -21,7 +56,7 @@ impl Default for ESDOutlierOptions {
     fn default() -> Self {
         ESDOutlierOptions {
             alpha: 0.05,
-            hybrid: false,
+            estimator: EsdEstimator::Hybrid,
             max_outliers: None,
         }
     }
@@ -35,8 +70,8 @@ impl Default for ESDOutlierOptions {
 pub struct ESDOutlierDetector {
     /// Significance level for a hypothesis test. Lower alpha means more conservative (fewer outliers).
     alpha: f64,
-    /// if true, use mean/std; if false, use median/MAD
-    hybrid: bool,
+    /// Location/scale pair backing the test statistic.
+    estimator: EsdEstimator,
     /// Maximum number of outliers to detect. Must be < n/2. If None, uses len(data)/2.
     max_outliers: Option<usize>,
 }
@@ -45,17 +80,17 @@ impl Default for ESDOutlierDetector {
     fn default() -> Self {
         ESDOutlierDetector {
             alpha: 0.05,
-            hybrid: false,
+            estimator: EsdEstimator::Hybrid,
             max_outliers: None,
         }
     }
 }
 
 impl ESDOutlierDetector {
-    pub fn new(alpha: f64, hybrid: bool, max_outliers: Option<usize>) -> Self {
+    pub fn new(alpha: f64, estimator: EsdEstimator, max_outliers: Option<usize>) -> Self {
         ESDOutlierDetector {
             alpha,
-            hybrid,
+            estimator,
             max_outliers,
         }
     }
@@ -71,14 +106,14 @@ impl AnomalyDetector for ESDOutlierDetector {
     }
 
     fn detect(&mut self, ts: &[f64]) -> TimeSeriesAnalysisResult<AnomalyResult> {
-        detect_anomalies_esd(ts, self.alpha, self.hybrid, self.max_outliers)
+        detect_anomalies_esd(ts, self.alpha, self.estimator, self.max_outliers)
     }
 }
 
 fn detect_anomalies_esd(
     data: &[f64],
     alpha: f64,
-    hybrid: bool,
+    estimator: EsdEstimator,
     max_outliers: Option<usize>,
 ) -> TimeSeriesAnalysisResult<AnomalyResult> {
     let n = data.len();
@@ -101,7 +136,7 @@ fn detect_anomalies_esd(
     };
 
     // Perform ESD test
-    let (anomalies, scores) = esd_test(data, alpha, hybrid, max_outliers)?;
+    let (anomalies, scores) = esd_test(data, alpha, estimator, max_outliers)?;
 
     Ok(AnomalyResult {
         anomalies,
@@ -129,7 +164,7 @@ fn esd_score_stat_over_stat_plus_lambda(stat: f64, lambda: f64) -> f64 {
 ///
 /// - `data`: slice of f64 values (original data)
 /// - `alpha`: significance level (default 0.05)
-/// - `hybrid`: if true, use mean/std; if false, use median/MAD
+/// - `estimator`: location/scale pair backing the statistic — see [`EsdEstimator`]
 /// - `max_outliers`: optional maximum number of outliers to search for. If None, uses len(data)/2.
 ///
 /// Returns a `TimeSeriesAnalysisResult<(Vec<Anomaly>, Vec<f64>)>` pair where `anomalies` contains
@@ -138,7 +173,7 @@ fn esd_score_stat_over_stat_plus_lambda(stat: f64, lambda: f64) -> f64 {
 fn esd_test(
     data: &[f64],
     alpha: f64,
-    hybrid: bool,
+    estimator: EsdEstimator,
     max_out: usize,
 ) -> TimeSeriesAnalysisResult<(Vec<Anomaly>, Vec<f64>)> {
     let n_total = data.len();
@@ -162,11 +197,11 @@ fn esd_test(
         }
 
         let current_vals = active_points(&masked);
-        let Some((loc, _scale)) = loc_and_scale(&current_vals, hybrid) else {
+        let Some((loc, _scale)) = loc_and_scale(&current_vals, estimator) else {
             break;
         };
 
-        let (test_stat, test_idx) = calc_test_statistic(&current_vals, hybrid);
+        let (test_stat, test_idx) = calc_test_statistic(&current_vals, estimator);
 
         // compute critical value using the current non-masked count
         let n = n_non_masked as f64;
@@ -228,7 +263,7 @@ fn esd_test(
     // After loop, score any remaining unmasked observations using the last lambda if available.
     score_active_points(
         &active_points(&masked),
-        hybrid,
+        estimator,
         last_lambda.unwrap_or(0.0),
         &mut scores,
     );
@@ -238,13 +273,13 @@ fn esd_test(
 
 /// Calculate the test statistic and index for the (masked) data.
 /// Returns (test_statistic, index_in_original_array)
-fn calc_test_statistic(values: &[(usize, f64)], hybrid: bool) -> (f64, usize) {
+fn calc_test_statistic(values: &[(usize, f64)], estimator: EsdEstimator) -> (f64, usize) {
     // If empty, return 0,0
     if values.is_empty() {
         return (0.0, 0);
     }
 
-    let Some((loc, scale)) = loc_and_scale(values, hybrid) else {
+    let Some((loc, scale)) = loc_and_scale(values, estimator) else {
         return (0.0f64, 0);
     };
 
@@ -274,33 +309,36 @@ fn active_points(masked: &[Option<f64>]) -> Vec<(usize, f64)> {
 }
 
 /// Compute the location and scale used by the ESD detector.
-fn loc_and_scale(values: &[(usize, f64)], hybrid: bool) -> Option<(f64, f64)> {
+fn loc_and_scale(values: &[(usize, f64)], estimator: EsdEstimator) -> Option<(f64, f64)> {
     if values.is_empty() {
         return None;
     }
 
-    let loc = if hybrid {
-        mean_values(values)
-    } else {
-        median_values(values)
-    };
-
-    let scale = if hybrid {
-        std_sample_values(values, loc)
-    } else {
-        let mut abs_devs: Vec<f64> = values.iter().map(|(_, x)| (x - loc).abs()).collect();
-        abs_devs.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        let mad = calculate_median_sorted(&abs_devs);
-        // MAD * 1.4826 is a consistent estimator for the standard deviation of a normal distribution
-        mad * 1.4826
-    };
-
-    Some((loc, scale))
+    match estimator {
+        EsdEstimator::Classic => {
+            let loc = mean_values(values);
+            let scale = std_sample_values(values, loc);
+            Some((loc, scale))
+        }
+        EsdEstimator::Hybrid => {
+            let loc = median_values(values);
+            let mut abs_devs: Vec<f64> = values.iter().map(|(_, x)| (x - loc).abs()).collect();
+            abs_devs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            let mad = calculate_median_sorted(&abs_devs);
+            // MAD * 1.4826 is a consistent estimator for the standard deviation of a normal distribution
+            Some((loc, mad * 1.4826))
+        }
+    }
 }
 
 /// Score a set of active observations using the provided lambda.
-fn score_active_points(values: &[(usize, f64)], hybrid: bool, lambda: f64, scores: &mut [f64]) {
-    let Some((loc, scale)) = loc_and_scale(values, hybrid) else {
+fn score_active_points(
+    values: &[(usize, f64)],
+    estimator: EsdEstimator,
+    lambda: f64,
+    scores: &mut [f64],
+) {
+    let Some((loc, scale)) = loc_and_scale(values, estimator) else {
         return;
     };
 
@@ -347,9 +385,55 @@ mod tests {
         // simple data with an outlier at index 4
         let data = [1.0, 1.1, 0.9, 1.05, 10.0];
         let values = active_points(&data.iter().cloned().map(Some).collect::<Vec<_>>());
-        let (stat, idx) = calc_test_statistic(&values, false);
+        let (stat, idx) = calc_test_statistic(&values, EsdEstimator::Hybrid);
         assert_eq!(idx, 4);
         assert!(stat > 0.0);
+    }
+
+    /// `Hybrid` must studentize against median/MAD and `Classic` against
+    /// mean/std. The two were transposed behind a `hybrid: bool` whose `true`
+    /// arm selected mean/std — the opposite of the name. A single left-skewed
+    /// sample separates them: the mean is dragged below the median, so the two
+    /// locations cannot coincide.
+    #[test]
+    fn estimator_selects_the_documented_location_and_scale() {
+        let data = [-20.0, 1.0, 1.1, 0.9, 1.05, 1.2];
+        let values = active_points(&data.iter().cloned().map(Some).collect::<Vec<_>>());
+
+        let (hybrid_loc, _) = loc_and_scale(&values, EsdEstimator::Hybrid).unwrap();
+        let (classic_loc, classic_scale) = loc_and_scale(&values, EsdEstimator::Classic).unwrap();
+
+        let expected_median = 1.025; // mean of the two middle values, 1.0 and 1.05
+        assert!(
+            (hybrid_loc - expected_median).abs() < 1e-9,
+            "Hybrid must locate at the median, got {hybrid_loc}"
+        );
+
+        let expected_mean = data.iter().sum::<f64>() / data.len() as f64;
+        assert!(
+            (classic_loc - expected_mean).abs() < 1e-9,
+            "Classic must locate at the mean, got {classic_loc}"
+        );
+
+        // The mean is dragged toward the outlier; the median is not.
+        assert!(classic_loc < hybrid_loc);
+
+        // Classic's scale is the sample standard deviation, which the outlier
+        // inflates far beyond a MAD-based scale.
+        let (_, hybrid_scale) = loc_and_scale(&values, EsdEstimator::Hybrid).unwrap();
+        assert!(
+            classic_scale > hybrid_scale,
+            "the outlier must inflate Classic's scale ({classic_scale}) past Hybrid's ({hybrid_scale})"
+        );
+    }
+
+    /// The default must be the robust variant, so `METHOD ESD` with no estimator
+    /// token keeps studentizing against median/MAD.
+    #[test]
+    fn default_estimator_is_hybrid() {
+        assert_eq!(EsdEstimator::default(), EsdEstimator::Hybrid);
+        assert_eq!(ESDOutlierOptions::default().estimator, EsdEstimator::Hybrid);
+        assert!(ESDOutlierOptions::default().estimator.is_hybrid());
     }
 
     #[test]
@@ -360,12 +444,13 @@ mod tests {
         // Mean = 2.81, Std = 4.02, max_dev = (10-2.81) = 7.19, R = 1.78
         // t_crit (df=3, p=0.005) = 4.54, Lambda = (4*4.54)/sqrt(25-10+5*20.6) = 1.71
         // Since R > Lambda, index 4 is an outlier.
-        let (anomalies, scores) = esd_test(&data, 0.05, true, 2).unwrap();
+        // The arithmetic above is mean/std, so this case is `Classic`.
+        let (anomalies, scores) = esd_test(&data, 0.05, EsdEstimator::Classic, 2).unwrap();
 
         // outlier at index 4 should be detected
         assert!(anomalies.iter().any(|a| a.index == 4));
 
-        // value 10.0 is above the median, so the signal must be Positive
+        // value 10.0 is above the location estimate, so the signal must be Positive
         let outlier = anomalies.iter().find(|a| a.index == 4).unwrap();
         assert!(matches!(outlier.signal, AnomalySignal::Positive));
         assert_eq!(outlier.value, 10.0);
@@ -393,7 +478,8 @@ mod tests {
     fn test_esd_detects_negative_outlier() {
         // index 0 (value -10.0) is below the median — should be Negative signal
         let data = vec![-10.0, 1.0, 1.1, 0.9, 1.05];
-        let (anomalies, scores) = esd_test(&data, 0.05, false, data.len() / 2).unwrap();
+        let (anomalies, scores) =
+            esd_test(&data, 0.05, EsdEstimator::Hybrid, data.len() / 2).unwrap();
 
         assert!(anomalies.iter().any(|a| a.index == 0));
         let outlier = anomalies.iter().find(|a| a.index == 0).unwrap();
@@ -412,7 +498,8 @@ mod tests {
             2.92, 2.93, 3.21, 3.26, 3.30, 3.59, 3.68, 4.30, 4.64, 5.34, 5.42, 6.01,
         ];
 
-        let result = detect_anomalies_esd(&data, 0.05, true, Some(10)).unwrap();
+        // Rosner's published result is the mean/std procedure, i.e. `Classic`.
+        let result = detect_anomalies_esd(&data, 0.05, EsdEstimator::Classic, Some(10)).unwrap();
         // Rosner's test on this data (with alpha=0.05) detects 3 outliers: 6.01, 5.42, 5.34
         assert_eq!(result.anomalies.len(), 3);
         let indices: Vec<usize> = result.anomalies.iter().map(|a| a.index).collect();

--- a/src/analysis/outliers/esd_outlier_detector.rs
+++ b/src/analysis/outliers/esd_outlier_detector.rs
@@ -1,4 +1,5 @@
 use crate::analysis::math::calculate_median_sorted;
+use crate::analysis::outliers::utils::normalize_evidence;
 use crate::analysis::outliers::{
     Anomaly, AnomalyDetector, AnomalyMethod, AnomalyResult, AnomalySignal,
 };
@@ -121,10 +122,8 @@ fn detect_anomalies_esd(
     // Parameter check: max_outliers
     let max_outliers = match max_outliers {
         Some(m) if m >= n / 2 => {
-            let message = format!(
-                "max_outliers must be less than n/2. Got max_outliers = {} and n = {}",
-                m, n
-            );
+            let message =
+                format!("max_outliers must be less than n/2. Got max_outliers = {m} and n = {n}",);
             let err = TimeSeriesAnalysisError::InvalidParameter {
                 name: "max_outliers".to_string(),
                 message,
@@ -147,17 +146,29 @@ fn detect_anomalies_esd(
     })
 }
 
-/// Map a test statistic and the ESD critical value (lambda) to [0.0, 1.0].
-/// Uses score = stat / (stat + lambda). Handles edge cases.
-fn esd_score_stat_over_stat_plus_lambda(stat: f64, lambda: f64) -> f64 {
-    if !stat.is_finite() || stat <= 0.0 {
-        return 0.0;
+/// A candidate produced by one iteration of the step-down loop, with everything
+/// the decision rule and the score each need.
+///
+/// The statistic and its critical value are kept *as numbers*. The truncation
+/// rule used to recover "was `stat > lambda`?" by asking whether the presentation
+/// score exceeded 0.5, which coupled a statistical decision to a display
+/// convention — and made rescoring the retained candidates impossible without
+/// changing the values the decision reads.
+struct Candidate {
+    index: usize,
+    value: f64,
+    signal: AnomalySignal,
+    /// The studentized statistic for this iteration.
+    stat: f64,
+    /// The critical value this iteration's statistic was tested against.
+    lambda: f64,
+}
+
+impl Candidate {
+    /// Rosner's per-iteration test, asked of the statistics directly.
+    fn rejects_null(&self) -> bool {
+        self.stat > self.lambda
     }
-    if !lambda.is_finite() || lambda <= 0.0 {
-        // Fallback denom to 1.0 to avoid division by zero and still provide a monotonic mapping
-        return (stat / (stat + 1.0)).clamp(0.0, 1.0);
-    }
-    (stat / (stat + lambda)).clamp(0.0, 1.0)
 }
 
 /// Perform the Extreme Studentized Deviate (ESD) test to detect potential outliers in the data.
@@ -180,7 +191,7 @@ fn esd_test(
 
     // masked representation: Some(value) for active, None for masked
     let mut masked: Vec<Option<f64>> = data.iter().cloned().map(Some).collect();
-    let mut anomalies: Vec<Anomaly> = Vec::new();
+    let mut candidates: Vec<Candidate> = Vec::new();
 
     // per-observation scores (original ordering)
     let mut scores: Vec<f64> = vec![0.0; n_total];
@@ -226,12 +237,6 @@ fn esd_test(
         // remember latest lambda
         last_lambda = Some(critical_value);
 
-        // compute normalized score for this candidate
-        let score = esd_score_stat_over_stat_plus_lambda(test_stat, critical_value);
-        if test_idx < scores.len() {
-            scores[test_idx] = score;
-        }
-
         let value = data[test_idx];
         let signal = if value > loc {
             AnomalySignal::Positive
@@ -239,28 +244,73 @@ fn esd_test(
             AnomalySignal::Negative
         };
 
-        anomalies.push(Anomaly {
-            signal,
-            value,
-            score,
+        candidates.push(Candidate {
             index: test_idx,
+            value,
+            signal,
+            stat: test_stat,
+            lambda: critical_value,
         });
 
         // mask that index (in original indexing)
         masked[test_idx] = None;
     }
 
-    // Standard ESD: find the largest k such that R_i > lambda_i for all i <= k
-    let mut k = 0;
-    for (i, anomaly) in anomalies.iter().enumerate() {
-        if anomaly.score > 0.5 {
-            // score > 0.5 means test_stat > critical_value
-            k = i + 1;
-        }
-    }
-    anomalies.truncate(k);
+    // Rosner's step-down rule: find the largest k whose statistic beats its own
+    // critical value, and declare all candidates i <= k outliers — including any
+    // that individually failed their own test. The decision reads the statistics
+    // directly, so it no longer depends on the presentation scale.
+    let k = candidates
+        .iter()
+        .rposition(Candidate::rejects_null)
+        .map_or(0, |i| i + 1);
 
-    // After loop, score any remaining unmasked observations using the last lambda if available.
+    // Candidates past k were tested and not rejected. They keep their own
+    // per-iteration score, which sits at or below 0.5 by construction.
+    for candidate in &candidates[k..] {
+        scores[candidate.index] = normalize_evidence(candidate.stat, candidate.lambda);
+    }
+
+    candidates.truncate(k);
+
+    // Retained candidates are scored against lambda_k — the critical value that
+    // actually justified the family-wise decision — rather than each against its
+    // own. Every retained candidate was admitted by that one test, so that is
+    // the test they should be measured against.
+    //
+    // The statistic is generally non-increasing across iterations (each removes
+    // the most extreme remaining point), so retained candidates land above
+    // lambda_k on their own. That is not guaranteed, though: the scale estimate
+    // shrinks alongside the statistic. Flooring at the accepted statistic keeps
+    // every retained candidate at least as anomalous as the one whose test
+    // admitted the whole family, which is what makes `score > 0.5 <=> flagged`
+    // hold here without a carve-out.
+    let anomalies: Vec<Anomaly> = if let Some(accepted) = candidates.last() {
+        let (lambda_k, stat_k) = (accepted.lambda, accepted.stat);
+        candidates
+            .iter()
+            .map(|candidate| {
+                let score = normalize_evidence(candidate.stat.max(stat_k), lambda_k);
+                scores[candidate.index] = score;
+                Anomaly {
+                    signal: candidate.signal,
+                    value: candidate.value,
+                    score,
+                    index: candidate.index,
+                }
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    // Score whatever the loop never masked. These points were examined and not
+    // rejected, so their scores must sit on the not-flagged side — but `max_out`
+    // can stop the loop with strong outliers still active, whose statistic would
+    // otherwise exceed the last critical value. Widening the boundary to the
+    // largest surviving statistic puts the most extreme of them exactly on 0.5
+    // and the rest below, which keeps them ranked instead of clamping them into
+    // a tie.
     score_active_points(
         &active_points(&masked),
         estimator,
@@ -288,7 +338,7 @@ fn calc_test_statistic(values: &[(usize, f64)], estimator: EsdEstimator) -> (f64
     let (max_idx, max_dev) = values
         .iter()
         .map(|(i, x)| (*i, (x - loc).abs()))
-        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
+        .max_by(|a, b| a.1.total_cmp(&b.1))
         .unwrap();
 
     if scale == 0.0 || scale.is_nan() {
@@ -323,7 +373,7 @@ fn loc_and_scale(values: &[(usize, f64)], estimator: EsdEstimator) -> Option<(f6
         EsdEstimator::Hybrid => {
             let loc = median_values(values);
             let mut abs_devs: Vec<f64> = values.iter().map(|(_, x)| (x - loc).abs()).collect();
-            abs_devs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            abs_devs.sort_by(f64::total_cmp);
             let mad = calculate_median_sorted(&abs_devs);
             // MAD * 1.4826 is a consistent estimator for the standard deviation of a normal distribution
             Some((loc, mad * 1.4826))
@@ -331,7 +381,13 @@ fn loc_and_scale(values: &[(usize, f64)], estimator: EsdEstimator) -> Option<(f6
     }
 }
 
-/// Score a set of active observations using the provided lambda.
+/// Score the observations the step-down loop never rejected.
+///
+/// The boundary is widened to the largest surviving statistic when that exceeds
+/// `lambda`. The procedure declined to reject any of these points, so none of
+/// them may score above 0.5 — but `max_outliers` can halt the loop while genuine
+/// outliers are still active, and those would otherwise beat the last critical
+/// value. Widening rather than clamping keeps the ordering among them intact.
 fn score_active_points(
     values: &[(usize, f64)],
     estimator: EsdEstimator,
@@ -346,10 +402,15 @@ fn score_active_points(
         return;
     }
 
-    for (idx, val) in values.iter() {
-        let stat = (val - loc).abs() / scale;
-        let sc = esd_score_stat_over_stat_plus_lambda(stat, lambda);
-        scores[*idx] = sc;
+    let stats: Vec<(usize, f64)> = values
+        .iter()
+        .map(|(idx, val)| (*idx, (val - loc).abs() / scale))
+        .collect();
+
+    let boundary = stats.iter().map(|(_, stat)| *stat).fold(lambda, f64::max);
+
+    for (idx, stat) in stats {
+        scores[idx] = normalize_evidence(stat, boundary);
     }
 }
 
@@ -372,7 +433,7 @@ fn std_sample_values(values: &[(usize, f64)], mean: f64) -> f64 {
 /// Helper: median for unsorted values (Vec<(idx,f64)>)
 fn median_values(values: &[(usize, f64)]) -> f64 {
     let mut v: Vec<f64> = values.iter().map(|(_, x)| *x).collect();
-    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    v.sort_by(f64::total_cmp);
     calculate_median_sorted(&v)
 }
 
@@ -486,6 +547,105 @@ mod tests {
         assert!(matches!(outlier.signal, AnomalySignal::Negative));
         assert_eq!(outlier.value, -10.0);
         assert_eq!(scores.len(), data.len());
+    }
+
+    /// Rosner's rule admits candidates as a family: every candidate up to the
+    /// largest `k` with `stat_k > lambda_k` is declared an outlier, including
+    /// any that failed its own test. Those retained candidates are scored
+    /// against `lambda_k` — the critical value that actually justified the
+    /// decision — so a flagged sample can never score at or below the boundary.
+    #[test]
+    fn retained_candidates_all_score_past_the_boundary() {
+        let fixtures: Vec<Vec<f64>> = vec![
+            // Rosner (1983).
+            vec![
+                -0.25, 0.68, 0.94, 1.15, 1.20, 1.26, 1.26, 1.34, 1.38, 1.43, 1.49, 1.49, 1.55,
+                1.56, 1.58, 1.65, 1.69, 1.70, 1.76, 1.77, 1.81, 1.91, 1.94, 1.96, 1.99, 2.06, 2.09,
+                2.10, 2.14, 2.15, 2.23, 2.24, 2.26, 2.35, 2.37, 2.40, 2.47, 2.54, 2.62, 2.64, 2.90,
+                2.92, 2.92, 2.93, 3.21, 3.26, 3.30, 3.59, 3.68, 4.30, 4.64, 5.34, 5.42, 6.01,
+            ],
+            // A cluster of outliers on one side, which is where the step-down
+            // rule retains candidates that failed their own test.
+            {
+                let mut v: Vec<f64> = (0..40).map(|i| 10.0 + (i % 5) as f64 * 0.1).collect();
+                v.extend([60.0, 62.0, 64.0, 66.0]);
+                v
+            },
+            // Outliers on both sides.
+            {
+                let mut v: Vec<f64> = (0..40).map(|i| 10.0 + (i % 5) as f64 * 0.1).collect();
+                v.extend([80.0, 82.0, -60.0, -62.0]);
+                v
+            },
+        ];
+
+        for (estimator, alpha) in [
+            (EsdEstimator::Classic, 0.05),
+            (EsdEstimator::Hybrid, 0.05),
+            (EsdEstimator::Classic, 0.2),
+            (EsdEstimator::Hybrid, 0.01),
+        ] {
+            for data in &fixtures {
+                let result =
+                    detect_anomalies_esd(data, alpha, estimator, Some(data.len() / 4)).unwrap();
+
+                let flagged: Vec<usize> = result.anomalies.iter().map(|a| a.index).collect();
+                for (i, &score) in result.scores.iter().enumerate() {
+                    assert_eq!(
+                        score > 0.5,
+                        flagged.contains(&i),
+                        "{estimator:?}/alpha={alpha}: score[{i}] = {score} disagrees with the verdict"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The truncation rule must read the statistics, not the presentation
+    /// score. Coupling them meant a change to the score scale would silently
+    /// change which samples ESD reports — and made rescoring the retained
+    /// candidates impossible, since that changes the values the loop reads.
+    #[test]
+    fn truncation_is_independent_of_the_score_scale() {
+        let mut data: Vec<f64> = (0..40).map(|i| 10.0 + (i % 5) as f64 * 0.1).collect();
+        data.extend([60.0, 62.0, 64.0]);
+
+        let result = detect_anomalies_esd(&data, 0.05, EsdEstimator::Classic, Some(10)).unwrap();
+
+        // The three planted outliers, and nothing else.
+        let mut indices: Vec<usize> = result.anomalies.iter().map(|a| a.index).collect();
+        indices.sort_unstable();
+        assert_eq!(indices, vec![40, 41, 42]);
+    }
+
+    /// `max_outliers` can stop the loop while genuine outliers are still active.
+    /// Those points were not rejected, so they must not read as flagged however
+    /// extreme they are — while still being ranked against each other.
+    #[test]
+    fn unrejected_points_stay_on_the_not_flagged_side() {
+        let mut data: Vec<f64> = (0..40).map(|i| 10.0 + (i % 5) as f64 * 0.1).collect();
+        data.extend([500.0, 400.0, 300.0, 200.0]);
+
+        // Only one removal allowed, so three strong outliers survive the loop.
+        let result = detect_anomalies_esd(&data, 0.05, EsdEstimator::Classic, Some(1)).unwrap();
+
+        let flagged: Vec<usize> = result.anomalies.iter().map(|a| a.index).collect();
+        for (i, &score) in result.scores.iter().enumerate() {
+            assert_eq!(
+                score > 0.5,
+                flagged.contains(&i),
+                "score[{i}] = {score} disagrees with the verdict"
+            );
+        }
+
+        // The survivors are still ordered by how extreme they are.
+        assert!(
+            result.scores[41] > result.scores[42] && result.scores[42] > result.scores[43],
+            "surviving outliers must stay ranked, got {} {} {}",
+            result.scores[41],
+            result.scores[42],
+            result.scores[43]
+        );
     }
 
     #[test]

--- a/src/analysis/outliers/ewma_outlier_detector.rs
+++ b/src/analysis/outliers/ewma_outlier_detector.rs
@@ -1,4 +1,4 @@
-use super::utils::{get_anomaly_direction, normalize_unbounded_score, normalize_value};
+use super::utils::{normalize_evidence, normalize_value};
 use crate::analysis::TimeSeriesAnalysisResult;
 use crate::analysis::math::{calculate_mean, calculate_std_dev};
 use crate::analysis::outliers::{
@@ -63,26 +63,39 @@ impl EwmaOutlierDetector {
                 * (1.0 - (1.0 - self.alpha).powi(2 * (i as i32 + 1)));
             let ewma_std = ewma_variance.sqrt();
 
-            let raw_score = if !ewma_std.is_finite() || ewma_std <= f64::EPSILON {
-                0.0
+            // The smoothed average's departure from target is the evidence; the
+            // control limit that departure is tested against is the boundary.
+            // Both grow with the observation index, which is why the limits are
+            // recomputed each step rather than fixed at `multiplier * sigma`.
+            let deviation = ewma - self.target;
+            let boundary = self.multiplier * ewma_std;
+
+            // A control limit at or below rounding noise is not a limit. The
+            // EWMA recurrence carries its own error — `0.3*3.0 + 0.7*3.0` is not
+            // exactly `3.0` — so a zero-width limit would flag every point of a
+            // constant series on floating-point dust. NaN is the module's
+            // "no boundary to be past" sentinel: it scores 0.0 and fails the
+            // comparison below, so both agree that nothing is testable here.
+            let boundary = if boundary <= f64::EPSILON {
+                f64::NAN
             } else {
-                (ewma - self.target).abs() / ewma_std
+                boundary
             };
 
-            let score = normalize_unbounded_score(raw_score);
+            let score = normalize_evidence(deviation.abs(), boundary);
             scores.push(score);
 
-            if ewma_std <= f64::EPSILON {
-                continue; // No variation, skip anomaly detection
-            }
-
-            let distance = self.multiplier * ewma_std;
-            let ucl = self.target + distance;
-            let lcl = self.target - distance;
-
-            // Fix: Handle zero variance case where ucl == lcl == target
-            // If distance is effectively zero, we only flag anomalies if there is a real deviation
-            let signal = get_anomaly_direction(lcl, ucl, ewma);
+            // A NaN limit — the degenerate case above — fails this comparison,
+            // which is how it stays unflagged.
+            let signal = if deviation.abs() > boundary {
+                if deviation > 0.0 {
+                    AnomalySignal::Positive
+                } else {
+                    AnomalySignal::Negative
+                }
+            } else {
+                AnomalySignal::None
+            };
 
             if signal != AnomalySignal::None {
                 anomalies.push(Anomaly {

--- a/src/analysis/outliers/iqr_outlier_detector.rs
+++ b/src/analysis/outliers/iqr_outlier_detector.rs
@@ -1,4 +1,4 @@
-use super::utils::{normalize_evidence, normalize_value};
+use super::utils::{deviation_and_fence_distance, normalize_evidence, normalize_value};
 use crate::analysis::TimeSeriesAnalysisResult;
 use crate::analysis::outliers::{
     AnomalyDetector, AnomalyMethod, AnomalyResult, AnomalySignal, MethodInfo, PointDetector,
@@ -56,13 +56,7 @@ impl IQROutlierDetector {
     /// read this pair, so they cannot disagree about which side a value is on.
     #[inline]
     fn deviation_and_boundary(&self, value: f64) -> (f64, f64) {
-        let deviation = value - self.center;
-        let boundary = if deviation >= 0.0 {
-            self.upper_fence - self.center
-        } else {
-            self.center - self.lower_fence
-        };
-        (deviation, boundary)
+        deviation_and_fence_distance(value, self.center, self.lower_fence, self.upper_fence)
     }
 
     pub fn detect(&mut self, ts: &[f64]) -> TimeSeriesAnalysisResult<AnomalyResult> {

--- a/src/analysis/outliers/iqr_outlier_detector.rs
+++ b/src/analysis/outliers/iqr_outlier_detector.rs
@@ -1,4 +1,4 @@
-use super::utils::{get_anomaly_direction, normalize_unbounded_score, normalize_value};
+use super::utils::{normalize_evidence, normalize_value};
 use crate::analysis::TimeSeriesAnalysisResult;
 use crate::analysis::outliers::{
     AnomalyDetector, AnomalyMethod, AnomalyResult, AnomalySignal, MethodInfo, PointDetector,
@@ -12,6 +12,10 @@ pub const IQR_DEFAULT_THRESHOLD: f64 = 1.5;
 pub struct IQROutlierDetector {
     lower_fence: f64,
     upper_fence: f64,
+    /// Quartile midpoint `(Q1 + Q3) / 2`. Both fences extend from their own
+    /// quartile by the same `T * IQR`, so they sit symmetrically about this
+    /// point — which makes it the center evidence is measured from.
+    center: f64,
     iqr: f64,
     threshold: f64,
 }
@@ -36,9 +40,29 @@ impl IQROutlierDetector {
         IQROutlierDetector {
             lower_fence,
             upper_fence,
+            center: (q1 + q3) / 2.0,
             iqr,
             threshold,
         }
+    }
+
+    /// Deviation from the quartile midpoint, and the distance out to the fence.
+    ///
+    /// `upper_fence - center == center - lower_fence == IQR * (0.5 + T)`, since
+    /// each fence extends `T * IQR` past its own quartile. The distance is read
+    /// off the fences rather than recomputed, so a value sitting exactly on a
+    /// reported fence produces evidence and boundary from the identical
+    /// subtraction and scores exactly `0.5`. Scoring and classification both
+    /// read this pair, so they cannot disagree about which side a value is on.
+    #[inline]
+    fn deviation_and_boundary(&self, value: f64) -> (f64, f64) {
+        let deviation = value - self.center;
+        let boundary = if deviation >= 0.0 {
+            self.upper_fence - self.center
+        } else {
+            self.center - self.lower_fence
+        };
+        (deviation, boundary)
     }
 
     pub fn detect(&mut self, ts: &[f64]) -> TimeSeriesAnalysisResult<AnomalyResult> {
@@ -55,7 +79,7 @@ impl AnomalyDetector for IQROutlierDetector {
         Some(MethodInfo::Fenced {
             lower_fence: self.lower_fence,
             upper_fence: self.upper_fence,
-            center_line: Some((self.lower_fence + self.upper_fence) / 2.0),
+            center_line: Some(self.center),
         })
     }
 
@@ -65,25 +89,31 @@ impl AnomalyDetector for IQROutlierDetector {
 }
 
 impl PointDetector for IQROutlierDetector {
+    /// Evidence is the distance from the quartile midpoint, not the distance
+    /// *past* the fence.
+    ///
+    /// Measuring past the fence meant every in-range sample scored exactly
+    /// `0.0` — the majority of any series, and the whole purpose of `FULL`
+    /// output. A near-miss was indistinguishable from a sample sitting on the
+    /// median.
     fn score(&self, value: f64) -> f64 {
-        // Guard against degenerate IQR to avoid division by zero / NaN.
-        if !self.iqr.is_finite() || self.iqr <= f64::EPSILON {
-            return 0.0;
-        }
-
-        let raw = if value < self.lower_fence {
-            (self.lower_fence - value) / self.iqr
-        } else if value > self.upper_fence {
-            (value - self.upper_fence) / self.iqr
-        } else {
-            0.0
-        };
-
-        normalize_unbounded_score(raw)
+        let (deviation, boundary) = self.deviation_and_boundary(value);
+        normalize_evidence(deviation.abs(), boundary)
     }
 
     fn classify(&self, value: f64) -> AnomalySignal {
-        get_anomaly_direction(self.lower_fence, self.upper_fence, value)
+        let (deviation, boundary) = self.deviation_and_boundary(value);
+        // A NaN on either side — a missing reading, or a scale that was never
+        // fitted — fails this comparison, which is how it stays unflagged.
+        if deviation.abs() > boundary {
+            if deviation > 0.0 {
+                AnomalySignal::Positive
+            } else {
+                AnomalySignal::Negative
+            }
+        } else {
+            AnomalySignal::None
+        }
     }
 }
 
@@ -99,6 +129,7 @@ pub(super) fn detect_anomalies_iqr(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::analysis::outliers::MethodInfo;
     use crate::analysis::outliers::iqr_outlier_detector::detect_anomalies_iqr;
 
@@ -144,6 +175,78 @@ mod tests {
         for score in &result.scores {
             assert!(score.is_finite(), "Score should be finite");
             assert!(*score >= 0.0, "Score should be non-negative");
+        }
+    }
+
+    /// In-range samples must be graded, not flattened.
+    ///
+    /// Evidence used to be the distance *past* the fence, so every sample inside
+    /// the fences scored exactly `0.0` — the majority of any series, and the
+    /// whole reason `FULL` output has a score column. A near-miss was
+    /// indistinguishable from a sample sitting on the median.
+    #[test]
+    fn test_iqr_grades_samples_inside_the_fences() {
+        let values: Vec<f64> = (0..24).map(|i| 40.0 + (i % 6) as f64).collect();
+
+        let detector = IQROutlierDetector::new(&values, 1.5);
+        let result = detect_anomalies_iqr(&values, Some(1.5)).unwrap();
+
+        assert!(
+            result.anomalies.is_empty(),
+            "no sample in this spread is outside the fences, got {:?}",
+            result.anomalies
+        );
+
+        // Nothing was flagged, so every score sits at or below the boundary...
+        for (i, &score) in result.scores.iter().enumerate() {
+            assert!(
+                score <= 0.5,
+                "unflagged sample {i} scored {score}, above the boundary"
+            );
+        }
+
+        // ...and they are still ranked by distance from the center, which used
+        // to be a column of identical zeros.
+        let center = detector.center;
+        let at_center = detector.score(center);
+        let near = detector.score(center + 1.0);
+        let far = detector.score(center + 2.0);
+
+        assert_eq!(at_center, 0.0, "a sample at the center is maximally normal");
+        assert!(
+            at_center < near && near < far && far < 0.5,
+            "expected in-range samples to be ranked, got {at_center} < {near} < {far}"
+        );
+    }
+
+    /// The score crosses 0.5 exactly at the fences the method reports.
+    #[test]
+    fn test_iqr_boundary_sits_at_one_half() {
+        let values: Vec<f64> = (0..24).map(|i| 40.0 + (i % 6) as f64).collect();
+
+        let mut detector = IQROutlierDetector::new(&values, 1.5);
+        let result = detector.detect(&values).unwrap();
+
+        let Some(MethodInfo::Fenced {
+            lower_fence,
+            upper_fence,
+            ..
+        }) = result.method_info
+        else {
+            panic!("IQR reports fences");
+        };
+
+        for fence in [lower_fence, upper_fence] {
+            assert!(
+                (detector.score(fence) - 0.5).abs() < 1e-12,
+                "the fence at {fence} scored {}, expected exactly 0.5",
+                detector.score(fence)
+            );
+            assert_eq!(
+                detector.classify(fence),
+                AnomalySignal::None,
+                "the fence belongs to the not-flagged side"
+            );
         }
     }
 

--- a/src/analysis/outliers/iqr_outlier_detector.rs
+++ b/src/analysis/outliers/iqr_outlier_detector.rs
@@ -127,6 +127,20 @@ mod tests {
     use crate::analysis::outliers::MethodInfo;
     use crate::analysis::outliers::iqr_outlier_detector::detect_anomalies_iqr;
 
+    /// A negative threshold inverts the fences. Before `deviation_and_boundary`
+    /// mapped a negative fence distance to NaN, this flagged essentially every
+    /// point — including the quartile midpoint itself — while still scoring it
+    /// `0.0`, since `normalize_evidence` already treated the negative boundary
+    /// as unusable. Both must now agree that there is nothing to be past.
+    #[test]
+    fn negative_threshold_does_not_flag_the_center() {
+        let values: Vec<f64> = (0..24).map(|i| 40.0 + (i % 6) as f64).collect();
+        let detector = IQROutlierDetector::new(&values, -1.5);
+
+        assert_eq!(detector.classify(detector.center), AnomalySignal::None);
+        assert_eq!(detector.score(detector.center), 0.0);
+    }
+
     #[test]
     fn test_iqr_anomaly_detection() {
         let mut ts = vec![1.0; 100];

--- a/src/analysis/outliers/mad_outlier_detector.rs
+++ b/src/analysis/outliers/mad_outlier_detector.rs
@@ -3,6 +3,7 @@ use crate::analysis::outliers::mad_estimator::{
     HarrellDavisNormalizedEstimator, InvariantMADEstimator, MedianAbsoluteDeviationEstimator,
     SimpleNormalizedEstimator,
 };
+use crate::analysis::outliers::utils::normalize_evidence;
 use crate::analysis::outliers::{
     AnomalyDetector, AnomalyMADEstimator, AnomalyMethod, AnomalyResult, AnomalySignal, MethodInfo,
     PointDetector, detect_pointwise,
@@ -54,7 +55,7 @@ impl MadOutlierDetector {
 
     /// Returns whether a value is an outlier, according to the detector.
     pub fn is_outlier(&self, value: f64) -> bool {
-        value < self.lower_fence || value > self.upper_fence
+        self.classify(value).is_anomaly()
     }
 
     /// Returns the lower fence.
@@ -67,35 +68,42 @@ impl MadOutlierDetector {
         self.upper_fence
     }
 
+    /// Deviation from the median, and the distance out to the fence on the
+    /// value's own side.
+    ///
+    /// The single source of truth for scoring and classification, so the two
+    /// cannot disagree about which side of the fence a value falls on. The
+    /// boundary is taken as `fence - median` rather than the algebraically equal
+    /// `k * mad` so that a value sitting *exactly on the reported fence* yields
+    /// evidence and boundary from the identical subtraction, and therefore
+    /// scores exactly `0.5`. Recomputing `k * mad` instead leaves the two
+    /// differing by a rounding step, which lands the fence on the flagged side.
+    #[inline]
+    fn deviation_and_boundary(&self, value: f64) -> (f64, f64) {
+        let deviation = value - self.median;
+        let boundary = if deviation >= 0.0 {
+            self.upper_fence - self.median
+        } else {
+            self.median - self.lower_fence
+        };
+        (deviation, boundary)
+    }
+
     /// Returns a normalized anomaly score in `[0..1]` describing how "anomalous" `value` is.
     ///
     /// Interpretation:
     /// - `0.0` means "at the median" (no deviation).
-    /// - `1.0` means "at or beyond the configured MAD fence" (i.e., `k * mad` away from the median).
+    /// - `0.5` means "exactly on the configured MAD fence" (i.e., `k * mad` away
+    ///   from the median).
+    /// - values approaching `1.0` lie progressively further beyond the fence.
     ///
-    /// This is computed as:
-    /// `score = clamp(|value - median| / (k * mad), 0..1)`
-    /// where `k` is inferred from the detector's fences.
+    /// This used to `clamp(|value - median| / (k * mad), 0..1)`, which saturated
+    /// at the fence: a point 3.1 MADs out and one 300 MADs out both scored
+    /// exactly `1.0`, so the field advertised as a score carried no ranking at
+    /// all among the samples it had flagged.
     pub fn get_anomaly_score(&self, value: f64) -> f64 {
-        if !value.is_finite() {
-            return 0.0;
-        }
-        if !self.mad.is_finite() || self.mad <= 0.0 {
-            return 0.0;
-        }
-
-        let k = self.k;
-        if !k.is_finite() || k <= 0.0 {
-            return 0.0;
-        }
-
-        let denom = k * self.mad;
-        if !denom.is_finite() || denom <= 0.0 {
-            return 0.0;
-        }
-
-        let raw = (value - self.median).abs() / denom;
-        raw.clamp(0.0, 1.0)
+        let (deviation, boundary) = self.deviation_and_boundary(value);
+        normalize_evidence(deviation.abs(), boundary)
     }
 
     pub fn detect(&mut self, ts: &[f64]) -> TimeSeriesAnalysisResult<AnomalyResult> {
@@ -163,10 +171,15 @@ impl PointDetector for MadOutlierDetector {
     }
 
     fn classify(&self, value: f64) -> AnomalySignal {
-        if value < self.lower_fence {
-            AnomalySignal::Negative
-        } else if value > self.upper_fence {
-            AnomalySignal::Positive
+        let (deviation, boundary) = self.deviation_and_boundary(value);
+        // A NaN on either side — a missing reading, or a scale that was never
+        // fitted — fails this comparison, which is how it stays unflagged.
+        if deviation.abs() > boundary {
+            if deviation > 0.0 {
+                AnomalySignal::Positive
+            } else {
+                AnomalySignal::Negative
+            }
         } else {
             AnomalySignal::None
         }
@@ -200,16 +213,48 @@ mod tests {
         let score_at_median = detector.get_anomaly_score(2.0);
         assert_eq!(score_at_median, 0.0);
 
-        // Exactly at the upper fence should be 1.0
+        // Exactly at the upper fence is the detection boundary, so 0.5.
         let score_at_upper_fence = detector.get_anomaly_score(detector.upper_fence());
-        assert!((score_at_upper_fence - 1.0).abs() < f64::EPSILON);
+        assert!(
+            (score_at_upper_fence - 0.5).abs() < 1e-9,
+            "the fence is the boundary and must score 0.5, got {score_at_upper_fence}"
+        );
 
-        // Beyond the fence clamps to 1.0
+        // Beyond the fence the score keeps climbing without ever reaching 1.0.
         let score_beyond = detector.get_anomaly_score(1e9);
-        assert!((score_beyond - 1.0).abs() < f64::EPSILON);
+        assert!(
+            score_beyond > 0.5 && score_beyond < 1.0,
+            "expected a strictly-inside-(0.5, 1.0) score past the fence, got {score_beyond}"
+        );
 
-        // Non-finite values are treated as non-anomalous for scoring purposes
+        // A missing reading is not evidence of an anomaly.
         let score_nan = detector.get_anomaly_score(f64::NAN);
         assert_eq!(score_nan, 0.0);
+
+        // An infinite reading is maximally anomalous, and is flagged as such.
+        assert_eq!(detector.get_anomaly_score(f64::INFINITY), 1.0);
+        assert!(detector.is_outlier(f64::INFINITY));
+    }
+
+    /// The saturation this replaced made every flagged sample score exactly
+    /// `1.0`, so `FULL` output could not tell a marginal outlier from an extreme
+    /// one.
+    #[test]
+    fn test_scores_rank_samples_beyond_the_fence() {
+        let data = [1.0, 2.0, 2.0, 2.0, 3.0, 14.0];
+        let mut detector = MadOutlierDetector::default();
+        detector.train(&data).unwrap();
+
+        let fence = detector.upper_fence();
+        let span = fence - detector.median;
+
+        let just_past = detector.get_anomaly_score(fence + span * 0.1);
+        let well_past = detector.get_anomaly_score(fence + span * 10.0);
+        let far_past = detector.get_anomaly_score(fence + span * 1000.0);
+
+        assert!(
+            0.5 < just_past && just_past < well_past && well_past < far_past && far_past < 1.0,
+            "expected a strict ranking, got {just_past} < {well_past} < {far_past}"
+        );
     }
 }

--- a/src/analysis/outliers/mad_outlier_detector.rs
+++ b/src/analysis/outliers/mad_outlier_detector.rs
@@ -3,7 +3,7 @@ use crate::analysis::outliers::mad_estimator::{
     HarrellDavisNormalizedEstimator, InvariantMADEstimator, MedianAbsoluteDeviationEstimator,
     SimpleNormalizedEstimator,
 };
-use crate::analysis::outliers::utils::normalize_evidence;
+use crate::analysis::outliers::utils::{deviation_and_fence_distance, normalize_evidence};
 use crate::analysis::outliers::{
     AnomalyDetector, AnomalyMADEstimator, AnomalyMethod, AnomalyResult, AnomalySignal, MethodInfo,
     PointDetector, detect_pointwise,
@@ -80,13 +80,7 @@ impl MadOutlierDetector {
     /// differing by a rounding step, which lands the fence on the flagged side.
     #[inline]
     fn deviation_and_boundary(&self, value: f64) -> (f64, f64) {
-        let deviation = value - self.median;
-        let boundary = if deviation >= 0.0 {
-            self.upper_fence - self.median
-        } else {
-            self.median - self.lower_fence
-        };
-        (deviation, boundary)
+        deviation_and_fence_distance(value, self.median, self.lower_fence, self.upper_fence)
     }
 
     /// Returns a normalized anomaly score in `[0..1]` describing how "anomalous" `value` is.

--- a/src/analysis/outliers/mad_outlier_detector.rs
+++ b/src/analysis/outliers/mad_outlier_detector.rs
@@ -125,6 +125,14 @@ impl AnomalyDetector for MadOutlierDetector {
             estimator: impl MedianAbsoluteDeviationEstimator,
         ) -> (f64, f64) {
             let samples = Samples::from(data.to_vec());
+            // Every reading was NaN (missing): nothing survived filtering, and
+            // the quantile estimators index into `sample.values`
+            // unconditionally, panicking on an empty sample. NaN here is the
+            // detector's own untrained state (see `Default`), which already
+            // reads as "nothing to measure against" everywhere fences are used.
+            if samples.is_empty() {
+                return (f64::NAN, f64::NAN);
+            }
             let median = estimator.quantile_estimator().median(&samples);
             let mad = estimator.mad(&samples);
             (median, mad)
@@ -197,6 +205,23 @@ mod tests {
 
         assert!(!detector.is_outlier(detector.median));
         assert_eq!(detector.get_anomaly_score(detector.median), 0.0);
+    }
+
+    /// All-NaN training data (every reading in the window was missing) used to
+    /// panic: NaN filtering left `Samples` empty, and the quantile estimators
+    /// index into `sample.values` unconditionally. Training must instead land
+    /// in the detector's own untrained-equivalent state — NaN fences — so
+    /// nothing is flagged.
+    #[test]
+    fn train_on_all_nan_data_does_not_panic() {
+        let data = [f64::NAN, f64::NAN, f64::NAN];
+        let mut detector = MadOutlierDetector::default();
+        detector.train(&data).unwrap();
+
+        assert!(detector.median.is_nan());
+        assert!(detector.mad.is_nan());
+        assert!(!detector.is_outlier(0.0));
+        assert_eq!(detector.get_anomaly_score(0.0), 0.0);
     }
 
     #[test]

--- a/src/analysis/outliers/mad_outlier_detector.rs
+++ b/src/analysis/outliers/mad_outlier_detector.rs
@@ -184,6 +184,21 @@ impl PointDetector for MadOutlierDetector {
 mod tests {
     use super::*;
 
+    /// A negative `k` inverts the fences. Before `deviation_and_boundary`
+    /// mapped a negative fence distance to NaN, this flagged essentially every
+    /// point — including the median itself — while still scoring it `0.0`,
+    /// since `normalize_evidence` already treated the negative boundary as
+    /// unusable. Both must now agree that there is nothing to be past.
+    #[test]
+    fn negative_k_does_not_flag_the_median() {
+        let data = [1.0, 2.0, 2.0, 2.0, 3.0, 14.0];
+        let mut detector = MadOutlierDetector::new(-3.0, AnomalyMADEstimator::Simple);
+        detector.train(&data).unwrap();
+
+        assert!(!detector.is_outlier(detector.median));
+        assert_eq!(detector.get_anomaly_score(detector.median), 0.0);
+    }
+
     #[test]
     fn test_mad_outlier_detector() {
         let data = [1.0, 2.0, 2.0, 2.0, 3.0, 14.0];

--- a/src/analysis/outliers/mod.rs
+++ b/src/analysis/outliers/mod.rs
@@ -15,6 +15,8 @@ mod modified_zscore_outlier_detector;
 #[cfg(test)]
 mod outlier_test_data;
 mod rcf_outlier_detector;
+#[cfg(test)]
+mod score_contract_tests;
 mod smoothed_zscores;
 mod utils;
 mod zscore_outlier_detector;
@@ -263,11 +265,29 @@ impl Anomaly {
 /// Result of anomaly detection
 #[derive(Debug, Clone)]
 pub struct AnomalyResult {
-    /// Anomaly scores for each point (higher scores indicate more anomalous)
+    /// Anomaly score for each point, in `[0, 1]`, higher being more anomalous.
+    ///
+    /// On the score scale the detection boundary is always `0.5` — see the
+    /// contract on [`AnomalyDetector::detect`]. Scores are therefore comparable
+    /// across methods and across threshold settings, which raw statistics are
+    /// not.
+    ///
+    /// When `SEASONALITY` is requested, detection runs on the seasonally
+    /// adjusted residuals and only [`Anomaly::value`] is restored to the
+    /// original observation. These scores stay in the adjusted domain: they
+    /// describe the residual, which is what was actually tested. Two scores are
+    /// comparable only when computed over the same domain.
     pub scores: Vec<f64>,
     /// Detected anomalies
     pub anomalies: Vec<Anomaly>,
-    /// Threshold used for binary classification
+    /// Threshold used for binary classification, on the *method's own* scale —
+    /// z-score multiples for `zscore`, `k` for `mad`, the decision interval `h`
+    /// for `cusum`, a contamination fraction for `rcf`, and so on. It is echoed
+    /// to clients in `parameters` to document what was requested.
+    ///
+    /// This is deliberately *not* rescaled onto the score scale. On the score
+    /// scale the boundary is always `0.5`, which is what makes this field
+    /// unnecessary as a comparison anchor.
     pub threshold: f64,
     /// Method used for detection
     pub method: AnomalyMethod,
@@ -389,6 +409,32 @@ pub trait AnomalyDetector {
     ///
     /// Implementations must return exactly one score per element of `ts`, each
     /// in `[0, 1]`, and every `Anomaly::index` must index into `ts`.
+    ///
+    /// # The 0.5 contract
+    ///
+    /// A sample scores exactly `0.5` at the method's detection boundary, so
+    /// `score > 0.5` ⟺ flagged and `score <= 0.5` ⟺ not flagged. The boundary
+    /// belongs to the not-flagged side, matching the strict comparisons every
+    /// classifier here uses. Scores are strictly monotone in evidence; `0.0` and
+    /// `1.0` are asymptotic, reached only by degenerate or non-finite input.
+    ///
+    /// Implementations get this by reducing their verdict to an
+    /// evidence/boundary pair and handing it to
+    /// [`normalize_evidence`](utils::normalize_evidence) — never by normalizing
+    /// raw evidence, which would anchor the boundary wherever the threshold
+    /// happened to put it and make scores incomparable across methods.
+    ///
+    /// Three windows are exempt, because they are scored without ever being
+    /// classified:
+    ///
+    /// - RCF's warmup window (`0..output_after`),
+    /// - the smoothed z-score's first `lag` samples,
+    /// - ESD's retained candidates, which Rosner's step-down rule admits as a
+    ///   family rather than individually.
+    ///
+    /// `±∞` observations are maximally anomalous: they score `1.0` and are
+    /// flagged. `NaN` observations score `0.0` and are never flagged — a missing
+    /// reading is not evidence of an anomaly.
     fn detect(&mut self, ts: &[f64]) -> TimeSeriesAnalysisResult<AnomalyResult>;
 }
 
@@ -480,7 +526,7 @@ mod tests {
 
     impl PointDetector for FenceDetector {
         fn score(&self, value: f64) -> f64 {
-            utils::normalize_unbounded_score((value.abs() - 1.0).max(0.0))
+            utils::normalize_evidence((value.abs() - 1.0).max(0.0), 1.0)
         }
 
         fn classify(&self, value: f64) -> AnomalySignal {

--- a/src/analysis/outliers/mod.rs
+++ b/src/analysis/outliers/mod.rs
@@ -424,13 +424,11 @@ pub trait AnomalyDetector {
     /// raw evidence, which would anchor the boundary wherever the threshold
     /// happened to put it and make scores incomparable across methods.
     ///
-    /// Three windows are exempt, because they are scored without ever being
+    /// Two windows are exempt, because they are scored without ever being
     /// classified:
     ///
     /// - RCF's warmup window (`0..output_after`),
-    /// - the smoothed z-score's first `lag` samples,
-    /// - ESD's retained candidates, which Rosner's step-down rule admits as a
-    ///   family rather than individually.
+    /// - the smoothed z-score's first `lag` samples.
     ///
     /// `±∞` observations are maximally anomalous: they score `1.0` and are
     /// flagged. `NaN` observations score `0.0` and are never flagged — a missing

--- a/src/analysis/outliers/modified_zscore_outlier_detector.rs
+++ b/src/analysis/outliers/modified_zscore_outlier_detector.rs
@@ -170,6 +170,23 @@ fn detect_anomalies_modified_zscore(
 #[cfg(test)]
 mod tests {
     use super::detect_anomalies_modified_zscore;
+    use super::*;
+    use crate::analysis::outliers::{AnomalyDetector, AnomalySignal, PointDetector};
+
+    /// A negative threshold inverts the fences. Before `deviation_and_boundary`
+    /// mapped a negative fence distance to NaN, this flagged essentially every
+    /// point — including the median itself — while still scoring it `0.0`,
+    /// since `normalize_evidence` already treated the negative boundary as
+    /// unusable. Both must now agree that there is nothing to be past.
+    #[test]
+    fn negative_threshold_does_not_flag_the_median() {
+        let ts = vec![1.0, 2.0, 1.5, 2.2, 1.8, 10.0, 2.1, 1.9];
+        let mut detector = ModifiedZScoreOutlierDetector::new(-3.5);
+        detector.train(&ts).unwrap();
+
+        assert_eq!(detector.classify(detector.median), AnomalySignal::None);
+        assert_eq!(detector.score(detector.median), 0.0);
+    }
 
     #[test]
     fn test_modified_zscore() {

--- a/src/analysis/outliers/modified_zscore_outlier_detector.rs
+++ b/src/analysis/outliers/modified_zscore_outlier_detector.rs
@@ -1,4 +1,4 @@
-use super::utils::{normalize_unbounded_score, normalize_value};
+use super::utils::{normalize_evidence, normalize_value};
 use crate::analysis::TimeSeriesAnalysisResult;
 use crate::analysis::math::calculate_median_sorted;
 use crate::analysis::outliers::{
@@ -37,9 +37,13 @@ impl ModifiedZScoreOutlierDetector {
         }
     }
 
+    /// NaN propagates rather than being substituted with `0.0`: the substitute
+    /// is a real position in the data, so it scores and classifies as if the
+    /// missing reading were a genuine observation at zero. A NaN statistic
+    /// scores `0.0` and fails every `>` comparison in `classify`, which is the
+    /// treatment a missing reading should get.
     #[inline]
     fn get_modified_zscore(&self, value: f64) -> f64 {
-        let value = normalize_value(value);
         if self.mad_scaled > 1e-10 {
             0.6745 * (value - self.median) / self.mad
         } else {
@@ -47,10 +51,46 @@ impl ModifiedZScoreOutlierDetector {
         }
     }
 
+    /// Deviation from the median, and the distance out to the fence.
+    ///
+    /// `|0.6745 * (v - med) / MAD| > T` is the same test as
+    /// `|v - med| > T * MAD/0.6745`, but only the second form is what
+    /// `model_info` reports as a fence. Deriving scoring, classification, and
+    /// the reported fences from this one pair keeps them from disagreeing by a
+    /// rounding step about a value sitting exactly on the fence.
+    #[inline]
+    fn deviation_and_boundary(&self, value: f64) -> (f64, f64) {
+        let deviation = value - self.median;
+        if self.mad_scaled <= 1e-10 {
+            // No usable scale: nothing to be past.
+            return (deviation, f64::NAN);
+        }
+        let (lower_fence, upper_fence) = self.fences();
+        let boundary = if deviation >= 0.0 {
+            upper_fence - self.median
+        } else {
+            self.median - lower_fence
+        };
+        (deviation, boundary)
+    }
+
+    /// The fences `model_info` reports, and the ones `deviation_and_boundary`
+    /// measures against. One definition, so they cannot drift apart.
+    #[inline]
+    fn fences(&self) -> (f64, f64) {
+        let delta = if self.mad_scaled > 1e-10 {
+            self.threshold * self.mad_scaled
+        } else {
+            0.0
+        };
+        (self.median - delta, self.median + delta)
+    }
+
     pub fn detect(&self, ts: &[f64]) -> TimeSeriesAnalysisResult<AnomalyResult> {
         Ok(detect_pointwise(self, ts, self.threshold))
     }
 }
+
 impl AnomalyDetector for ModifiedZScoreOutlierDetector {
     fn method(&self) -> AnomalyMethod {
         AnomalyMethod::ModifiedZScore
@@ -59,16 +99,12 @@ impl AnomalyDetector for ModifiedZScoreOutlierDetector {
     fn model_info(&self) -> Option<MethodInfo> {
         // Modified Z-score threshold |z| > T translates to:
         // x < median - T * (MAD / 0.6745)  OR  x > median + T * (MAD / 0.6745)
-        let delta = if self.mad_scaled > 1e-10 {
-            self.threshold * self.mad_scaled
-        } else {
-            0.0
-        };
+        let (lower_fence, upper_fence) = self.fences();
 
         Some(MethodInfo::Fenced {
-            lower_fence: self.median - delta,
-            upper_fence: self.median + delta,
-            center_line: None,
+            lower_fence,
+            upper_fence,
+            center_line: Some(self.median),
         })
     }
 
@@ -102,16 +138,20 @@ impl AnomalyDetector for ModifiedZScoreOutlierDetector {
 }
 
 impl PointDetector for ModifiedZScoreOutlierDetector {
+    /// Evidence is the departure from the median against the fence distance it
+    /// is tested against, so the score crosses 0.5 exactly where `classify`
+    /// starts flagging — for any threshold, rather than at 0.778 for `T=3.5`.
     fn score(&self, value: f64) -> f64 {
-        let modified_zscore = self.get_modified_zscore(value).abs();
-        normalize_unbounded_score(modified_zscore)
+        let (deviation, boundary) = self.deviation_and_boundary(value);
+        normalize_evidence(deviation.abs(), boundary)
     }
 
     fn classify(&self, value: f64) -> AnomalySignal {
-        let modified_zscore = self.get_modified_zscore(value);
-        let z_abs = modified_zscore.abs();
-        if z_abs > self.threshold {
-            if modified_zscore > 0.0 {
+        let (deviation, boundary) = self.deviation_and_boundary(value);
+        // A NaN on either side — a missing reading, or a scale that was never
+        // fitted — fails this comparison, which is how it stays unflagged.
+        if deviation.abs() > boundary {
+            if deviation > 0.0 {
                 AnomalySignal::Positive
             } else {
                 AnomalySignal::Negative
@@ -147,8 +187,22 @@ mod tests {
         // Should detect the outlier at index 5
         assert_eq!(result.anomalies[0].value, 10.0, "Should detect one anomaly");
         assert!(
-            result.anomalies[0].score > 0.9,
-            "Anomaly score should be high for outlier"
+            result.anomalies[0].score > 0.5,
+            "an outlier must score past the 0.5 boundary, got {}",
+            result.anomalies[0].score
+        );
+        // ...and outrank every sample that was not flagged.
+        let highest_normal = result
+            .scores
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != 5)
+            .map(|(_, s)| *s)
+            .fold(0.0f64, f64::max);
+        assert!(
+            highest_normal < 0.5 && highest_normal < result.anomalies[0].score,
+            "the outlier ({}) must outrank every in-range sample ({highest_normal})",
+            result.anomalies[0].score
         );
     }
 }

--- a/src/analysis/outliers/modified_zscore_outlier_detector.rs
+++ b/src/analysis/outliers/modified_zscore_outlier_detector.rs
@@ -1,4 +1,4 @@
-use super::utils::{normalize_evidence, normalize_value};
+use super::utils::{deviation_and_fence_distance, normalize_evidence, normalize_value};
 use crate::analysis::TimeSeriesAnalysisResult;
 use crate::analysis::math::calculate_median_sorted;
 use crate::analysis::outliers::{
@@ -60,18 +60,12 @@ impl ModifiedZScoreOutlierDetector {
     /// rounding step about a value sitting exactly on the fence.
     #[inline]
     fn deviation_and_boundary(&self, value: f64) -> (f64, f64) {
-        let deviation = value - self.median;
         if self.mad_scaled <= 1e-10 {
             // No usable scale: nothing to be past.
-            return (deviation, f64::NAN);
+            return (value - self.median, f64::NAN);
         }
         let (lower_fence, upper_fence) = self.fences();
-        let boundary = if deviation >= 0.0 {
-            upper_fence - self.median
-        } else {
-            self.median - lower_fence
-        };
-        (deviation, boundary)
+        deviation_and_fence_distance(value, self.median, lower_fence, upper_fence)
     }
 
     /// The fences `model_info` reports, and the ones `deviation_and_boundary`

--- a/src/analysis/outliers/rcf_outlier_detector.rs
+++ b/src/analysis/outliers/rcf_outlier_detector.rs
@@ -1,4 +1,4 @@
-use super::utils::normalize_unbounded_score;
+use super::utils::normalize_evidence;
 use crate::analysis::math::{calculate_mean, calculate_mean_std_dev, quantile};
 use crate::analysis::outliers::{
     Anomaly, AnomalyDetector, AnomalyMethod, AnomalyResult, AnomalySignal,
@@ -280,19 +280,11 @@ impl RcfOutlierDetector {
     ///
     /// # Score consistency
     ///
-    /// All score-related fields in the returned [`AnomalyResult`] are normalized to the
-    /// `[0, 1]` range:
-    ///
-    /// | Field                     | Scale        |
-    /// |---------------------------|--------------|
-    /// | `AnomalyResult::scores[i]`| [0, 1]       |
-    /// | `Anomaly::score`          | [0, 1]       |
-    /// | `AnomalyResult::threshold`| depends      |
-    ///
-    /// For `StdDev` thresholding, `AnomalyResult::threshold` is the raw Z-score cutoff.
-    /// For `Contamination` thresholding, it is the normalized RCF score at the quantile.
-    ///
-    /// Callers can apply [`normalize_rcf_score`] to any raw RCF score.
+    /// Both modes report scores on the module-wide scale: `0.5` sits exactly on
+    /// the cutoff, so `score > 0.5` ⟺ flagged, whichever threshold mode is in
+    /// use. `AnomalyResult::threshold` stays on the *requested* scale — the
+    /// standard-deviation multiple, or the contamination fraction — since that
+    /// is what is echoed back in `parameters`.
     ///
     /// # Direction
     ///
@@ -353,53 +345,62 @@ impl RcfOutlierDetector {
         }
     }
 
-    fn detect_with_zscores(
-        &mut self,
+    /// Both threshold modes reduce to the same shape: a cutoff on the raw forest
+    /// scores, an evidence quantity measured against it, and a direction taken
+    /// from the data values.
+    ///
+    /// They used to disagree on all three. `StdDev` reported a normalized
+    /// *z-score of the batch's forest scores* while `Contamination` reported
+    /// `1 - e^(-raw)` of the forest score itself — same method, same field, two
+    /// scales, and switching threshold mode silently changed what the number
+    /// meant. Expressing both as evidence against their own cutoff makes the two
+    /// modes agree with each other and each mode agree with its own verdict.
+    fn assemble(
+        &self,
         values: &[f64],
-        raw_scores: Vec<f64>,
+        raw_scores: &[f64],
+        evidence: impl Fn(f64) -> f64,
+        boundary: f64,
         threshold: f64,
     ) -> AnomalyResult {
-        let mut scores = raw_scores;
+        // Direction comes from the value distribution. The `StdDev` path used to
+        // compare each data value against the mean of the *forest scores* —
+        // unrelated units, so the reported direction depended on whether the
+        // series happened to live on the same numeric scale as the forest's
+        // internal statistic.
+        let value_mean = calculate_mean(values);
 
-        // Compute a stable center-line for directional classification.
-        // The mean over the full slice is used so that the signal assignment is
-        // independent of point ordering and robust to a small number of outliers.
-        let (mean, std_dev) = calculate_mean_std_dev(&scores);
-        let score_cutoff = mean + std_dev * threshold;
-
+        let mut scores = Vec::with_capacity(raw_scores.len());
         let mut anomalies: Vec<Anomaly> = Vec::with_capacity(4);
-        for (index, (score, &value)) in scores.iter_mut().zip(values.iter()).enumerate() {
-            // Suppress anomaly flagging during the warmup window.  The forest has not
-            // yet learned enough of the distribution to produce reliable scores, so
-            // detections in this region are likely false positives.  Scores are still
-            // recorded above, so AnomalyResult::scores always has one entry per point.
+
+        for (index, (&raw_score, &value)) in raw_scores.iter().zip(values.iter()).enumerate() {
+            let score = normalize_evidence(evidence(raw_score), boundary);
+            scores.push(score);
+
+            // Suppress anomaly flagging during the warmup window. The forest has
+            // not yet learned enough of the distribution to produce reliable
+            // scores, so detections here are likely false positives. Scores are
+            // still recorded, so `scores` always has one entry per point — which
+            // is why this window is a documented carve-out from the 0.5 contract
+            // rather than a violation of it.
             if index < self.output_after {
                 continue;
             }
 
-            let z_score = (*score - mean) / std_dev;
-            let z_abs = z_score.abs();
-            let normalized_score = normalize_unbounded_score(z_abs);
-
-            if *score > score_cutoff {
-                // Derive a direction by comparing the anomalous value to the mean score.
-                let signal = if value >= mean {
+            if score > 0.5 {
+                let signal = if value >= value_mean {
                     AnomalySignal::Positive
                 } else {
                     AnomalySignal::Negative
                 };
 
-                // Store the raw score — consistent with AnomalyResult::scores and
-                // AnomalyResult::threshold so callers can compare all three uniformly.
                 anomalies.push(Anomaly {
                     index,
                     signal,
                     value,
-                    score: normalized_score,
+                    score,
                 });
             }
-
-            *score = normalized_score;
         }
 
         AnomalyResult {
@@ -411,6 +412,34 @@ impl RcfOutlierDetector {
         }
     }
 
+    /// Cutoff at `mean + threshold * std_dev` of the batch's forest scores.
+    ///
+    /// Evidence is floored at zero, which is what makes the score one-sided.
+    /// It used to be `|z|`, so a point whose forest score was unusually *low* —
+    /// i.e. more ordinary than average — received a high anomaly score while the
+    /// verdict, a plain `>` against the cutoff, correctly declined to flag it.
+    fn detect_with_zscores(
+        &mut self,
+        values: &[f64],
+        raw_scores: Vec<f64>,
+        threshold: f64,
+    ) -> AnomalyResult {
+        let (mean, std_dev) = calculate_mean_std_dev(&raw_scores);
+
+        self.assemble(
+            values,
+            &raw_scores,
+            |raw| raw - mean,
+            threshold * std_dev,
+            threshold,
+        )
+    }
+
+    /// Cutoff at the `1 - contamination` quantile of the forest scores.
+    ///
+    /// By construction roughly a `contamination` fraction of samples exceed that
+    /// quantile, so roughly that fraction score above 0.5 — which is exactly
+    /// what the caller asked for.
     fn detect_with_contamination(
         &self,
         values: &[f64],
@@ -420,61 +449,19 @@ impl RcfOutlierDetector {
         let start = self.output_after.min(raw_scores.len());
         let usable_scores = &raw_scores[start..];
 
-        // If everything is in warmup, still return normalized scores but no anomalies.
-        if usable_scores.is_empty() {
-            let scores = raw_scores.into_iter().map(normalize_rcf_score).collect();
-
-            return AnomalyResult {
-                scores,
-                anomalies: Vec::new(),
-                threshold: contamination, // effectively unreachable during a warmup-only result
-                method: AnomalyMethod::RandomCutForest,
-                method_info: None,
-            };
-        }
-
         // Keep contamination in a safe open interval for quantile selection.
         let contamination = contamination.clamp(f64::EPSILON, 1.0 - f64::EPSILON);
 
-        let raw_threshold = quantile(usable_scores, 1.0 - contamination);
+        // If everything is in warmup there is no usable distribution to take a
+        // quantile of. An unusable boundary scores every point 0.0, and the
+        // warmup window flags nothing regardless.
+        let boundary = if usable_scores.is_empty() {
+            f64::NAN
+        } else {
+            quantile(usable_scores, 1.0 - contamination)
+        };
 
-        // Direction should be based on the value distribution, not the score distribution.
-        let value_mean = calculate_mean(values);
-
-        let mut scores = Vec::with_capacity(raw_scores.len());
-        let mut anomalies: Vec<Anomaly> = Vec::with_capacity(4);
-
-        for (index, (&raw_score, &value)) in raw_scores.iter().zip(values.iter()).enumerate() {
-            let normalized_score = normalize_rcf_score(raw_score);
-            scores.push(normalized_score);
-
-            if index < self.output_after {
-                continue;
-            }
-
-            if raw_score > raw_threshold {
-                let signal = if value >= value_mean {
-                    AnomalySignal::Positive
-                } else {
-                    AnomalySignal::Negative
-                };
-
-                anomalies.push(Anomaly {
-                    index,
-                    signal,
-                    value,
-                    score: normalized_score,
-                });
-            }
-        }
-
-        AnomalyResult {
-            scores,
-            anomalies,
-            threshold: contamination,
-            method: AnomalyMethod::RandomCutForest,
-            method_info: None,
-        }
+        self.assemble(values, &raw_scores, |raw| raw, boundary, contamination)
     }
 }
 
@@ -490,28 +477,6 @@ impl AnomalyDetector for RcfOutlierDetector {
     fn detect(&mut self, ts: &[f64]) -> TimeSeriesAnalysisResult<AnomalyResult> {
         RcfOutlierDetector::detect(self, ts)
     }
-}
-
-/// Normalize an RCF raw anomaly score to the range \[0, 1\].
-///
-/// Uses the transformation `1 - e^(-raw_score)`:
-///
-/// | raw score | normalized |
-/// |-----------|------------|
-/// | 0         | 0.000      |
-/// | 1         | 0.632      |
-/// | 2         | 0.865      |
-/// | 3         | 0.950      |
-/// | ∞         | 1.000      |
-///
-/// Note: [`RcfOutlierDetector::detect`] stores **raw** scores in both
-/// `AnomalyResult::scores` and `Anomaly::score`. Apply this function when a
-/// \[0, 1\] value is required for display or cross-method comparison.
-pub fn normalize_rcf_score(raw_score: f64) -> f64 {
-    if raw_score.is_nan() || raw_score < 0.0 {
-        return 0.0;
-    }
-    1.0 - (-raw_score).exp()
 }
 
 #[cfg(test)]
@@ -957,6 +922,123 @@ mod tests {
                     anomaly.value
                 );
             }
+        }
+    }
+
+    /// Direction must come from the data, on a value scale deliberately unlike
+    /// the forest's.
+    ///
+    /// `StdDev` used to pick a signal by comparing each data *value* to the mean
+    /// of the *forest scores* — unrelated units, so the answer depended on
+    /// whether the series happened to live near the forest's own numeric range.
+    /// Raw RCF scores sit around 1-4; a series near 10,000 therefore has every
+    /// value above that mean, and every anomaly was reported `Positive`,
+    /// including the dips. `detect_assigns_direction_relative_to_mean` above
+    /// cannot catch this: it builds a series centered on zero, where the two
+    /// scales happen to agree.
+    #[test]
+    fn detect_assigns_direction_on_the_data_scale_not_the_forest_scale() {
+        let mut ts: Vec<f64> = (0..120).map(|i| 10_000.0 + (i % 7) as f64).collect();
+        ts[60] = 90_000.0; // unmistakable high spike
+        ts[90] = -70_000.0; // unmistakable low dip
+
+        for threshold in [RCFThreshold::StdDev(2.0), RCFThreshold::Contamination(0.05)] {
+            let mut detector = RcfOutlierDetector::new(RCFOptions {
+                num_trees: Some(50),
+                sample_size: Some(64),
+                threshold: Some(threshold),
+                output_after: Some(20),
+                ..Default::default()
+            })
+            .unwrap();
+
+            let result = detector.detect(&ts).unwrap();
+
+            let dip = result.anomalies.iter().find(|a| a.index == 90);
+            assert!(
+                dip.is_some(),
+                "{threshold:?}: the dip at index 90 should be detected"
+            );
+            assert_eq!(
+                dip.unwrap().signal,
+                AnomalySignal::Negative,
+                "{threshold:?}: a value far *below* the series mean must be Negative"
+            );
+
+            if let Some(spike) = result.anomalies.iter().find(|a| a.index == 60) {
+                assert_eq!(
+                    spike.signal,
+                    AnomalySignal::Positive,
+                    "{threshold:?}: a value far above the series mean must be Positive"
+                );
+            }
+        }
+    }
+
+    /// The score is one-sided, matching the verdict.
+    ///
+    /// `StdDev` used to score `|z|` of the forest scores while flagging on a
+    /// plain `>` against the cutoff, so a point whose forest score was unusually
+    /// *low* — more ordinary than average — received a high anomaly score and
+    /// was correctly not flagged. Score and verdict disagreed by construction.
+    #[test]
+    fn stddev_scores_are_one_sided() {
+        let mut ts = vec![10.0f64; 120];
+        ts[80] = 900.0;
+
+        let mut detector = RcfOutlierDetector::new(RCFOptions {
+            num_trees: Some(50),
+            sample_size: Some(64),
+            threshold: Some(RCFThreshold::StdDev(3.0)),
+            output_after: Some(20),
+            ..Default::default()
+        })
+        .unwrap();
+
+        let result = detector.detect(&ts).unwrap();
+        let flagged: Vec<usize> = result.anomalies.iter().map(|a| a.index).collect();
+
+        for (index, &score) in result.scores.iter().enumerate().skip(20) {
+            assert_eq!(
+                score > 0.5,
+                flagged.contains(&index),
+                "score[{index}] = {score} disagrees with the verdict"
+            );
+        }
+    }
+
+    /// Both threshold modes report on the same scale. They used to report a
+    /// normalized z-score of the forest scores and `1 - e^(-raw)` of the forest
+    /// score respectively, so switching threshold mode silently changed what the
+    /// number meant.
+    #[test]
+    fn both_threshold_modes_put_the_boundary_at_one_half() {
+        let mut ts: Vec<f64> = (0..200).map(|i| 10.0 + (i as f64 * 0.1).sin()).collect();
+        ts[150] = 100.0;
+
+        for threshold in [RCFThreshold::StdDev(3.0), RCFThreshold::Contamination(0.05)] {
+            let mut detector = RcfOutlierDetector::new(RCFOptions {
+                num_trees: Some(50),
+                sample_size: Some(64),
+                threshold: Some(threshold),
+                output_after: Some(50),
+                ..Default::default()
+            })
+            .unwrap();
+
+            let result = detector.detect(&ts).unwrap();
+
+            for anomaly in &result.anomalies {
+                assert!(
+                    anomaly.score > 0.5,
+                    "{threshold:?}: a flagged point scored {}, at or below the boundary",
+                    anomaly.score
+                );
+            }
+            assert!(
+                result.scores.iter().all(|s| (0.0..=1.0).contains(s)),
+                "{threshold:?}: scores must stay in [0, 1]"
+            );
         }
     }
 

--- a/src/analysis/outliers/score_contract_tests.rs
+++ b/src/analysis/outliers/score_contract_tests.rs
@@ -1,0 +1,834 @@
+//! The cross-method score contract, held against every detector.
+//!
+//! Each method anchored its detection boundary at a different score before this
+//! suite existed — `mad` flagged at `1.0`, `iqr` at anything above `0.0`,
+//! `zscore` at `0.75` for `T=3` but `0.857` for `T=6` — so no property spanning
+//! the methods was expressible. The contract on
+//! [`AnomalyDetector::detect`](super::AnomalyDetector::detect) makes one
+//! expressible, and this is where it is enforced:
+//!
+//! > A sample's score is `0.5` exactly at the method's detection boundary.
+//! > `score > 0.5` ⟺ flagged.
+//!
+//! Every detector runs against every fixture below. The exceptions in
+//! [`Carveout`] are named rather than absorbed into a tolerance, because each
+//! one is a window where a sample is *scored without being classified* — the
+//! contract has nothing to say there, and blurring that into a fudge factor
+//! would hide real disagreements elsewhere.
+
+use super::{
+    AnomalyDetectionMethodOptions, AnomalyDetector, AnomalyMethod, AnomalyResult, AnomalySignal,
+    Detector, MADAnomalyOptions, RCFOptions, RCFThreshold, SmoothedZScoreOptions,
+};
+use crate::analysis::outliers::esd_outlier_detector::ESDOutlierOptions;
+
+/// Warmup length shared by the RCF cases, so the carve-out and the options
+/// cannot drift apart.
+const RCF_WARMUP: usize = 16;
+/// Lag shared by the smoothed z-score cases, for the same reason.
+const SMOOTHED_LAG: usize = 8;
+
+/// A window in which samples are scored but never classified, so
+/// [`Invariant 3`](check_score_partitions_anomalies) cannot apply to them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Carveout {
+    /// Every sample is both scored and classified.
+    None,
+    /// Indices `0..n` are scored but suppressed from flagging.
+    LeadingWindow(usize),
+}
+
+impl Carveout {
+    fn exempts(&self, index: usize) -> bool {
+        match self {
+            Carveout::None => false,
+            Carveout::LeadingWindow(n) => index < *n,
+        }
+    }
+}
+
+struct MethodCase {
+    name: &'static str,
+    options: AnomalyDetectionMethodOptions,
+    carveout: Carveout,
+}
+
+impl MethodCase {
+    /// RCF cannot be run against a fixture containing NaN *in a unit test*: the
+    /// forest rejects the update and the module logs a warning, and the logging
+    /// shim needs a live Valkey context that no unit test has. The limitation is
+    /// the harness's, not the detector's, so it is skipped by fixture rather
+    /// than dropped from the suite.
+    fn skips(&self, fixture: &Fixture) -> bool {
+        fixture.values.iter().any(|v| v.is_nan())
+            && self.options.method() == AnomalyMethod::RandomCutForest
+    }
+}
+
+/// Every scoring path in the module. RCF appears twice because its two
+/// threshold modes used to be two different score scales; keeping both here is
+/// what stops them drifting apart again.
+fn method_cases() -> Vec<MethodCase> {
+    vec![
+        MethodCase {
+            name: "zscore",
+            options: AnomalyDetectionMethodOptions::ZScore(Some(3.0)),
+            carveout: Carveout::None,
+        },
+        MethodCase {
+            name: "modified-zscore",
+            options: AnomalyDetectionMethodOptions::ModifiedZScore(Some(3.5)),
+            carveout: Carveout::None,
+        },
+        MethodCase {
+            name: "mad",
+            options: AnomalyDetectionMethodOptions::Mad(MADAnomalyOptions::default()),
+            carveout: Carveout::None,
+        },
+        MethodCase {
+            name: "double-mad",
+            options: AnomalyDetectionMethodOptions::DoubleMAD(MADAnomalyOptions::default()),
+            carveout: Carveout::None,
+        },
+        MethodCase {
+            name: "iqr",
+            options: AnomalyDetectionMethodOptions::InterQuartileRange(Some(1.5)),
+            carveout: Carveout::None,
+        },
+        MethodCase {
+            name: "cusum",
+            options: AnomalyDetectionMethodOptions::Cusum,
+            carveout: Carveout::None,
+        },
+        MethodCase {
+            name: "ewma",
+            options: AnomalyDetectionMethodOptions::Ewma(Some(0.3)),
+            carveout: Carveout::None,
+        },
+        MethodCase {
+            name: "smoothed-zscore",
+            options: AnomalyDetectionMethodOptions::SmoothedZScore(SmoothedZScoreOptions {
+                threshold: 3.0,
+                influence: 0.0,
+                lag: SMOOTHED_LAG,
+            }),
+            // The first `lag` samples form the initial window: they are padded
+            // with 0.0 and never classified.
+            carveout: Carveout::LeadingWindow(SMOOTHED_LAG),
+        },
+        MethodCase {
+            name: "esd",
+            options: AnomalyDetectionMethodOptions::Esd(Some(ESDOutlierOptions::default())),
+            carveout: Carveout::None,
+        },
+        MethodCase {
+            name: "rcf/stddev",
+            options: AnomalyDetectionMethodOptions::Rcf(RCFOptions {
+                threshold: Some(RCFThreshold::StdDev(3.0)),
+                output_after: Some(RCF_WARMUP),
+                ..Default::default()
+            }),
+            // The forest has not learned the distribution yet, so detections in
+            // this region are suppressed while the scores are still recorded.
+            carveout: Carveout::LeadingWindow(RCF_WARMUP),
+        },
+        MethodCase {
+            name: "rcf/contamination",
+            options: AnomalyDetectionMethodOptions::Rcf(RCFOptions {
+                threshold: Some(RCFThreshold::Contamination(0.05)),
+                output_after: Some(RCF_WARMUP),
+                ..Default::default()
+            }),
+            carveout: Carveout::LeadingWindow(RCF_WARMUP),
+        },
+    ]
+}
+
+struct Fixture {
+    name: &'static str,
+    values: Vec<f64>,
+}
+
+/// Deterministic pseudo-noise. A fixed LCG rather than a `rand` dependency, so
+/// a failure reported by CI reproduces exactly.
+fn noise(i: usize) -> f64 {
+    let x = (i as u64)
+        .wrapping_mul(6_364_136_223_846_793_005)
+        .wrapping_add(1_442_695_040_888_963_407);
+    ((x >> 33) as f64 / (1u64 << 31) as f64) - 0.5
+}
+
+fn baseline(n: usize) -> Vec<f64> {
+    (0..n).map(|i| 50.0 + noise(i)).collect()
+}
+
+fn fixtures() -> Vec<Fixture> {
+    let mut single_spike = baseline(64);
+    single_spike[40] = 500.0;
+
+    let mut bilateral = baseline(64);
+    bilateral[20] = 500.0;
+    bilateral[45] = -400.0;
+
+    // Right-skewed: the half the distribution spreads on is the half
+    // `double-mad` exists to measure separately.
+    let skewed: Vec<f64> = (0..64)
+        .map(|i| {
+            let base = 10.0 + noise(i);
+            if i % 4 == 0 { base * 3.0 } else { base }
+        })
+        .collect();
+
+    let mut with_nan = baseline(64);
+    with_nan[10] = f64::NAN;
+    with_nan[33] = f64::NAN;
+
+    // More than half constant, so every robust scale estimate collapses to zero
+    // while a real spike is still present.
+    let mut flat_with_spike = vec![7.0; 64];
+    flat_with_spike[50] = 900.0;
+
+    vec![
+        Fixture {
+            name: "clean",
+            values: baseline(64),
+        },
+        Fixture {
+            name: "single-spike",
+            values: single_spike,
+        },
+        Fixture {
+            name: "bilateral-spikes",
+            values: bilateral,
+        },
+        Fixture {
+            name: "skewed",
+            values: skewed,
+        },
+        Fixture {
+            name: "constant",
+            values: vec![42.0; 64],
+        },
+        Fixture {
+            name: "flat-with-spike",
+            values: flat_with_spike,
+        },
+        Fixture {
+            name: "with-nan",
+            values: with_nan,
+        },
+    ]
+}
+
+fn run(case: &MethodCase, values: &[f64]) -> AnomalyResult {
+    let mut detector = Detector::build(values, &case.options)
+        .unwrap_or_else(|e| panic!("{}: detector should build: {e:?}", case.name));
+    detector
+        .train(values)
+        .unwrap_or_else(|e| panic!("{}: train should succeed: {e:?}", case.name));
+    detector
+        .detect(values)
+        .unwrap_or_else(|e| panic!("{}: detect should succeed: {e:?}", case.name))
+}
+
+/// Invariant 1: one score per observation. This is `debug_assert`ed on the
+/// dispatch path; here it is a real assertion.
+#[test]
+fn scores_have_one_entry_per_observation() {
+    for case in method_cases() {
+        for fixture in fixtures() {
+            if case.skips(&fixture) {
+                continue;
+            }
+            let result = run(&case, &fixture.values);
+            assert_eq!(
+                result.scores.len(),
+                fixture.values.len(),
+                "{}/{}: expected one score per observation",
+                case.name,
+                fixture.name
+            );
+            for anomaly in &result.anomalies {
+                assert!(
+                    anomaly.index < fixture.values.len(),
+                    "{}/{}: anomaly index {} out of bounds",
+                    case.name,
+                    fixture.name,
+                    anomaly.index
+                );
+            }
+        }
+    }
+}
+
+/// Invariant 2: every score is finite and inside `[0, 1]`.
+#[test]
+fn scores_are_finite_and_in_the_unit_interval() {
+    for case in method_cases() {
+        for fixture in fixtures() {
+            if case.skips(&fixture) {
+                continue;
+            }
+            let result = run(&case, &fixture.values);
+            for (i, &score) in result.scores.iter().enumerate() {
+                assert!(
+                    score.is_finite() && (0.0..=1.0).contains(&score),
+                    "{}/{}: score[{i}] = {score} is outside [0, 1]",
+                    case.name,
+                    fixture.name
+                );
+            }
+        }
+    }
+}
+
+/// Invariant 3, the one the whole contract exists for: the score partitions the
+/// series exactly the way the classifier does.
+///
+/// Note which side the boundary belongs to. Every classifier here compares
+/// strictly, so a sample sitting *exactly* on the fence is not flagged and must
+/// score exactly `0.5` — `> 0.5 ⟺ flagged` paired with `<= 0.5 ⟺ not flagged`,
+/// which is a biconditional. `< 0.5 ⟺ not flagged` would leave the fence case
+/// unspecified.
+#[test]
+fn check_score_partitions_anomalies() {
+    for case in method_cases() {
+        for fixture in fixtures() {
+            if case.skips(&fixture) {
+                continue;
+            }
+            let result = run(&case, &fixture.values);
+            let flagged: Vec<usize> = result.anomalies.iter().map(|a| a.index).collect();
+
+            for (i, &score) in result.scores.iter().enumerate() {
+                if case.carveout.exempts(i) {
+                    continue;
+                }
+
+                let is_flagged = flagged.contains(&i);
+                assert_eq!(
+                    score > 0.5,
+                    is_flagged,
+                    "{}/{}: score[{i}] = {score} (value {}) says {}, but the detector says {}",
+                    case.name,
+                    fixture.name,
+                    fixture.values[i],
+                    if score > 0.5 { "anomaly" } else { "normal" },
+                    if is_flagged { "anomaly" } else { "normal" },
+                );
+            }
+        }
+    }
+}
+
+/// Invariant 4: the score reported alongside an anomaly is the score recorded
+/// for its index. Two fields, one number.
+#[test]
+fn anomaly_score_matches_the_score_vector() {
+    for case in method_cases() {
+        for fixture in fixtures() {
+            if case.skips(&fixture) {
+                continue;
+            }
+            let result = run(&case, &fixture.values);
+            for anomaly in &result.anomalies {
+                assert_eq!(
+                    anomaly.score, result.scores[anomaly.index],
+                    "{}/{}: Anomaly::score disagrees with scores[{}]",
+                    case.name, fixture.name, anomaly.index
+                );
+            }
+        }
+    }
+}
+
+/// Invariant 5: monotone in evidence. Only the [`PointDetector`]s can be asked
+/// this, since only they answer about a value independently of its position.
+#[test]
+fn point_detectors_score_monotonically_away_from_center() {
+    let values = baseline(64);
+
+    for case in method_cases() {
+        let mut detector = match Detector::build(&values, &case.options) {
+            Ok(d) => d,
+            Err(e) => panic!("{}: detector should build: {e:?}", case.name),
+        };
+        detector.train(&values).unwrap();
+        let Some(point) = detector.as_point_detector() else {
+            continue;
+        };
+
+        // Walk outward from the middle of the fitted data in both directions.
+        for direction in [1.0f64, -1.0] {
+            let mut previous = f64::NEG_INFINITY;
+            for step in 0..40 {
+                let probe = 50.0 + direction * (step as f64) * 2.0;
+                let score = point.score(probe);
+                assert!(
+                    score >= previous - 1e-12,
+                    "{}: score fell from {previous} to {score} while moving further from center (probe {probe})",
+                    case.name
+                );
+                previous = score;
+            }
+        }
+    }
+}
+
+/// Invariant 6: a constant series has no anomalies and no evidence of any.
+/// `double-mad` and `smoothed-zscore` used to score `1.0` here where the others
+/// scored `0.0`.
+///
+/// Scoped to the methods that fit a *scale* to the data. RCF fits a forest
+/// instead, and the partition a forest cuts through identical points is
+/// randomized, so its raw scores vary even on a constant series; there is no
+/// zero-variance branch for it to take.
+#[test]
+fn constant_series_scores_zero_everywhere() {
+    let values = vec![42.0; 64];
+
+    for case in method_cases() {
+        if case.options.method() == AnomalyMethod::RandomCutForest {
+            continue;
+        }
+
+        let result = run(&case, &values);
+
+        assert!(
+            result.anomalies.is_empty(),
+            "{}: constant series must yield no anomalies, got {:?}",
+            case.name,
+            result.anomalies
+        );
+        for (i, &score) in result.scores.iter().enumerate() {
+            assert_eq!(
+                score, 0.0,
+                "{}: constant series scored {score} at index {i}",
+                case.name
+            );
+        }
+    }
+}
+
+/// Invariant 7: `±∞` is maximally anomalous — flagged, scored `1.0`, with the
+/// direction it actually points. `NaN` is the opposite case: a missing reading
+/// is not evidence, so it scores `0.0` and is never flagged.
+///
+/// Both used to be broken in the same place. `detect_pointwise` skips only NaN,
+/// so `±∞` reached `classify`, crossed every finite fence, and was flagged —
+/// while the normalizer handed back `0.0` for non-finite evidence. An infinite
+/// observation was therefore *flagged with score 0.0*.
+#[test]
+fn infinities_are_maximal_and_nan_is_never_flagged() {
+    for case in method_cases() {
+        // Only the pointwise detectors have a position-independent answer here;
+        // the sequential ones propagate an infinity into their running
+        // statistics, which is a separate question from how it is scored.
+        let values = baseline(64);
+        let mut detector = Detector::build(&values, &case.options).unwrap();
+        detector.train(&values).unwrap();
+        let Some(point) = detector.as_point_detector() else {
+            continue;
+        };
+
+        for infinity in [f64::INFINITY, f64::NEG_INFINITY] {
+            let score = point.score(infinity);
+            assert_eq!(
+                score, 1.0,
+                "{}: {infinity} should score 1.0, got {score}",
+                case.name
+            );
+
+            let expected = if infinity.is_sign_positive() {
+                AnomalySignal::Positive
+            } else {
+                AnomalySignal::Negative
+            };
+            assert_eq!(
+                point.classify(infinity),
+                expected,
+                "{}: {infinity} should be flagged {expected:?}",
+                case.name
+            );
+        }
+
+        assert_eq!(
+            point.score(f64::NAN),
+            0.0,
+            "{}: NaN should score 0.0",
+            case.name
+        );
+    }
+
+    // And through the batch path, where `detect_pointwise` skips NaN outright.
+    //
+    // Scoped to the pointwise detectors. The sequential ones still substitute
+    // `0.0` for a missing reading and let the substitute enter their running
+    // statistic, so an EWMA or CUSUM baseline is dragged toward zero by a gap in
+    // the data — a separate defect, tracked as out of scope for the score
+    // contract because it concerns what NaN contributes to a *fitted baseline*,
+    // not how it is scored.
+    for case in method_cases() {
+        let mut values = baseline(64);
+        values[7] = f64::NAN;
+
+        let probe = Detector::build(&values, &case.options).unwrap();
+        if probe.as_point_detector().is_none() {
+            continue;
+        }
+
+        let result = run(&case, &values);
+        assert_eq!(result.scores[7], 0.0, "{}: NaN should score 0.0", case.name);
+        assert!(
+            !result.anomalies.iter().any(|a| a.index == 7),
+            "{}: NaN must never be flagged",
+            case.name
+        );
+    }
+}
+
+/// Invariant 8: direction is reported on the data's own scale.
+///
+/// The probe values are deliberately far from any internal statistic's scale —
+/// RCF's `StdDev` path used to pick a direction by comparing the *data value*
+/// to the mean of the *forest scores*, which are unrelated units. On a series
+/// living near zero that mistake is invisible; on one living near 10,000 it
+/// reports every anomaly as `Positive`.
+#[test]
+fn direction_follows_the_data_not_an_internal_statistic() {
+    let mut values: Vec<f64> = (0..96).map(|i| 10_000.0 + noise(i)).collect();
+    values[40] = 90_000.0; // unmistakable high spike
+    values[70] = -70_000.0; // unmistakable low dip
+
+    for case in method_cases() {
+        let result = run(&case, &values);
+
+        for anomaly in &result.anomalies {
+            if anomaly.index == 40 {
+                assert_eq!(
+                    anomaly.signal,
+                    AnomalySignal::Positive,
+                    "{}: the high spike must be Positive",
+                    case.name
+                );
+            }
+            if anomaly.index == 70 {
+                assert_eq!(
+                    anomaly.signal,
+                    AnomalySignal::Negative,
+                    "{}: the low dip must be Negative",
+                    case.name
+                );
+            }
+        }
+    }
+}
+
+/// Invariant 9: the threshold enters only as a divisor on a fixed evidence
+/// statistic, so raising it rescales scores without reordering them.
+///
+/// Scoped deliberately. It does **not** hold for `esd`, where `alpha` moves each
+/// iteration's critical value and therefore the truncation point, nor for
+/// `smoothed-zscore` with `influence > 0`, where classification feeds back into
+/// the rolling baseline that later evidence is measured against. In both, the
+/// threshold changes the evidence itself rather than its scale.
+#[test]
+fn threshold_rescales_scores_without_reordering_them() {
+    let mut values = baseline(64);
+    values[15] = 300.0;
+    values[38] = 180.0;
+    values[52] = -220.0;
+
+    let cases: Vec<(
+        &str,
+        AnomalyDetectionMethodOptions,
+        AnomalyDetectionMethodOptions,
+    )> = vec![
+        (
+            "zscore",
+            AnomalyDetectionMethodOptions::ZScore(Some(2.0)),
+            AnomalyDetectionMethodOptions::ZScore(Some(6.0)),
+        ),
+        (
+            "modified-zscore",
+            AnomalyDetectionMethodOptions::ModifiedZScore(Some(2.0)),
+            AnomalyDetectionMethodOptions::ModifiedZScore(Some(7.0)),
+        ),
+        (
+            "mad",
+            AnomalyDetectionMethodOptions::Mad(MADAnomalyOptions {
+                k: 2.0,
+                ..Default::default()
+            }),
+            AnomalyDetectionMethodOptions::Mad(MADAnomalyOptions {
+                k: 6.0,
+                ..Default::default()
+            }),
+        ),
+        (
+            "double-mad",
+            AnomalyDetectionMethodOptions::DoubleMAD(MADAnomalyOptions {
+                k: 2.0,
+                ..Default::default()
+            }),
+            AnomalyDetectionMethodOptions::DoubleMAD(MADAnomalyOptions {
+                k: 6.0,
+                ..Default::default()
+            }),
+        ),
+        (
+            "iqr",
+            AnomalyDetectionMethodOptions::InterQuartileRange(Some(1.5)),
+            AnomalyDetectionMethodOptions::InterQuartileRange(Some(4.5)),
+        ),
+    ];
+
+    for (name, tight, loose) in cases {
+        let tight_scores = run(
+            &MethodCase {
+                name,
+                options: tight,
+                carveout: Carveout::None,
+            },
+            &values,
+        )
+        .scores;
+        let loose_scores = run(
+            &MethodCase {
+                name,
+                options: loose,
+                carveout: Carveout::None,
+            },
+            &values,
+        )
+        .scores;
+
+        for i in 0..values.len() {
+            for j in 0..values.len() {
+                let tight_order = tight_scores[i].partial_cmp(&tight_scores[j]).unwrap();
+                let loose_order = loose_scores[i].partial_cmp(&loose_scores[j]).unwrap();
+                assert_eq!(
+                    tight_order, loose_order,
+                    "{name}: raising the threshold reordered scores[{i}] and scores[{j}] \
+                     ({} vs {} became {} vs {})",
+                    tight_scores[i], tight_scores[j], loose_scores[i], loose_scores[j]
+                );
+            }
+        }
+
+        // And a looser threshold must lower every score, never raise one.
+        for i in 0..values.len() {
+            assert!(
+                loose_scores[i] <= tight_scores[i] + 1e-12,
+                "{name}: a looser threshold raised scores[{i}] from {} to {}",
+                tight_scores[i],
+                loose_scores[i]
+            );
+        }
+    }
+}
+
+/// The boundary case, constructed exactly rather than approached: a value
+/// sitting on the fence is not flagged, and scores exactly `0.5`.
+#[test]
+fn a_value_exactly_on_the_fence_scores_one_half_and_is_not_flagged() {
+    use super::MethodInfo;
+
+    let values = baseline(64);
+
+    for case in method_cases() {
+        let mut detector = Detector::build(&values, &case.options).unwrap();
+        detector.train(&values).unwrap();
+
+        let Some(MethodInfo::Fenced {
+            lower_fence,
+            upper_fence,
+            ..
+        }) = detector.model_info()
+        else {
+            continue;
+        };
+        let Some(point) = detector.as_point_detector() else {
+            continue;
+        };
+
+        for fence in [lower_fence, upper_fence] {
+            if !fence.is_finite() {
+                continue;
+            }
+            let score = point.score(fence);
+            assert!(
+                (score - 0.5).abs() < 1e-9,
+                "{}: the fence at {fence} scored {score}, expected 0.5",
+                case.name
+            );
+            assert_eq!(
+                point.classify(fence),
+                AnomalySignal::None,
+                "{}: the fence at {fence} must sit on the not-flagged side",
+                case.name
+            );
+        }
+    }
+}
+
+/// The fitted upper fence and the distance from the center out to it, for the
+/// methods that report fences. Probes are expressed as multiples of that
+/// distance so each case is tested on its own scale.
+fn fence_and_span(detector: &Detector) -> Option<(f64, f64)> {
+    use super::MethodInfo;
+
+    let MethodInfo::Fenced {
+        lower_fence,
+        upper_fence,
+        ..
+    } = detector.model_info()?
+    else {
+        return None;
+    };
+
+    if !lower_fence.is_finite() || !upper_fence.is_finite() || upper_fence <= lower_fence {
+        return None;
+    }
+
+    let span = (upper_fence - lower_fence) / 2.0;
+    Some((upper_fence, span))
+}
+
+/// `mad` used to `clamp(…, 0, 1)` at the fence, so a point 3.1 MADs out and one
+/// 300 MADs out both scored exactly `1.0` — the score column carried no ranking
+/// at all among the samples it had flagged.
+#[test]
+fn scores_rank_samples_beyond_the_fence() {
+    let values = baseline(64);
+
+    for case in method_cases() {
+        let mut detector = Detector::build(&values, &case.options).unwrap();
+        detector.train(&values).unwrap();
+        let (Some((fence, span)), Some(point)) =
+            (fence_and_span(&detector), detector.as_point_detector())
+        else {
+            continue;
+        };
+
+        let near = point.score(fence + span * 0.5);
+        let far = point.score(fence + span * 50.0);
+        let further = point.score(fence + span * 5_000.0);
+
+        assert!(
+            0.5 < near && near < far && far < further && further < 1.0,
+            "{}: expected a strict ranking past the fence, got {near} < {far} < {further}",
+            case.name
+        );
+    }
+}
+
+/// `iqr` measured the distance *beyond* the fence, so every in-range sample —
+/// the majority of the series, and the whole point of `FULL` output — scored
+/// exactly `0.0`. A near-miss was indistinguishable from a sample at the median.
+#[test]
+fn scores_rank_samples_inside_the_fence() {
+    let values = baseline(64);
+
+    for case in method_cases() {
+        let mut detector = Detector::build(&values, &case.options).unwrap();
+        detector.train(&values).unwrap();
+        let (Some((fence, span)), Some(point)) =
+            (fence_and_span(&detector), detector.as_point_detector())
+        else {
+            continue;
+        };
+
+        // Walk in from the fence toward the center, staying strictly inside.
+        let center = fence - span;
+        let just_inside = point.score(fence - span * 0.05);
+        let halfway = point.score(fence - span * 0.5);
+        let at_center = point.score(center);
+
+        assert!(
+            at_center < halfway && halfway < just_inside && just_inside < 0.5,
+            "{}: expected in-range samples to be graded, got {at_center} < {halfway} < {just_inside}",
+            case.name
+        );
+    }
+}
+
+/// The methods that report fences must agree with themselves: the score crosses
+/// `0.5` at exactly the fence they advertise in `method_info`.
+#[test]
+fn reported_fences_agree_with_the_score_scale() {
+    use super::MethodInfo;
+
+    let values = baseline(64);
+
+    for case in method_cases() {
+        let mut detector = Detector::build(&values, &case.options).unwrap();
+        detector.train(&values).unwrap();
+
+        let Some(MethodInfo::Fenced {
+            lower_fence,
+            upper_fence,
+            ..
+        }) = detector.model_info()
+        else {
+            continue;
+        };
+        let Some(point) = detector.as_point_detector() else {
+            continue;
+        };
+
+        if !lower_fence.is_finite() || !upper_fence.is_finite() {
+            continue;
+        }
+
+        let width = upper_fence - lower_fence;
+        assert!(
+            point.score(upper_fence + width * 0.01) > 0.5,
+            "{}: just past the upper fence must read as flagged",
+            case.name
+        );
+        assert!(
+            point.score(upper_fence - width * 0.01) < 0.5,
+            "{}: just inside the upper fence must read as normal",
+            case.name
+        );
+        assert!(
+            point.score(lower_fence - width * 0.01) > 0.5,
+            "{}: just past the lower fence must read as flagged",
+            case.name
+        );
+        assert!(
+            point.score(lower_fence + width * 0.01) < 0.5,
+            "{}: just inside the lower fence must read as normal",
+            case.name
+        );
+    }
+}
+
+/// Detectors must not silently disagree about how many methods exist. If a
+/// scoring path is added without a case here, the contract stops covering it.
+#[test]
+fn every_method_has_a_case() {
+    let covered: Vec<AnomalyMethod> = method_cases()
+        .iter()
+        .map(|case| case.options.method())
+        .collect();
+
+    for method in [
+        AnomalyMethod::Ewma,
+        AnomalyMethod::Cusum,
+        AnomalyMethod::ZScore,
+        AnomalyMethod::ModifiedZScore,
+        AnomalyMethod::SmoothedZScore,
+        AnomalyMethod::Mad,
+        AnomalyMethod::DoubleMAD,
+        AnomalyMethod::InterquartileRange,
+        AnomalyMethod::RandomCutForest,
+        AnomalyMethod::Esd,
+    ] {
+        assert!(
+            covered.contains(&method),
+            "{method:?} has no score-contract case"
+        );
+    }
+}

--- a/src/analysis/outliers/smoothed_zscores.rs
+++ b/src/analysis/outliers/smoothed_zscores.rs
@@ -4,6 +4,7 @@
 /// Port of the golang implementation here:
 /// https://github.com/MicahParks/peakdetect
 /// Original License: Apache-2.0
+use super::utils::normalize_evidence;
 use super::{Anomaly, AnomalyDetector, AnomalyMethod, AnomalyResult, AnomalySignal};
 use crate::analysis::{TimeSeriesAnalysisError, TimeSeriesAnalysisResult};
 
@@ -183,29 +184,20 @@ impl SmoothedZScoreAnomalyDetector {
 
     /// Calculates a normalized anomaly score in [0, 1] for `value`.
     ///
-    /// The score is based on the current moving mean and standard deviation:
-    /// `z = |value - prev_mean| / prev_std_dev`.
-    /// It is then mapped to [0, 1) via `z / (threshold + z)` so that:
+    /// Evidence is the departure from the moving mean; the boundary is the
+    /// `threshold * prev_std_dev` that [`Self::next`] tests it against. So:
     /// - `0.0` when `value == prev_mean`
-    /// - `0.5` when `z == threshold`
-    /// - approaches `1.0` as `z` grows
+    /// - `0.5` when the deviation sits exactly on the threshold
+    /// - approaches `1.0` as the deviation grows
+    ///
+    /// This algorithm already satisfied the 0.5 contract — `z / (threshold + z)`
+    /// is `normalize_evidence(deviation, threshold * std_dev)` rearranged — so
+    /// routing it through the shared helper changes no value. It is written this
+    /// way so the arithmetic lives in one place rather than being re-derived,
+    /// and so the degenerate cases cannot drift from the rest of the module.
     pub fn get_anomaly_score(&self, value: f64) -> f64 {
         let deviation = (value - self.prev_mean).abs();
-
-        // Guard against degenerate or invalid std dev.
-        if !self.prev_std_dev.is_finite() || self.prev_std_dev <= 0.0 {
-            return if deviation <= f64::EPSILON { 0.0 } else { 1.0 };
-        }
-
-        // Guard against nonsensical thresholds.
-        if !self.threshold.is_finite() || self.threshold <= 0.0 {
-            return 0.0;
-        }
-
-        let z = deviation / self.prev_std_dev;
-        let score = z / (self.threshold + z);
-
-        score.clamp(0.0, 1.0)
+        normalize_evidence(deviation, self.threshold * self.prev_std_dev)
     }
 
     pub fn detect(&mut self, ts: &[f64]) -> TimeSeriesAnalysisResult<AnomalyResult> {

--- a/src/analysis/outliers/smoothed_zscores.rs
+++ b/src/analysis/outliers/smoothed_zscores.rs
@@ -128,6 +128,11 @@ impl SmoothedZScoreAnomalyDetector {
                 "the length of the initial values is zero, the length is used as the lag for the algorithm".to_string()
             ));
         }
+        if !threshold.is_finite() {
+            return Err(TimeSeriesAnalysisError::InvalidInput(format!(
+                "threshold must be finite, got {threshold}"
+            )));
+        }
         if threshold < 0.0 {
             return Err(TimeSeriesAnalysisError::InvalidInput(format!(
                 "threshold must be non-negative, got {threshold}"
@@ -568,6 +573,28 @@ mod tests {
                 assert!(msg.contains("non-negative"));
             }
             _ => panic!("Expected InvalidInput error"),
+        }
+    }
+
+    /// `NaN < 0.0` is `false`, so the non-negative check alone lets a NaN
+    /// threshold through; `f64::INFINITY < 0.0` is also `false`. Either one
+    /// reaching `threshold * prev_std_dev` makes every comparison in `next`
+    /// false, so the detector goes permanently inert without ever reporting an
+    /// error. Finiteness must be checked first.
+    #[test]
+    fn test_new_rejects_non_finite_threshold() {
+        for threshold in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let result = SmoothedZScoreAnomalyDetector::new(0.5, threshold, 5);
+
+            match result {
+                Err(TimeSeriesAnalysisError::InvalidInput(msg)) => {
+                    assert!(
+                        msg.contains("finite"),
+                        "expected a finiteness error for threshold {threshold}, got: {msg}"
+                    );
+                }
+                _ => panic!("Expected InvalidInput error for threshold {threshold}"),
+            }
         }
     }
 

--- a/src/analysis/outliers/smoothed_zscores.rs
+++ b/src/analysis/outliers/smoothed_zscores.rs
@@ -128,6 +128,11 @@ impl SmoothedZScoreAnomalyDetector {
                 "the length of the initial values is zero, the length is used as the lag for the algorithm".to_string()
             ));
         }
+        if threshold < 0.0 {
+            return Err(TimeSeriesAnalysisError::InvalidInput(format!(
+                "threshold must be non-negative, got {threshold}"
+            )));
+        }
 
         let mut res = Self {
             index: 0,
@@ -545,6 +550,22 @@ mod tests {
         match result.unwrap_err() {
             TimeSeriesAnalysisError::InvalidInput(msg) => {
                 assert!(msg.contains("zero"));
+            }
+            _ => panic!("Expected InvalidInput error"),
+        }
+    }
+
+    #[test]
+    fn test_new_rejects_negative_threshold() {
+        // A negative threshold flips the sign of `threshold * std_dev`, which
+        // breaks the 0.5 contract: `classify` (a plain `score > boundary`) would
+        // flag almost every point, while `normalize_evidence` treats the
+        // negative boundary as unusable and reports 0.0 for the same point.
+        let result = SmoothedZScoreAnomalyDetector::new(0.5, -1.0, 5);
+
+        match result {
+            Err(TimeSeriesAnalysisError::InvalidInput(msg)) => {
+                assert!(msg.contains("non-negative"));
             }
             _ => panic!("Expected InvalidInput error"),
         }

--- a/src/analysis/outliers/smoothed_zscores.rs
+++ b/src/analysis/outliers/smoothed_zscores.rs
@@ -128,6 +128,14 @@ impl SmoothedZScoreAnomalyDetector {
                 "the length of the initial values is zero, the length is used as the lag for the algorithm".to_string()
             ));
         }
+        // `influence` is a mixing weight — `influence * value + (1 - influence)
+        // * prev_value` — so anything outside `[0, 1]` turns that blend into an
+        // extrapolation rather than an interpolation.
+        if !(0.0..=1.0).contains(&influence) {
+            return Err(TimeSeriesAnalysisError::InvalidInput(format!(
+                "influence must be between 0 and 1 inclusive, got {influence}"
+            )));
+        }
         if !threshold.is_finite() {
             return Err(TimeSeriesAnalysisError::InvalidInput(format!(
                 "threshold must be finite, got {threshold}"
@@ -596,6 +604,30 @@ mod tests {
                 _ => panic!("Expected InvalidInput error for threshold {threshold}"),
             }
         }
+    }
+
+    /// `influence` blends `value` and `prev_value`: outside `[0, 1]` that blend
+    /// becomes an extrapolation rather than an interpolation, which the
+    /// algorithm was never designed to handle.
+    #[test]
+    fn test_new_rejects_influence_outside_unit_interval() {
+        for influence in [-0.1, 1.1, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let result = SmoothedZScoreAnomalyDetector::new(influence, 3.0, 5);
+
+            match result {
+                Err(TimeSeriesAnalysisError::InvalidInput(msg)) => {
+                    assert!(
+                        msg.contains("influence"),
+                        "expected an influence error for {influence}, got: {msg}"
+                    );
+                }
+                _ => panic!("Expected InvalidInput error for influence {influence}"),
+            }
+        }
+
+        // The documented endpoints must still be accepted.
+        assert!(SmoothedZScoreAnomalyDetector::new(0.0, 3.0, 5).is_ok());
+        assert!(SmoothedZScoreAnomalyDetector::new(1.0, 3.0, 5).is_ok());
     }
 
     #[test]

--- a/src/analysis/outliers/utils.rs
+++ b/src/analysis/outliers/utils.rs
@@ -60,6 +60,32 @@ pub(super) fn normalize_evidence(evidence: f64, boundary: f64) -> f64 {
     score
 }
 
+/// Signed deviation from `center`, and the distance out to the fence on the
+/// value's own side.
+///
+/// The boundary is taken as the fence-minus-center subtraction rather than a
+/// recomputation (e.g. `k * mad`), so a value sitting *exactly on the
+/// reported fence* yields evidence and boundary from the identical
+/// subtraction and scores exactly `0.5` via [`normalize_evidence`]. Shared by
+/// every fenced detector (MAD, IQR, Z-score, modified Z-score) so scoring and
+/// classification read the same pair and cannot disagree about which side of
+/// the fence a value falls on.
+#[inline]
+pub(super) fn deviation_and_fence_distance(
+    value: f64,
+    center: f64,
+    lower_fence: f64,
+    upper_fence: f64,
+) -> (f64, f64) {
+    let deviation = value - center;
+    let boundary = if deviation >= 0.0 {
+        upper_fence - center
+    } else {
+        center - lower_fence
+    };
+    (deviation, boundary)
+}
+
 #[inline]
 pub(super) fn normalize_value(v: f64) -> f64 {
     if v.is_nan() { 0.0 } else { v }

--- a/src/analysis/outliers/utils.rs
+++ b/src/analysis/outliers/utils.rs
@@ -47,8 +47,13 @@ pub(super) fn normalize_evidence(evidence: f64, boundary: f64) -> f64 {
         return 1.0;
     }
 
-    let r = evidence / boundary;
-    let score = r / (r + 1.0);
+    // `evidence / (evidence + boundary)` rather than `r / (r + 1.0)` with
+    // `r = evidence / boundary`: algebraically identical, but the latter
+    // overflows to infinity (and then NaN from inf/inf) when `evidence` is
+    // huge and `boundary` is tiny, since the intermediate ratio can exceed
+    // `f64::MAX` even though neither input, nor the true score, is anywhere
+    // near it.
+    let score = evidence / (evidence + boundary);
 
     if score <= 0.5 && evidence > boundary {
         // `evidence / boundary` rounds to exactly 1.0 when evidence is a single
@@ -146,6 +151,19 @@ mod tests {
         // The two exact 1.0s the contract admits.
         assert_eq!(normalize_evidence(f64::INFINITY, 3.0), 1.0);
         assert_eq!(normalize_evidence(100.0, 0.0), 1.0);
+    }
+
+    /// Huge evidence against a vanishingly small (but usable) boundary must
+    /// still land in `[0, 1]`. The naive `r = evidence / boundary` overflows to
+    /// infinity here even though neither input is infinite, which then turns
+    /// `r / (r + 1.0)` into `inf / inf`, i.e. NaN.
+    #[test]
+    fn huge_evidence_against_a_tiny_boundary_stays_finite_and_in_range() {
+        let score = normalize_evidence(1e300, f64::MIN_POSITIVE / 2.0);
+        assert!(
+            score.is_finite() && (0.0..=1.0).contains(&score),
+            "expected a finite score in [0, 1], got {score}"
+        );
     }
 
     /// A collapsed scale is what a robust estimator reports for a series that is

--- a/src/analysis/outliers/utils.rs
+++ b/src/analysis/outliers/utils.rs
@@ -1,13 +1,63 @@
 use crate::analysis::outliers::AnomalySignal;
 
-/// Squash an unbounded non-negative score into the range [0..1].
+/// Map `evidence` against a detection `boundary` onto `[0, 1]`, with `0.5` at the
+/// boundary.
+///
+/// Every method reduces its verdict to one dimensionless ratio
+/// `r = evidence / boundary`, where `r == 1` exactly at the point the method
+/// starts flagging. `score = r / (r + 1)` then puts `0.0` at the center, `0.5`
+/// at the boundary, and approaches `1.0` as evidence grows without bound. See
+/// [`AnomalyDetector::detect`](super::AnomalyDetector::detect) for the contract
+/// this implements.
+///
+/// Taking the boundary as an argument — rather than exposing a bare
+/// `normalize(r)` each detector must remember to pre-divide — keeps the division
+/// and the degenerate guard in one place, so a detector cannot normalize raw
+/// evidence by accident.
+///
+/// # Edges
+///
+/// - No evidence (`<= 0`, or NaN) yields `0.0`, whatever the boundary. A sample
+///   sitting at the center is the least anomalous thing there is, and a missing
+///   reading is not evidence of an anomaly. Callers must also not flag NaN — see
+///   [`detect_pointwise`](super::detect_pointwise).
+/// - An unusable boundary — NaN (nothing fitted yet), negative, or `+∞` (a fence
+///   nothing can cross) — yields `0.0`: there is no test to be past.
+/// - A *collapsed* boundary (exactly `0.0`, i.e. a fitted scale of zero) with
+///   positive evidence yields `1.0`. Every deviation is then infinitely many
+///   units of a zero scale, and the fences have collapsed onto the center, so
+///   the classifiers flag it; scoring it `0.0` would put "flagged" and
+///   "score > 0.5" in direct contradiction. This is what a robust scale does on
+///   a series that is more than half constant — a lone spike over a flat
+///   baseline still has to be reported.
+/// - Infinite evidence against a usable boundary yields `1.0`, matching the
+///   classifiers, which flag infinities against any finite fence.
+///
+/// Those last two are the only places the contract admits an exact `1.0`, and
+/// both exist so that "flagged" and "score > 0.5" cannot disagree.
 #[inline]
-pub(super) fn normalize_unbounded_score(score: f64) -> f64 {
-    if !score.is_finite() || score <= 0.0 {
-        0.0
-    } else {
-        score / (score + 1.0)
+pub(super) fn normalize_evidence(evidence: f64, boundary: f64) -> f64 {
+    if evidence.is_nan() || evidence <= 0.0 {
+        return 0.0;
     }
+    if boundary.is_nan() || boundary < 0.0 || boundary == f64::INFINITY {
+        return 0.0;
+    }
+    if boundary == 0.0 || evidence.is_infinite() {
+        return 1.0;
+    }
+
+    let r = evidence / boundary;
+    let score = r / (r + 1.0);
+
+    if score <= 0.5 && evidence > boundary {
+        // `evidence / boundary` rounds to exactly 1.0 when evidence is a single
+        // ULP past the boundary, which would report 0.5 — the not-flagged side —
+        // for a sample its own classifier flags. Nudge it back across.
+        return f64::from_bits(0.5f64.to_bits() + 1);
+    }
+
+    score
 }
 
 #[inline]
@@ -34,32 +84,116 @@ pub(super) fn get_anomaly_direction(
 mod tests {
     use super::*;
 
+    /// The anchor the whole contract rests on: evidence sitting exactly on the
+    /// boundary scores `0.5`, whatever the boundary happens to be.
     #[test]
-    fn test_normalize_unbounded_score_range_and_edges() {
-        // Range contract + edge handling.
-        assert_eq!(normalize_unbounded_score(f64::NAN), 0.0);
-        assert_eq!(normalize_unbounded_score(f64::INFINITY), 0.0);
-        assert_eq!(normalize_unbounded_score(-1.0), 0.0);
-        assert_eq!(normalize_unbounded_score(0.0), 0.0);
+    fn evidence_at_the_boundary_scores_one_half() {
+        for boundary in [0.25, 1.0, 3.0, 3.5, 5.0, 1e6] {
+            let s = normalize_evidence(boundary, boundary);
+            assert!(
+                (s - 0.5).abs() < 1e-12,
+                "boundary {boundary} should score 0.5, got {s}"
+            );
+        }
+    }
 
-        let s = normalize_unbounded_score(1.0);
-        assert!(s > 0.0 && s < 1.0, "Expected (0,1) for score=1.0, got {s}");
+    /// The score must partition the same way the classifiers do: strictly above
+    /// the boundary is flagged territory, at or below it is not.
+    #[test]
+    fn score_straddles_one_half_at_the_boundary() {
+        assert!(normalize_evidence(2.9, 3.0) < 0.5);
+        assert!(normalize_evidence(3.1, 3.0) > 0.5);
     }
 
     #[test]
-    fn test_normalize_unbounded_score_monotonicity() {
-        // Monotonic squashing: larger inputs must not produce smaller outputs.
-        let a = normalize_unbounded_score(0.5);
-        let b = normalize_unbounded_score(1.0);
-        let c = normalize_unbounded_score(2.0);
-        let d = normalize_unbounded_score(10.0);
+    fn normalize_evidence_range_and_edges() {
+        assert_eq!(normalize_evidence(f64::NAN, 3.0), 0.0);
+        assert_eq!(normalize_evidence(-1.0, 3.0), 0.0);
+        assert_eq!(normalize_evidence(0.0, 3.0), 0.0);
 
-        assert!(a < b, "Expected 0.5 < 1.0 mapping, got {a} vs {b}");
-        assert!(b < c, "Expected 1.0 < 2.0 mapping, got {b} vs {c}");
-        assert!(c < d, "Expected 2.0 < 10.0 mapping, got {c} vs {d}");
+        // No usable boundary: nothing to be past.
+        assert_eq!(normalize_evidence(100.0, -1.0), 0.0);
+        assert_eq!(normalize_evidence(100.0, f64::NAN), 0.0);
+        assert_eq!(normalize_evidence(100.0, f64::INFINITY), 0.0);
+        assert_eq!(normalize_evidence(f64::INFINITY, f64::NAN), 0.0);
+
+        // The two exact 1.0s the contract admits.
+        assert_eq!(normalize_evidence(f64::INFINITY, 3.0), 1.0);
+        assert_eq!(normalize_evidence(100.0, 0.0), 1.0);
+    }
+
+    /// A collapsed scale is what a robust estimator reports for a series that is
+    /// more than half constant. The fences collapse onto the center, so the
+    /// classifiers flag every deviation — the score has to agree, or a lone
+    /// spike over a flat baseline gets flagged while scoring "maximally normal".
+    #[test]
+    fn collapsed_boundary_makes_any_deviation_maximal() {
+        assert_eq!(normalize_evidence(9.0, 0.0), 1.0);
+        assert_eq!(normalize_evidence(1e-300, 0.0), 1.0);
+        // ...but a sample sitting exactly on the collapsed center is not.
+        assert_eq!(normalize_evidence(0.0, 0.0), 0.0);
+    }
+
+    /// The score must never land on the not-flagged side for evidence that is
+    /// past the boundary, however narrowly — the ratio rounds to exactly 1.0
+    /// within an ULP of the fence.
+    #[test]
+    fn evidence_one_ulp_past_the_boundary_scores_above_one_half() {
+        for boundary in [1.0f64, 3.0, 3.5, 1e-8, 1e8] {
+            let evidence = f64::from_bits(boundary.to_bits() + 1);
+            assert!(
+                evidence > boundary,
+                "test setup: expected a larger neighbor"
+            );
+
+            let s = normalize_evidence(evidence, boundary);
+            assert!(
+                s > 0.5,
+                "evidence {evidence} past boundary {boundary} scored {s}, which reads as not-flagged"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_evidence_is_monotone_and_stays_below_one() {
+        let scores: Vec<f64> = [0.5, 1.0, 2.0, 10.0, 1e12]
+            .iter()
+            .map(|&e| normalize_evidence(e, 1.0))
+            .collect();
+
+        for pair in scores.windows(2) {
+            assert!(
+                pair[0] < pair[1],
+                "expected monotone increase, got {scores:?}"
+            );
+        }
         assert!(
-            d < 1.0,
-            "Expected strict less than 1.0 for finite inputs, got {d}"
+            *scores.last().unwrap() < 1.0,
+            "finite evidence must stay strictly below 1.0, got {scores:?}"
         );
+    }
+
+    /// The threshold enters only as a divisor, so raising it rescales scores
+    /// without reordering them.
+    #[test]
+    fn normalize_evidence_preserves_ordering_across_boundaries() {
+        let evidence = [0.5, 1.0, 4.0, 9.0];
+        let tight: Vec<f64> = evidence
+            .iter()
+            .map(|&e| normalize_evidence(e, 1.0))
+            .collect();
+        let loose: Vec<f64> = evidence
+            .iter()
+            .map(|&e| normalize_evidence(e, 5.0))
+            .collect();
+
+        for i in 0..evidence.len() - 1 {
+            assert!(tight[i] < tight[i + 1]);
+            assert!(loose[i] < loose[i + 1]);
+            assert!(
+                loose[i] < tight[i],
+                "a looser boundary must lower every score"
+            );
+        }
     }
 }

--- a/src/analysis/outliers/utils.rs
+++ b/src/analysis/outliers/utils.rs
@@ -140,7 +140,8 @@ mod tests {
         let upper_fence = 4.0;
 
         for value in [center, center + 5.0, center - 5.0] {
-            let (_, boundary) = deviation_and_fence_distance(value, center, lower_fence, upper_fence);
+            let (_, boundary) =
+                deviation_and_fence_distance(value, center, lower_fence, upper_fence);
             assert!(
                 boundary.is_nan(),
                 "expected an unusable boundary for value {value}, got {boundary}"

--- a/src/analysis/outliers/utils.rs
+++ b/src/analysis/outliers/utils.rs
@@ -72,9 +72,18 @@ pub(super) fn normalize_evidence(evidence: f64, boundary: f64) -> f64 {
 /// recomputation (e.g. `k * mad`), so a value sitting *exactly on the
 /// reported fence* yields evidence and boundary from the identical
 /// subtraction and scores exactly `0.5` via [`normalize_evidence`]. Shared by
-/// every fenced detector (MAD, IQR, Z-score, modified Z-score) so scoring and
-/// classification read the same pair and cannot disagree about which side of
-/// the fence a value falls on.
+/// every fenced detector (MAD, double MAD, IQR, Z-score, modified Z-score) so
+/// scoring and classification read the same pair and cannot disagree about
+/// which side of the fence a value falls on.
+///
+/// A misconfigured detector (a non-positive threshold) inverts its fences,
+/// which would otherwise make this subtraction negative. `classify`'s
+/// `deviation.abs() > boundary` is then true for essentially every value —
+/// even the center itself — while [`normalize_evidence`] already treats a
+/// negative boundary as unusable and reports `0.0`. Mapping it to `NaN` here
+/// keeps the two in agreement: both sides read the fences as having nothing
+/// to be past, rather than classify flagging what scoring calls maximally
+/// normal.
 #[inline]
 pub(super) fn deviation_and_fence_distance(
     value: f64,
@@ -88,6 +97,7 @@ pub(super) fn deviation_and_fence_distance(
     } else {
         center - lower_fence
     };
+    let boundary = if boundary < 0.0 { f64::NAN } else { boundary };
     (deviation, boundary)
 }
 
@@ -114,6 +124,29 @@ pub(super) fn get_anomaly_direction(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A non-positive threshold inverts the fences (`upper < center < lower`),
+    /// which used to make this return a negative boundary — `classify`'s
+    /// `deviation.abs() > boundary` is then true for essentially every value,
+    /// including the center itself, while `normalize_evidence` already reports
+    /// `0.0` for a negative boundary. Mapping it to NaN keeps both readings
+    /// "nothing to be past" in agreement.
+    #[test]
+    fn inverted_fences_from_a_negative_threshold_yield_no_usable_boundary() {
+        let center = 10.0;
+        // As if built from `median - k * mad` / `median + k * mad` with a
+        // negative `k`: the fences swap sides.
+        let lower_fence = 16.0;
+        let upper_fence = 4.0;
+
+        for value in [center, center + 5.0, center - 5.0] {
+            let (_, boundary) = deviation_and_fence_distance(value, center, lower_fence, upper_fence);
+            assert!(
+                boundary.is_nan(),
+                "expected an unusable boundary for value {value}, got {boundary}"
+            );
+        }
+    }
 
     /// The anchor the whole contract rests on: evidence sitting exactly on the
     /// boundary scores `0.5`, whatever the boundary happens to be.

--- a/src/analysis/outliers/zscore_outlier_detector.rs
+++ b/src/analysis/outliers/zscore_outlier_detector.rs
@@ -1,6 +1,6 @@
 use crate::analysis::TimeSeriesAnalysisResult;
 use crate::analysis::math::calculate_mean_std_dev;
-use crate::analysis::outliers::utils::normalize_evidence;
+use crate::analysis::outliers::utils::{deviation_and_fence_distance, normalize_evidence};
 use crate::analysis::outliers::{
     AnomalyDetector, AnomalyMethod, AnomalyResult, AnomalySignal, MethodInfo, PointDetector,
     detect_pointwise,
@@ -61,17 +61,11 @@ impl ZScoreOutlierDetector {
     /// the identical subtraction and scores exactly `0.5`.
     #[inline]
     fn deviation_and_boundary(&self, value: f64) -> (f64, f64) {
-        let deviation = value - self.mean;
         if self.std_dev < f64::EPSILON {
             // Constant to within rounding: no scale, so nothing to be past.
-            return (deviation, f64::NAN);
+            return (value - self.mean, f64::NAN);
         }
-        let boundary = if deviation >= 0.0 {
-            self.upper_fence - self.mean
-        } else {
-            self.mean - self.lower_fence
-        };
-        (deviation, boundary)
+        deviation_and_fence_distance(value, self.mean, self.lower_fence, self.upper_fence)
     }
 
     pub fn detect(&mut self, ts: &[f64]) -> TimeSeriesAnalysisResult<AnomalyResult> {

--- a/src/analysis/outliers/zscore_outlier_detector.rs
+++ b/src/analysis/outliers/zscore_outlier_detector.rs
@@ -1,6 +1,6 @@
 use crate::analysis::TimeSeriesAnalysisResult;
 use crate::analysis::math::calculate_mean_std_dev;
-use crate::analysis::outliers::utils::normalize_unbounded_score;
+use crate::analysis::outliers::utils::normalize_evidence;
 use crate::analysis::outliers::{
     AnomalyDetector, AnomalyMethod, AnomalyResult, AnomalySignal, MethodInfo, PointDetector,
     detect_pointwise,
@@ -52,6 +52,28 @@ impl ZScoreOutlierDetector {
         (value - self.mean) / self.std_dev
     }
 
+    /// Deviation from the mean, and the distance out to the fence.
+    ///
+    /// `|z| > T` and `|value - mean| > T * sigma` are the same test, but only
+    /// the second is expressed in the units `model_info` reports as fences. The
+    /// distance is read off the fences rather than recomputed, so a value
+    /// sitting exactly on a reported fence produces evidence and boundary from
+    /// the identical subtraction and scores exactly `0.5`.
+    #[inline]
+    fn deviation_and_boundary(&self, value: f64) -> (f64, f64) {
+        let deviation = value - self.mean;
+        if self.std_dev < f64::EPSILON {
+            // Constant to within rounding: no scale, so nothing to be past.
+            return (deviation, f64::NAN);
+        }
+        let boundary = if deviation >= 0.0 {
+            self.upper_fence - self.mean
+        } else {
+            self.mean - self.lower_fence
+        };
+        (deviation, boundary)
+    }
+
     pub fn detect(&mut self, ts: &[f64]) -> TimeSeriesAnalysisResult<AnomalyResult> {
         if !self.is_trained {
             self.train(ts)?;
@@ -93,19 +115,24 @@ impl AnomalyDetector for ZScoreOutlierDetector {
 }
 
 impl PointDetector for ZScoreOutlierDetector {
+    /// Evidence is the departure from the mean and the boundary is the fence it
+    /// is tested against, so the score crosses 0.5 exactly where `classify`
+    /// starts flagging — for any threshold, rather than at 0.75 for `T=3` and
+    /// 0.857 for `T=6`.
     fn score(&self, value: f64) -> f64 {
-        let z_abs = self.get_zscore(value).abs();
-        normalize_unbounded_score(z_abs)
+        let (deviation, boundary) = self.deviation_and_boundary(value);
+        normalize_evidence(deviation.abs(), boundary)
     }
 
     fn classify(&self, value: f64) -> AnomalySignal {
-        let zscore = self.get_zscore(value);
-        let z_abs = zscore.abs();
-        if z_abs > self.threshold {
-            match zscore.signum() {
-                1.0 => AnomalySignal::Positive,
-                -1.0 => AnomalySignal::Negative,
-                _ => AnomalySignal::None,
+        let (deviation, boundary) = self.deviation_and_boundary(value);
+        // A NaN on either side — a missing reading, or a scale that was never
+        // fitted — fails this comparison, which is how it stays unflagged.
+        if deviation.abs() > boundary {
+            if deviation > 0.0 {
+                AnomalySignal::Positive
+            } else {
+                AnomalySignal::Negative
             }
         } else {
             AnomalySignal::None
@@ -145,11 +172,28 @@ mod tests {
             "Should detect at least 2 anomalies, found {anomaly_count}"
         );
 
-        // Anomalies should have high scores
+        // Anomalies score above the 0.5 boundary. The absolute magnitude is not
+        // the interesting part and used to be read as one: `|z| ≈ 5` against
+        // `T = 3` is `r ≈ 1.67`, which is ~0.625 — a firm anomaly, even though
+        // it looks unimpressive next to the old scale, where any point at all
+        // past `T = 3` already scored 0.75.
         let score_25 = result.scores[25];
         let score_75 = result.scores[75];
-        assert!(score_25 > 0.8);
-        assert!(score_75 > 0.8);
+        assert!(
+            score_25 > 0.5,
+            "index 25 should read as an anomaly: {score_25}"
+        );
+        assert!(
+            score_75 > 0.5,
+            "index 75 should read as an anomaly: {score_75}"
+        );
+
+        // And they must outrank the ordinary points around them.
+        let typical = result.scores[10];
+        assert!(
+            typical < 0.5 && typical < score_25.min(score_75),
+            "a baseline point scored {typical}, against {score_25} and {score_75}"
+        );
     }
 
     #[test]
@@ -259,14 +303,16 @@ mod tests {
             "Should detect at least 2 anomalies, found {anomaly_count}"
         );
 
+        // On the normalized scale "high" means past the 0.5 boundary, which is
+        // where the detector itself draws the line.
         assert!(
-            result.scores[25] > 0.75,
-            "Expected high normalized score at index 25, got {}",
+            result.scores[25] > 0.5,
+            "Expected an above-boundary score at index 25, got {}",
             result.scores[25]
         );
         assert!(
-            result.scores[75] > 0.75,
-            "Expected high normalized score at index 75, got {}",
+            result.scores[75] > 0.5,
+            "Expected an above-boundary score at index 75, got {}",
             result.scores[75]
         );
     }
@@ -300,15 +346,15 @@ mod tests {
             "Expected negative anomaly at index 5"
         );
 
-        // And have "high" normalized scores.
+        // And score past the boundary, which is what "high" means on this scale.
         assert!(
-            result.scores[4] > 0.6,
-            "Expected high score at index 4, got {}",
+            result.scores[4] > 0.5,
+            "Expected an above-boundary score at index 4, got {}",
             result.scores[4]
         );
         assert!(
-            result.scores[5] > 0.6,
-            "Expected high score at index 5, got {}",
+            result.scores[5] > 0.5,
+            "Expected an above-boundary score at index 5, got {}",
             result.scores[5]
         );
     }

--- a/src/analysis/outliers/zscore_outlier_detector.rs
+++ b/src/analysis/outliers/zscore_outlier_detector.rs
@@ -150,6 +150,21 @@ mod tests {
     use super::*;
     use crate::analysis::outliers::{AnomalyOptions, detect_anomalies};
 
+    /// A negative threshold inverts the fences. Before `deviation_and_boundary`
+    /// mapped a negative fence distance to NaN, this flagged essentially every
+    /// point — including the mean itself — while still scoring it `0.0`, since
+    /// `normalize_evidence` already treated the negative boundary as unusable.
+    /// Both must now agree that there is nothing to be past.
+    #[test]
+    fn negative_threshold_does_not_flag_the_mean() {
+        let ts: Vec<f64> = (0..100).map(|i| (i as f64 / 10.0).sin()).collect();
+        let mut detector = ZScoreOutlierDetector::new(-3.0);
+        detector.train(&ts).unwrap();
+
+        assert_eq!(detector.classify(detector.mean), AnomalySignal::None);
+        assert_eq!(detector.score(detector.mean), 0.0);
+    }
+
     #[test]
     fn test_zscore_anomaly_detection() {
         // Create a time series with clear anomalies

--- a/src/analysis/quantile_estimators/samples.rs
+++ b/src/analysis/quantile_estimators/samples.rs
@@ -11,11 +11,16 @@ impl Samples {
         Self::new_sorted_unweighted(values)
     }
 
-    /// Sorted with [`f64::total_cmp`] rather than `partial_cmp().unwrap()`,
-    /// which panicked on any NaN in the sample — reachable from
-    /// `TS.OUTLIERS METHOD MAD` over a series with a missing reading.
+    /// NaN values (missing readings) are dropped rather than sorted in: with
+    /// `total_cmp`, NaN sorts as a real (if extreme) element, which both
+    /// biases every quantile position — `n` counts an observation that carries
+    /// no information — and can make the median itself NaN, silently
+    /// disabling a MAD fit for the whole series. Sorted with
+    /// [`f64::total_cmp`] rather than `partial_cmp().unwrap()`, which panicked
+    /// on any NaN in the sample — reachable from `TS.OUTLIERS METHOD MAD` over
+    /// a series with a missing reading.
     pub fn new_unweighted(values: Vec<f64>) -> Self {
-        let mut values = values;
+        let mut values: Vec<f64> = values.into_iter().filter(|v| !v.is_nan()).collect();
         values.sort_by(f64::total_cmp);
         Self::new_sorted_unweighted(values)
     }
@@ -29,7 +34,11 @@ impl Samples {
         }
     }
 
+    /// A NaN value is dropped along with its weight, for the same reason
+    /// [`Self::new_unweighted`] drops one: it carries no information but would
+    /// still bias `total_weight` and every quantile position derived from it.
     pub fn new_weighted(mut values: Vec<(f64, f64)>) -> Self {
+        values.retain(|(v, _)| !v.is_nan());
         values.sort_by(|a, b| a.0.total_cmp(&b.0));
         let total_weight: f64 = values.iter().map(|(_, w)| *w).sum();
         let (sorted_values, sorted_weights): (Vec<f64>, Vec<f64>) = values.into_iter().unzip();
@@ -66,5 +75,29 @@ impl From<Vec<f64>> for Samples {
 impl From<&[f64]> for Samples {
     fn from(values: &[f64]) -> Self {
         Self::new_unweighted(values.to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_unweighted_drops_nan_rather_than_sorting_it_in() {
+        let sample = Samples::new_unweighted(vec![1.0, f64::NAN, 2.0, 3.0, f64::NAN]);
+
+        assert_eq!(sample.values, vec![1.0, 2.0, 3.0]);
+        assert_eq!(sample.len(), 3);
+        assert_eq!(sample.weighted_size(), 3.0);
+    }
+
+    #[test]
+    fn new_weighted_drops_nan_and_its_paired_weight() {
+        let sample =
+            Samples::new_weighted(vec![(1.0, 10.0), (f64::NAN, 99.0), (2.0, 20.0)]);
+
+        assert_eq!(sample.values, vec![1.0, 2.0]);
+        assert_eq!(sample.sorted_weights, Some(vec![10.0, 20.0]));
+        assert_eq!(sample.weighted_size(), 30.0);
     }
 }

--- a/src/analysis/quantile_estimators/samples.rs
+++ b/src/analysis/quantile_estimators/samples.rs
@@ -11,9 +11,12 @@ impl Samples {
         Self::new_sorted_unweighted(values)
     }
 
+    /// Sorted with [`f64::total_cmp`] rather than `partial_cmp().unwrap()`,
+    /// which panicked on any NaN in the sample — reachable from
+    /// `TS.OUTLIERS METHOD MAD` over a series with a missing reading.
     pub fn new_unweighted(values: Vec<f64>) -> Self {
         let mut values = values;
-        values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        values.sort_by(f64::total_cmp);
         Self::new_sorted_unweighted(values)
     }
 
@@ -27,7 +30,7 @@ impl Samples {
     }
 
     pub fn new_weighted(mut values: Vec<(f64, f64)>) -> Self {
-        values.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        values.sort_by(|a, b| a.0.total_cmp(&b.0));
         let total_weight: f64 = values.iter().map(|(_, w)| *w).sum();
         let (sorted_values, sorted_weights): (Vec<f64>, Vec<f64>) = values.into_iter().unzip();
         Samples {

--- a/src/analysis/quantile_estimators/samples.rs
+++ b/src/analysis/quantile_estimators/samples.rs
@@ -93,11 +93,32 @@ mod tests {
 
     #[test]
     fn new_weighted_drops_nan_and_its_paired_weight() {
-        let sample =
-            Samples::new_weighted(vec![(1.0, 10.0), (f64::NAN, 99.0), (2.0, 20.0)]);
+        let sample = Samples::new_weighted(vec![(1.0, 10.0), (f64::NAN, 99.0), (2.0, 20.0)]);
 
         assert_eq!(sample.values, vec![1.0, 2.0]);
         assert_eq!(sample.sorted_weights, Some(vec![10.0, 20.0]));
         assert_eq!(sample.weighted_size(), 30.0);
+    }
+
+    /// All-NaN input (every reading in the window was missing) must produce a
+    /// well-formed empty sample, not just one that happens not to panic while
+    /// being built — callers (e.g. `MadOutlierDetector::train`) decide whether
+    /// to fit against `is_empty()`/`weighted_size() == 0.0`.
+    #[test]
+    fn new_unweighted_all_nan_yields_an_empty_sample() {
+        let sample = Samples::new_unweighted(vec![f64::NAN, f64::NAN, f64::NAN]);
+
+        assert!(sample.is_empty());
+        assert_eq!(sample.len(), 0);
+        assert_eq!(sample.weighted_size(), 0.0);
+    }
+
+    #[test]
+    fn new_weighted_all_nan_yields_an_empty_sample_with_zero_weight() {
+        let sample = Samples::new_weighted(vec![(f64::NAN, 10.0), (f64::NAN, 20.0)]);
+
+        assert!(sample.is_empty());
+        assert_eq!(sample.sorted_weights, Some(Vec::new()));
+        assert_eq!(sample.weighted_size(), 0.0);
     }
 }

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -340,7 +340,7 @@ fn parse_zscore_options(args: &mut CommandArgIterator) -> ValkeyResult<AnomalyOp
                 threshold = Some(parse_positive_value(args, "THRESHOLD")?);
             },
             "INFLUENCE" => {
-                influence = Some(parse_positive_value(args, "INFLUENCE")?);
+                influence = Some(parse_unit_interval_value(args, "INFLUENCE")?);
             },
             "LAG" => {
                 lag = Some(parse_positive_value(args, "LAG")? as usize);
@@ -400,7 +400,7 @@ fn parse_smoothed_zscore_options(args: &mut CommandArgIterator) -> ValkeyResult<
                 smoothed_options.threshold = parse_positive_value(args, "THRESHOLD")?;
             },
             "INFLUENCE" => {
-                smoothed_options.influence = parse_positive_value(args, "INFLUENCE")?;
+                smoothed_options.influence = parse_unit_interval_value(args, "INFLUENCE")?;
             },
             "LAG" => {
                 smoothed_options.lag = parse_positive_value(args, "LAG")? as usize;
@@ -617,6 +617,23 @@ fn parse_positive_value(iter: &mut CommandArgIterator, option_name: &str) -> Val
     if value <= 0.0 {
         return Err(ValkeyError::String(format!(
             "TSDB: {option_name} must be positive"
+        )));
+    }
+    Ok(value)
+}
+
+/// `INFLUENCE` is a mixing weight — `influence * value + (1 - influence) *
+/// prev_value` — so anything outside `[0, 1]` turns that blend into an
+/// extrapolation rather than an interpolation. `0` (no influence) is valid and
+/// meaningful, which rules out reusing `parse_positive_value`.
+fn parse_unit_interval_value(
+    iter: &mut CommandArgIterator,
+    option_name: &str,
+) -> ValkeyResult<f64> {
+    let value = parse_single_value(iter, option_name)?;
+    if !(0.0..=1.0).contains(&value) {
+        return Err(ValkeyError::String(format!(
+            "TSDB: {option_name} must be between 0 and 1 inclusive"
         )));
     }
     Ok(value)

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -507,14 +507,21 @@ fn parse_rcf_options(args: &mut CommandArgIterator) -> ValkeyResult<AnomalyOptio
                 rcf_options.sample_size = Some(parse_positive_value(args, "SAMPLE_SIZE")? as usize);
             },
             "THRESHOLD" => {
-                let val = parse_positive_value(args, "THRESHOLD")?;
+                // Positivity is `RCFThreshold::std_dev`'s job, not this parser's:
+                // it produces the specific "std_dev threshold must be positive"
+                // message, whereas a generic pre-check here would shadow it with
+                // a less informative one for every out-of-range value.
+                let val = parse_finite_value(args, "THRESHOLD")?;
                 rcf_options.threshold = Some(
                     RCFThreshold::std_dev(val)
                         .map_err(|e| ValkeyError::String(format!("TSDB: {e}")))?
                 );
             },
             "CONTAMINATION" => {
-                let val = parse_positive_value(args, "CONTAMINATION")?;
+                // Same reasoning as THRESHOLD above: `RCFThreshold::contamination`
+                // validates the full `(0..0.5]` range and reports it, so this
+                // parser only needs to guard against non-finite input.
+                let val = parse_finite_value(args, "CONTAMINATION")?;
                 rcf_options.threshold = Some(
                     RCFThreshold::contamination(val)
                         .map_err(|e| ValkeyError::String(format!("TSDB: {e}")))?
@@ -608,15 +615,24 @@ fn parse_single_value(iter: &mut CommandArgIterator, option_name: &str) -> Valke
 }
 
 fn parse_positive_value(iter: &mut CommandArgIterator, option_name: &str) -> ValkeyResult<f64> {
+    let value = parse_finite_value(iter, option_name)?;
+    if value <= 0.0 {
+        return Err(ValkeyError::String(format!(
+            "TSDB: {option_name} must be positive"
+        )));
+    }
+    Ok(value)
+}
+
+/// Rejects NaN/infinite input but leaves range validation to the caller.
+/// For options backed by a constructor with its own range check (e.g.
+/// `RCFThreshold::std_dev`/`::contamination`), pre-filtering here for
+/// positivity would shadow that constructor's more specific error message.
+fn parse_finite_value(iter: &mut CommandArgIterator, option_name: &str) -> ValkeyResult<f64> {
     let value = parse_single_value(iter, option_name)?;
     if !value.is_finite() {
         return Err(ValkeyError::String(format!(
             "TSDB: {option_name} must be finite"
-        )));
-    }
-    if value <= 0.0 {
-        return Err(ValkeyError::String(format!(
-            "TSDB: {option_name} must be positive"
         )));
     }
     Ok(value)

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -337,13 +337,13 @@ fn parse_zscore_options(args: &mut CommandArgIterator) -> ValkeyResult<AnomalyOp
         let arg_slice = arg.as_slice();
         hashify::fnc_map_ignore_case!(arg_slice,
             "THRESHOLD" => {
-                threshold = Some(parse_single_value(args, "THRESHOLD")?);
+                threshold = Some(parse_positive_value(args, "THRESHOLD")?);
             },
             "INFLUENCE" => {
-                influence = Some(parse_single_value(args, "INFLUENCE")?);
+                influence = Some(parse_positive_value(args, "INFLUENCE")?);
             },
             "LAG" => {
-                lag = Some(parse_single_value(args, "LAG")? as usize);
+                lag = Some(parse_positive_value(args, "LAG")? as usize);
             },
             _ => {
                 return Err(ValkeyError::String(format!("TSDB: unknown zscore option {arg}")));
@@ -397,13 +397,13 @@ fn parse_smoothed_zscore_options(args: &mut CommandArgIterator) -> ValkeyResult<
         let arg_slice = arg.as_slice();
         hashify::fnc_map_ignore_case!(arg_slice,
             "THRESHOLD" => {
-                smoothed_options.threshold = parse_single_value(args, "THRESHOLD")?;
+                smoothed_options.threshold = parse_positive_value(args, "THRESHOLD")?;
             },
             "INFLUENCE" => {
-                smoothed_options.influence = parse_single_value(args, "INFLUENCE")?;
+                smoothed_options.influence = parse_positive_value(args, "INFLUENCE")?;
             },
             "LAG" => {
-                smoothed_options.lag = parse_single_value(args, "LAG")? as usize;
+                smoothed_options.lag = parse_positive_value(args, "LAG")? as usize;
             },
             _ => {
                 return Err(ValkeyError::String(format!("TSDB: unknown smoothed zscore option {arg}")));
@@ -434,7 +434,7 @@ fn parse_mad_options(args: &mut CommandArgIterator) -> ValkeyResult<AnomalyOptio
                  mad_options.estimator = estimator_arg.parse()?;
             },
             "THRESHOLD" => {
-                 mad_options.k = parse_single_value(args, "THRESHOLD")?;
+                 mad_options.k = parse_positive_value(args, "THRESHOLD")?;
             },
             _ => {
                  return Err(ValkeyError::String(format!("TSDB: unknown Mad option {arg}")));
@@ -467,7 +467,7 @@ fn parse_double_mad_options(args: &mut CommandArgIterator) -> ValkeyResult<Anoma
                 double_mad_options.estimator = estimator_arg.parse()?;
             },
             "THRESHOLD" => {
-                double_mad_options.k = parse_single_value(args, "THRESHOLD")?;
+                double_mad_options.k = parse_positive_value(args, "THRESHOLD")?;
             },
             _ => {
                 return Err(ValkeyError::String(format!("TSDB: unknown Double Mad option {arg}")));
@@ -501,20 +501,20 @@ fn parse_rcf_options(args: &mut CommandArgIterator) -> ValkeyResult<AnomalyOptio
         let arg_slice = arg.as_slice();
         hashify::fnc_map_ignore_case!(arg_slice,
             "NUM_TREES" => {
-                rcf_options.num_trees = Some(parse_single_value(args, "NUM_TREES")? as usize);
+                rcf_options.num_trees = Some(parse_positive_value(args, "NUM_TREES")? as usize);
             },
             "SAMPLE_SIZE" => {
-                rcf_options.sample_size = Some(parse_single_value(args, "SAMPLE_SIZE")? as usize);
+                rcf_options.sample_size = Some(parse_positive_value(args, "SAMPLE_SIZE")? as usize);
             },
             "THRESHOLD" => {
-                let val = parse_single_value(args, "THRESHOLD")?;
+                let val = parse_positive_value(args, "THRESHOLD")?;
                 rcf_options.threshold = Some(
                     RCFThreshold::std_dev(val)
                         .map_err(|e| ValkeyError::String(format!("TSDB: {e}")))?
                 );
             },
             "CONTAMINATION" => {
-                let val = parse_single_value(args, "CONTAMINATION")?;
+                let val = parse_positive_value(args, "CONTAMINATION")?;
                 rcf_options.threshold = Some(
                     RCFThreshold::contamination(val)
                         .map_err(|e| ValkeyError::String(format!("TSDB: {e}")))?
@@ -524,10 +524,10 @@ fn parse_rcf_options(args: &mut CommandArgIterator) -> ValkeyResult<AnomalyOptio
                 rcf_options.time_decay = Some(parse_single_value(args, "DECAY")?);
             },
             "SHINGLE_SIZE" => {
-                rcf_options.shingle_size = Some(parse_single_value(args, "SHINGLE_SIZE")? as usize);
+                rcf_options.shingle_size = Some(parse_positive_value(args, "SHINGLE_SIZE")? as usize);
             },
             "OUTPUT_AFTER" => {
-                rcf_options.output_after = Some(parse_single_value(args, "OUTPUT_AFTER")? as usize);
+                rcf_options.output_after = Some(parse_positive_value(args, "OUTPUT_AFTER")? as usize);
             },
             _ => {
                 return Err(ValkeyError::String(format!("TSDB: unknown RCF option {arg}")));
@@ -560,7 +560,7 @@ fn parse_esd_options(args: &mut CommandArgIterator) -> ValkeyResult<AnomalyOptio
 
         hashify::fnc_map_ignore_case!(arg_slice,
            "ALPHA" => {
-                esd_options.alpha = parse_single_value(args, "ALPHA")?;
+                esd_options.alpha = parse_positive_value(args, "ALPHA")?;
             },
             "HYBRID" => {
                 esd_options.estimator = EsdEstimator::Hybrid;
@@ -569,7 +569,7 @@ fn parse_esd_options(args: &mut CommandArgIterator) -> ValkeyResult<AnomalyOptio
                 esd_options.estimator = EsdEstimator::Classic;
             },
             "MAX_OUTLIERS" => {
-                esd_options.max_outliers = Some(parse_single_value(args, "MAX_OUTLIERS")? as usize);
+                esd_options.max_outliers = Some(parse_positive_value(args, "MAX_OUTLIERS")? as usize);
             },
             _ => {
                 return Err(ValkeyError::String(format!("TSDB: unknown ESD option {arg}")));
@@ -587,7 +587,7 @@ fn parse_optional_threshold_option(args: &mut CommandArgIterator) -> ValkeyResul
         && arg.eq_ignore_ascii_case(b"threshold")
     {
         let _ = args.next();
-        Ok(Some(parse_single_value(args, "THRESHOLD")?))
+        Ok(Some(parse_positive_value(args, "THRESHOLD")?))
     } else {
         Ok(None)
     }
@@ -605,6 +605,16 @@ fn parse_single_value(iter: &mut CommandArgIterator, option_name: &str) -> Valke
             "TSDB: invalid value for {option_name}: {value_str}"
         ))
     })
+}
+
+fn parse_positive_value(iter: &mut CommandArgIterator, option_name: &str) -> ValkeyResult<f64> {
+    let value = parse_single_value(iter, option_name)?;
+    if value <= 0.0 {
+        return Err(ValkeyError::String(format!(
+            "TSDB: {option_name} must be positive"
+        )));
+    }
+    Ok(value)
 }
 
 fn send_reply(

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -1,7 +1,7 @@
 use crate::analysis::outliers::{
     Anomaly, AnomalyDetectionMethodOptions, AnomalyDirection, AnomalyMethod, AnomalyOptions,
-    AnomalyResult, ESDOutlierOptions, EWMA_DEFAULT_ALPHA, MADAnomalyOptions, MethodInfo,
-    RCF_DEFAULT_NUM_TREES, RCF_DEFAULT_SAMPLE_SIZE, RCFOptions, RCFThreshold,
+    AnomalyResult, ESDOutlierOptions, EWMA_DEFAULT_ALPHA, EsdEstimator, MADAnomalyOptions,
+    MethodInfo, RCF_DEFAULT_NUM_TREES, RCF_DEFAULT_SAMPLE_SIZE, RCFOptions, RCFThreshold,
     SmoothedZScoreOptions, detect_anomalies,
 };
 use crate::analysis::seasonality::Seasonality;
@@ -548,19 +548,25 @@ fn parse_esd_options(args: &mut CommandArgIterator) -> ValkeyResult<AnomalyOptio
 
     let mut esd_options = ESDOutlierOptions::default();
 
-    while let Some(arg) = args.next() {
-        let arg_slice = arg.as_slice();
-
-        if is_command_option(arg_slice) {
+    // Peek before consuming: a trailing command option (OUTPUT, DIRECTION, ...)
+    // belongs to the caller's loop. Consuming it here and then breaking would
+    // swallow the token and leave its argument to be parsed as a top-level one.
+    while let Some(arg) = args.peek() {
+        if is_command_option(arg.as_slice()) {
             break;
         }
+        let arg = args.next().unwrap();
+        let arg_slice = arg.as_slice();
 
         hashify::fnc_map_ignore_case!(arg_slice,
            "ALPHA" => {
                 esd_options.alpha = parse_single_value(args, "ALPHA")?;
             },
             "HYBRID" => {
-                esd_options.hybrid = true;
+                esd_options.estimator = EsdEstimator::Hybrid;
+            },
+            "CLASSIC" => {
+                esd_options.estimator = EsdEstimator::Classic;
             },
             "MAX_OUTLIERS" => {
                 esd_options.max_outliers = Some(parse_single_value(args, "MAX_OUTLIERS")? as usize);
@@ -946,7 +952,7 @@ fn reply_with_parameters(
             ctx.reply_with_string("alpha");
             ctx.reply_with_double(o.alpha);
             ctx.reply_with_string("hybrid");
-            ctx.reply_with_bool(o.hybrid);
+            ctx.reply_with_bool(o.estimator.is_hybrid());
             if let Some(max) = o.max_outliers {
                 ctx.reply_with_string("max_outliers");
                 ctx.reply_with_integer(max as i64);

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -609,6 +609,11 @@ fn parse_single_value(iter: &mut CommandArgIterator, option_name: &str) -> Valke
 
 fn parse_positive_value(iter: &mut CommandArgIterator, option_name: &str) -> ValkeyResult<f64> {
     let value = parse_single_value(iter, option_name)?;
+    if !value.is_finite() {
+        return Err(ValkeyError::String(format!(
+            "TSDB: {option_name} must be finite"
+        )));
+    }
     if value <= 0.0 {
         return Err(ValkeyError::String(format!(
             "TSDB: {option_name} must be positive"

--- a/src/series/chunks/uncompressed/mod.rs
+++ b/src/series/chunks/uncompressed/mod.rs
@@ -224,7 +224,14 @@ impl UncompressedChunk {
         let max_size = read_usize(&mut buf)?;
         let max_elements = read_usize(&mut buf)?;
         let len = read_usize(&mut buf)?;
-        let mut samples = Vec::with_capacity(len);
+        // `len` is untrusted (corrupt/malicious peer, truncated RDB, ...): every
+        // sample needs at least 1 byte (uvarint timestamp) + 8 bytes (f64 value),
+        // so capping the reservation to what the remaining buffer could possibly
+        // hold prevents an attacker-controlled `Vec::with_capacity` from
+        // requesting an unbounded allocation, which aborts the process rather
+        // than returning an `Err`.
+        let capacity = len.min(buf.len() / 9);
+        let mut samples = Vec::with_capacity(capacity);
         for _ in 0..len {
             let ts = try_read_uvarint(&mut buf).map_err(|_| TsdbError::ChunkDecoding)? as i64;
             let val = try_read_f64_le(&mut buf).map_err(|_| TsdbError::ChunkDecoding)?;
@@ -1452,5 +1459,25 @@ mod tests {
         let new_chunk = empty_chunk.split().unwrap();
         assert!(empty_chunk.samples.is_empty());
         assert!(new_chunk.samples.is_empty());
+    }
+
+    /// A corrupt/malicious peer can declare an absurd sample count in the
+    /// `len` header while sending only a handful of bytes. `deserialize_raw`
+    /// must reject this via the normal EOF error path rather than reserving
+    /// `len` elements up front: a multi-terabyte `Vec::with_capacity` request
+    /// aborts the process (allocation failure is not a catchable panic), which
+    /// turns a malformed fan-out payload into a crash.
+    #[test]
+    fn test_deserialize_raw_rejects_oversized_len_without_huge_allocation() {
+        use crate::common::encoding::write_uvarint;
+
+        let mut buf = Vec::new();
+        write_uvarint(&mut buf, 0); // max_size
+        write_uvarint(&mut buf, 0); // max_elements
+        write_uvarint(&mut buf, u64::MAX); // len: wildly larger than the buffer could hold
+        // No sample payload follows, so decoding must fail on the first read.
+
+        let result = super::UncompressedChunk::deserialize_raw(&buf);
+        assert!(result.is_err(), "oversized len must be rejected, not honored");
     }
 }

--- a/src/series/chunks/uncompressed/mod.rs
+++ b/src/series/chunks/uncompressed/mod.rs
@@ -1478,6 +1478,9 @@ mod tests {
         // No sample payload follows, so decoding must fail on the first read.
 
         let result = super::UncompressedChunk::deserialize_raw(&buf);
-        assert!(result.is_err(), "oversized len must be rejected, not honored");
+        assert!(
+            result.is_err(),
+            "oversized len must be rejected, not honored"
+        );
     }
 }


### PR DESCRIPTION
This pull request introduces several improvements and clarifications to the anomaly detection methods, especially around how anomaly scores are calculated and interpreted. It also refactors the Double MAD outlier detector for clarity and correctness, and documents the new ESD method and scoring conventions in detail.

**Documentation updates and new features:**

* Added comprehensive documentation for the new ESD (Extreme Studentized Deviate) outlier detection method, including usage, options, and caveats. [[1]](diffhunk://#diff-4ad066055e1c9ff0053cd360b7274e4eecb9d7828fb93a19f6f211792908dd6aR103-R137) [[2]](diffhunk://#diff-4ad066055e1c9ff0053cd360b7274e4eecb9d7828fb93a19f6f211792908dd6aR451-R495)
* Clarified the meaning and calculation of anomaly scores across all methods, establishing that a score of `0.5` is always the detection threshold, making results consistent and comparable. [[1]](diffhunk://#diff-4ad066055e1c9ff0053cd360b7274e4eecb9d7828fb93a19f6f211792908dd6aL251-R287) [[2]](diffhunk://#diff-4ad066055e1c9ff0053cd360b7274e4eecb9d7828fb93a19f6f211792908dd6aL262-R339) [[3]](diffhunk://#diff-4ad066055e1c9ff0053cd360b7274e4eecb9d7828fb93a19f6f211792908dd6aR523-R532)

**Refactoring and scoring logic improvements:**

* Refactored the Double MAD outlier detector (`double_mad_outlier_detector.rs`) to use a single `Fitted` struct for all fitted parameters, simplified fence calculations, and updated scoring to use the new `normalize_evidence` function. This ensures that scores are consistent with the new documentation and that the method is robust to edge cases. [[1]](diffhunk://#diff-c82ca29ba704b65ffcd35be8303ac4dcb518a901317152caa9b3e45ca59761bbL1-R1) [[2]](diffhunk://#diff-c82ca29ba704b65ffcd35be8303ac4dcb518a901317152caa9b3e45ca59761bbL21-L44) [[3]](diffhunk://#diff-c82ca29ba704b65ffcd35be8303ac4dcb518a901317152caa9b3e45ca59761bbL58-R84) [[4]](diffhunk://#diff-c82ca29ba704b65ffcd35be8303ac4dcb518a901317152caa9b3e45ca59761bbL86-R150) [[5]](diffhunk://#diff-c82ca29ba704b65ffcd35be8303ac4dcb518a901317152caa9b3e45ca59761bbL179-R174) [[6]](diffhunk://#diff-c82ca29ba704b65ffcd35be8303ac4dcb518a901317152caa9b3e45ca59761bbL205-R211)
* Updated CUSUM and EWMA outlier detectors to use `normalize_evidence` for score calculation, aligning their scoring with the new conventions. [[1]](diffhunk://#diff-40b1d4fba1509093f63926831d7e8905d0dc027d93fadca40f109110aa0e2bf7L1-R1) [[2]](diffhunk://#diff-40b1d4fba1509093f63926831d7e8905d0dc027d93fadca40f109110aa0e2bf7L96-R99) [[3]](diffhunk://#diff-3a408c2fc45bfc00c7e973fa9c38eb793a6e78448f1976b1c7f72278819595f3L1-R1)

**Dependency updates:**

* Updated the `statrs` crate dependency from version `0.18` to `0.19.0` in `Cargo.toml`.

**Internal API consistency:**

* Changed ESD detector construction to use an `estimator` parameter instead of a `hybrid` boolean, improving clarity and flexibility.

These changes make anomaly detection results more interpretable and consistent, improve code maintainability, and add robust documentation for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Classic and Hybrid estimator options for ESD outlier detection.
  * Standardized anomaly scoring around the 0.5 detection boundary.
  * Improved support for asymmetric distributions, directional signals, constant data, and non-finite values.
  * Enhanced ESD metadata and command-line configuration.

* **Bug Fixes**
  * Improved input validation and handling of invalid or missing values.
  * Prevented sorting failures and unsafe allocations during data decoding.
  * Improved score and classification accuracy at detection boundaries.

* **Documentation**
  * Expanded outlier detection, scoring, ESD configuration, caveat, and performance guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->