### PR TITLE
Implement various bug fixes following code review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.92.0
+          toolchain: 1.96.0
           components: rustfmt, clippy
 
       - name: Set up Buf
@@ -156,7 +156,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.92.0
+          toolchain: 1.96.0
           components: rustfmt, clippy
 
       - name: Run cargo and clippy format check
@@ -182,7 +182,7 @@ jobs:
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.92.0
+          toolchain: 1.96.0
           components: rustfmt, clippy
 
       - name: Set the server version for python integration tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Key ENV and behavior (from `./build.sh`)
 
 Setup & Environment Notes
 
-- Rust: edition 2024, minimum supported version `1.92`.
+- Rust: edition 2024, minimum supported version `1.96`.
 - **After pulling or switching branches, always rebuild the module.** The module binary
   (`target/release/libvalkey_timeseries.{so,dylib}`) is not tracked in git and can be stale
   after source changes — e.g. new config parameters or commands won't be registered, causing

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = "1.0.4"
 croaring = "2.6"
 enquote = "1.1.0"
 enum_dispatch = "0.3.13"
-get-size2 = { version = "0.10.2", features = ["derive"] }
+get-size2 = { version = "0.11.0", features = ["derive"] }
 hashify = { version = "0.2" }
 itertools = "0.14"
 linkme = "0.3"
@@ -36,16 +36,16 @@ smallvec = "1.15.2"
 speedate = "0.17"
 thiserror = "2.0"
 topo_sort = "0.4.0"
-valkey-module = "0.1.11"
-valkey-module-macros = "0.1.11"
+valkey-module = "0.1.14"
+valkey-module-macros = "0.1.14"
 range-set-blaze = "0.6.1"
 rayon-core = "1.13"
 regex = "1"
 strum = { version = "0.28", features = ["derive"] }
 strum_macros = "0.28"
-simd-json = "0.17.3"
+simd-json = "0.18.0"
 log = "0.4"
-statrs = "0.19.0"
+statrs = "0.19.1"
 welch-sde = "0.1.0"
 regex-syntax = "0.8.11"
 crc16 = "0.4.0"
@@ -58,7 +58,7 @@ criterion = { version = "0.8", features = ["html_reports"] }
 rand = "0.10"
 rand_distr = "0.6"
 test-case = "3.3"
-serial_test = { version = "3.5", default-features = false }
+serial_test = { version = "3.5.0", default-features = false }
 proptest = "1"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "valkey-timeseries"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version = "1.96.0"
 readme = "README.md"
 repository = "https://github.com/ccollie/valkey-timeseries"
 homepage = "https://github.com/ccollie/valkey-timeseries"
@@ -12,15 +12,15 @@ description = "A Timeseries data type for Valkey"
 ahash = { version = "0.8", features = ["std"] }
 arc-swap = "1.9"
 blart = "0.5"
-bon = "3.9"
+bon = "3.10.0"
 byte-pool = "0.2.4"
 cfg-if = "1.0.4"
-croaring = "2.6"
+croaring = "2.7.0"
 enquote = "1.1.0"
 enum_dispatch = "0.3.13"
 get-size2 = { version = "0.11.0", features = ["derive"] }
 hashify = { version = "0.2" }
-itertools = "0.14"
+itertools = "0.15.0"
 linkme = "0.3"
 logos = "0.16"
 orx-parallel = "3.4"
@@ -43,7 +43,7 @@ rayon-core = "1.13"
 regex = "1"
 strum = { version = "0.28", features = ["derive"] }
 strum_macros = "0.28"
-simd-json = "0.18.0"
+simd-json = "0.18.1"
 log = "0.4"
 statrs = "0.19.1"
 welch-sde = "0.1.0"
@@ -58,7 +58,7 @@ criterion = { version = "0.8", features = ["html_reports"] }
 rand = "0.10"
 rand_distr = "0.6"
 test-case = "3.3"
-serial_test = { version = "3.5.0", default-features = false }
+serial_test = { version = "4.0.1", default-features = false }
 proptest = "1"
 
 [build-dependencies]

--- a/docs/plans/ts-read-implementation-plan.md
+++ b/docs/plans/ts-read-implementation-plan.md
@@ -24,7 +24,7 @@ work changed an answer, a dated note says so inline rather than silently rewriti
 
 1. **The cluster question answers itself.** §2 called slot migration "genuinely open" and guessed
    a blocked client would hang until timeout. The server already redirects it. See the resolution
-   note in [§2](#registration-and-cluster-behavior) — it is the most load-bearing correction here,
+   note in [§2](#registration-and-cluster-behavior) — it is the most consequential correction here,
    because it is the reason no cluster event handling was written.
 2. **The `dont_cache` tip was expressible.** §1 doubted the macro could emit tips and offered a
    metadata divergence as the fallback. It can; no divergence was needed.

--- a/proto/v1/generated/valkey_timeseries.fanout.v1.rs
+++ b/proto/v1/generated/valkey_timeseries.fanout.v1.rs
@@ -697,8 +697,12 @@ impl LabelResultsSortOrder {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MGetValue {
-    #[prost(string, tag = "1")]
-    pub key: ::prost::alloc::string::String,
+    /// Key names are binary-safe in Valkey (an interior NUL or a non-UTF-8 byte is
+    /// legal), so this is `bytes`, not `string`: proto3 `string` requires valid
+    /// UTF-8 and would force a lossy conversion that corrupts the name the client
+    /// sees. Same for every other key-name field below.
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
     #[prost(message, optional, tag = "2")]
     pub sample: ::core::option::Option<Sample>,
     #[prost(message, repeated, tag = "3")]
@@ -706,8 +710,8 @@ pub struct MGetValue {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SeriesRangeResponse {
-    #[prost(string, tag = "1")]
-    pub key: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "1")]
+    pub key: ::prost::alloc::vec::Vec<u8>,
     #[prost(string, tag = "2")]
     pub group_label_value: ::prost::alloc::string::String,
     #[prost(message, repeated, tag = "3")]
@@ -754,8 +758,8 @@ pub struct ReducePartialState {
 pub struct GroupPartialSeries {
     #[prost(string, tag = "1")]
     pub group_label_value: ::prost::alloc::string::String,
-    #[prost(string, repeated, tag = "2")]
-    pub source_keys: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(bytes = "vec", repeated, tag = "2")]
+    pub source_keys: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
     #[prost(int64, repeated, tag = "3")]
     pub bucket_timestamps: ::prost::alloc::vec::Vec<i64>,
     #[prost(message, repeated, tag = "4")]

--- a/proto/v1/response.proto
+++ b/proto/v1/response.proto
@@ -5,13 +5,17 @@ package valkey_timeseries.fanout.v1;
 import "v1/common.proto";
 
 message MGetValue {
-  string key = 1;
+  // Key names are binary-safe in Valkey (an interior NUL or a non-UTF-8 byte is
+  // legal), so this is `bytes`, not `string`: proto3 `string` requires valid
+  // UTF-8 and would force a lossy conversion that corrupts the name the client
+  // sees. Same for every other key-name field below.
+  bytes key = 1;
   Sample sample = 2;
   repeated Label labels = 3;
 }
 
 message SeriesRangeResponse {
-  string key = 1;
+  bytes key = 1;
   string group_label_value = 2;
   repeated Label labels = 3;
   repeated SampleData columns = 4;
@@ -45,7 +49,7 @@ message ReducePartialState {
 
 message GroupPartialSeries {
   string group_label_value = 1;
-  repeated string source_keys = 2;
+  repeated bytes source_keys = 2;
   repeated int64 bucket_timestamps = 3;
   repeated ReducePartialState states = 4;
   uint32 column_count = 5;

--- a/src/commands/command_parser.rs
+++ b/src/commands/command_parser.rs
@@ -1452,9 +1452,10 @@ fn parse_asof_join_options(args: &mut CommandArgIterator) -> ValkeyResult<JoinTy
         if let Some(next_arg) = args.peek()
             && let Ok(arg_str) = next_arg.try_as_str()
         {
-            // durations in all cases start with an ascii digit, e.g., 1000 or 40 ms
-            let ch = arg_str.chars().next().unwrap();
-            if ch.is_ascii_digit() {
+            // durations in all cases start with an ascii digit, e.g., 1000 or 40 ms.
+            // An empty argument is not a duration; fall through and let the syntax
+            // handling below report it rather than indexing into an empty string.
+            if arg_str.chars().next().is_some_and(|ch| ch.is_ascii_digit()) {
                 let tolerance_ms = parse_duration_ms(arg_str)?;
                 if tolerance_ms < 0 {
                     return Err(ValkeyError::Str(error_consts::INVALID_ASOF_TOLERANCE));

--- a/src/commands/fanout_codec/chunks.rs
+++ b/src/commands/fanout_codec/chunks.rs
@@ -1,4 +1,5 @@
 use super::generated::{CompressionType, Label as FanoutLabel, SampleData, SeriesRangeResponse};
+use crate::common::context::key_for_display;
 use crate::common::logging::log_warning;
 use crate::common::{MultiSample, Sample};
 use crate::error_consts;
@@ -203,7 +204,9 @@ impl TryFrom<SeriesRangeResponse> for MRangeSeriesResult {
         // 1 column => raw/single-aggregation chunk; >= 2 => multi-aggregation
         // rows; 0 => an empty multi-aggregation series (no buckets). Decode
         // failures name the series so triage can locate the owning shard.
-        let with_key = |e: ValkeyError| ValkeyError::String(format!("{e} (series '{key}')"));
+        let with_key = |e: ValkeyError| {
+            ValkeyError::String(format!("{e} (series '{}')", key_for_display(&key)))
+        };
         let data = match value.columns.len() {
             0 => SeriesResultData::Rows(Vec::new()),
             1 => SeriesResultData::Chunk(deserialize_chunk(&value.columns[0]).map_err(with_key)?),

--- a/src/commands/fanout_codec/conversions.rs
+++ b/src/commands/fanout_codec/conversions.rs
@@ -363,7 +363,7 @@ impl From<MGetSeriesData> for MGetValue {
         let sample = value.sample.map(Into::into);
 
         MGetValue {
-            key: value.series_key.to_string_lossy(),
+            key: value.series_key.as_slice().to_vec(),
             labels,
             sample,
         }

--- a/src/commands/fanout_codec/symbol_table.rs
+++ b/src/commands/fanout_codec/symbol_table.rs
@@ -20,6 +20,7 @@
 //! treated as untrusted throughout this crate).
 
 use super::generated::{Label, SeriesRangeResponse};
+use crate::common::context::key_for_display;
 use std::collections::HashMap;
 use valkey_module::{ValkeyError, ValkeyResult};
 
@@ -97,7 +98,7 @@ pub fn resolve_labels(
         if name_refs.len() != value_refs.len() {
             return Err(ValkeyError::String(format!(
                 "TSDB: malformed symbol-table response: series '{}' has {} label name refs but {} value refs",
-                s.key,
+                key_for_display(&s.key),
                 name_refs.len(),
                 value_refs.len()
             )));
@@ -108,14 +109,14 @@ pub fn resolve_labels(
             let name = names.get(name_idx as usize).ok_or_else(|| {
                 ValkeyError::String(format!(
                     "TSDB: malformed symbol-table response: series '{}' label name ref {name_idx} out of range ({} names)",
-                    s.key,
+                    key_for_display(&s.key),
                     names.len()
                 ))
             })?;
             let value = values.get(value_idx as usize).ok_or_else(|| {
                 ValkeyError::String(format!(
                     "TSDB: malformed symbol-table response: series '{}' label value ref {value_idx} out of range ({} values)",
-                    s.key,
+                    key_for_display(&s.key),
                     values.len()
                 ))
             })?;
@@ -177,7 +178,12 @@ mod tests {
 
         resolve_labels(&mut batch, &names, &values).expect("resolve");
         for (got, want) in batch.iter().zip(&original) {
-            assert_eq!(got.labels, want.labels, "series '{}'", want.key);
+            assert_eq!(
+                got.labels,
+                want.labels,
+                "series '{}'",
+                key_for_display(&want.key)
+            );
             assert!(got.label_name_refs.is_empty());
             assert!(got.label_value_refs.is_empty());
         }

--- a/src/commands/ts_mdel.rs
+++ b/src/commands/ts_mdel.rs
@@ -36,9 +36,11 @@ pub fn ts_mdel_cmd(ctx: &Context, args: Vec<ValkeyString>) -> ValkeyResult {
         return operation.exec(ctx);
     }
 
+    // `delete_series_by_selectors` propagates the resolved effects itself (`DEL` / `TS.DEL`), on
+    // this path and on the clustered one above. Replicating verbatim here as well would apply the
+    // deletion twice on the replica, and would re-resolve relative timestamp bounds against the
+    // replica's clock.
     let total_deleted = delete_series_by_selectors(ctx, &filters, date_range)?;
-
-    ctx.replicate_verbatim();
 
     Ok(ValkeyValue::from(total_deleted))
 }

--- a/src/commands/ts_mdel_fanout_command.rs
+++ b/src/commands/ts_mdel_fanout_command.rs
@@ -1,8 +1,10 @@
 use crate::commands::fanout_codec::filters::{deserialize_matchers_list, serialize_matchers_list};
 use crate::commands::fanout_codec::{CountResponse, DateRange, MDelRequest};
+use crate::common::context::is_replica;
 use crate::error_consts;
 use crate::fanout::{FanoutClientCommand, NodeInfo};
 use crate::fanout::{FanoutCommandResult, FanoutContext};
+use crate::fanout::{FanoutTargetMode, FanoutTargets, get_fanout_targets};
 use crate::labels::filters::SeriesSelector;
 use crate::series::{TimestampRange, delete_series_by_selectors};
 use valkey_module::{Context, Status, ValkeyError, ValkeyResult, ValkeyValue};
@@ -36,7 +38,23 @@ impl FanoutClientCommand for MDelFanoutCommand {
         "mdel"
     }
 
+    /// Unlike every other fanout command in this module, `TS.MDEL` is a write. The trait default
+    /// (`FanoutTargetMode::Random`) picks uniformly among each shard's primary *and* its replicas,
+    /// which would delete keys directly on a replica — a write the replica's primary never made,
+    /// and one the next full resync silently reverts. A write has exactly one correct target per
+    /// shard.
+    fn get_targets(&self, ctx: &Context) -> FanoutTargets {
+        get_fanout_targets(ctx, FanoutTargetMode::Primary)
+    }
+
     fn get_local_response(ctx: &Context, req: Self::Request) -> ValkeyResult<Self::Response> {
+        // Defence in depth behind `get_targets`: the coordinator picked us from *its* cluster map,
+        // and a failover between selection and delivery can leave that map naming a node that has
+        // since been demoted. Fail this shard's slice loudly rather than diverge the replica.
+        if is_replica(ctx) {
+            return Err(ValkeyError::Str(error_consts::FANOUT_WRITE_ON_REPLICA));
+        }
+
         let filters = deserialize_matchers_list(Some(req.filters))
             .map_err(|_e| ValkeyError::Str(error_consts::COMMAND_DESERIALIZATION_ERROR))?;
 
@@ -47,6 +65,10 @@ impl FanoutClientCommand for MDelFanoutCommand {
             None
         };
 
+        // `delete_series_by_selectors` propagates its own effects (`DEL` / `TS.DEL`) to this
+        // node's replicas. The command itself cannot be propagated from here: this runs in a
+        // fanout RPC handler whose context has no client argv for `ReplicateVerbatim` to copy,
+        // and a replica replaying `TS.MDEL` would fan the command out a second time.
         let deleted_count = delete_series_by_selectors(ctx, &filters, range)?;
         Ok(CountResponse {
             count: deleted_count as u64,

--- a/src/commands/ts_mrange_fanout_command.rs
+++ b/src/commands/ts_mrange_fanout_command.rs
@@ -6,6 +6,7 @@ use crate::aggregators::EmptyFillBounds;
 use crate::aggregators::MultiAggregateIterator;
 use crate::aggregators::{PartialReducer, PartialState};
 use crate::commands::utils::{MRangeReplyShape, reply_with_mrange_series_results};
+use crate::common::context::key_for_display;
 use crate::common::{MultiSample, Sample};
 use crate::fanout::{FanoutClientCommand, NodeInfo};
 use crate::fanout::{FanoutCommandResult, FanoutContext};
@@ -421,7 +422,7 @@ fn serialize_request(request: &MRangeOptions) -> MultiRangeRequest {
 }
 
 struct GroupData {
-    keys: SmallVec<[String; 8]>,
+    keys: SmallVec<[Vec<u8>; 8]>,
     series: Vec<MRangeSeriesResult>,
 }
 
@@ -453,12 +454,12 @@ fn handle_grouping(
 /// Short, bounded rendering of a partial's source keys for error/log context:
 /// enough to identify the owning shard without flooding the message when a
 /// group has many members.
-fn sources_preview(source_keys: &[String]) -> String {
+fn sources_preview(source_keys: &[Vec<u8>]) -> String {
     const MAX_SHOWN: usize = 3;
     let mut preview = source_keys
         .iter()
         .take(MAX_SHOWN)
-        .cloned()
+        .map(|key| key_for_display(key))
         .collect::<Vec<_>>()
         .join(",");
     if source_keys.len() > MAX_SHOWN {
@@ -501,7 +502,7 @@ fn handle_group_partials(
     };
 
     type BucketStates = SmallVec<[PartialState; 4]>;
-    type MergedGroup = (BTreeMap<i64, BucketStates>, BTreeSet<String>);
+    type MergedGroup = (BTreeMap<i64, BucketStates>, BTreeSet<Vec<u8>>);
     let mut groups: BTreeMap<String, MergedGroup> = BTreeMap::new();
     for partial in partials {
         // Corrupt-peer defense: states must be row-major with exactly the
@@ -570,7 +571,7 @@ fn handle_group_partials(
                 )))
             };
 
-            let sources: Vec<String> = sources.into_iter().collect(); // sorted via BTreeSet
+            let sources: Vec<Vec<u8>> = sources.into_iter().collect(); // sorted via BTreeSet
             let labels = if options.with_labels {
                 build_mrange_grouped_labels(
                     &group_options.group_label,
@@ -583,7 +584,7 @@ fn handle_group_partials(
             };
 
             MRangeSeriesResult {
-                key: format!("{}={}", group_options.group_label, label),
+                key: format!("{}={}", group_options.group_label, label).into_bytes(),
                 group_label_value: Some(label),
                 labels,
                 sources,
@@ -709,7 +710,7 @@ fn process_group(
     };
 
     MRangeSeriesResult {
-        key: format!("{}={}", group_options.group_label, label),
+        key: format!("{}={}", group_options.group_label, label).into_bytes(),
         group_label_value: Some(label),
         labels,
         sources: data.keys.to_vec(),
@@ -971,7 +972,7 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         let group = &results[0];
-        assert_eq!(group.key, "region=us");
+        assert_eq!(group.key, "region=us".as_bytes());
         assert_eq!(group.group_label_value.as_deref(), Some("us"));
         assert_eq!(
             result_samples(group),
@@ -991,7 +992,7 @@ mod tests {
         let results = handle_grouping(make_responses(), &options).unwrap();
         assert_eq!(results.len(), 1);
         assert!(results[0].labels.is_empty());
-        assert_eq!(results[0].key, "region=us");
+        assert_eq!(results[0].key, "region=us".as_bytes());
     }
 
     /// The request flag mirrors the latched push-down decision.
@@ -1077,7 +1078,7 @@ mod tests {
                 PartialSampleReducer::new(shard_samples.into_iter(), reducer.clone()).unzip();
             GroupPartialSeries {
                 group_label_value: "us".into(),
-                source_keys: keys.iter().map(|s| s.to_string()).collect(),
+                source_keys: keys.iter().map(|s| s.as_bytes().to_vec()).collect(),
                 bucket_timestamps,
                 states: states.into_iter().map(Into::into).collect(),
                 column_count: 1,
@@ -1093,7 +1094,7 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         let group = &results[0];
-        assert_eq!(group.key, "region=us");
+        assert_eq!(group.key, "region=us".as_bytes());
         assert_eq!(
             result_samples(group),
             samples(&[(0, 10.0), (100, 3.0), (200, 7.0)]),
@@ -1238,7 +1239,7 @@ mod tests {
                     };
                     GroupPartialSeries {
                         group_label_value: "us".into(),
-                        source_keys: keys.iter().map(|s| s.to_string()).collect(),
+                        source_keys: keys.iter().map(|s| s.as_bytes().to_vec()).collect(),
                         bucket_timestamps,
                         states: states.into_iter().map(Into::into).collect(),
                         column_count: 1,
@@ -1298,7 +1299,7 @@ mod tests {
         ];
         let results = command.process_responses(responses, Vec::new()).unwrap();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].key, "s");
+        assert_eq!(results[0].key, "s".as_bytes());
 
         // Without the flag the empty series is reported, as before.
         let mut options = mrange_options(0, 500);
@@ -1501,7 +1502,7 @@ mod tests {
         let results = handle_grouping(responses, &options).unwrap();
         assert_eq!(results.len(), 1);
         let group = &results[0];
-        assert_eq!(group.key, "region=us");
+        assert_eq!(group.key, "region=us".as_bytes());
         let rows = result_rows(group);
 
         // column-wise sum across series per bucket timestamp:
@@ -1644,7 +1645,10 @@ mod tests {
 
         GroupPartialSeries {
             group_label_value: "us".into(),
-            source_keys: members.iter().map(|(key, _)| key.to_string()).collect(),
+            source_keys: members
+                .iter()
+                .map(|(key, _)| key.as_bytes().to_vec())
+                .collect(),
             bucket_timestamps,
             states: buckets.into_iter().flatten().map(Into::into).collect(),
             column_count: columns as u32,
@@ -1891,7 +1895,7 @@ mod tests {
     /// sources_preview stays bounded for large groups.
     #[test]
     fn test_sources_preview_bounded() {
-        let keys: Vec<String> = (0..10).map(|i| format!("k{i}")).collect();
+        let keys: Vec<Vec<u8>> = (0..10).map(|i| format!("k{i}").into_bytes()).collect();
         assert_eq!(sources_preview(&keys[..2]), "k0,k1");
         assert_eq!(sources_preview(&keys[..3]), "k0,k1,k2");
         assert_eq!(sources_preview(&keys), "k0,k1,k2,+7 more");
@@ -2206,7 +2210,12 @@ mod tests {
 
         assert_eq!(cmd.series.len(), 2);
         for ((series, _bucketed), want) in cmd.series.iter().zip(&expected) {
-            assert_eq!(&label_pairs(series), want, "series '{}'", series.key);
+            assert_eq!(
+                &label_pairs(series),
+                want,
+                "series '{}'",
+                key_for_display(&series.key)
+            );
         }
     }
 

--- a/src/commands/ts_outliers.rs
+++ b/src/commands/ts_outliers.rs
@@ -127,8 +127,6 @@ fn process_request(
     anomaly_direction: AnomalyDirection,
     output_format: OutputFormat,
 ) -> ValkeyResult {
-    let key = ctx.create_string(key);
-
     let samples = match get_timeseries(ctx, &key, Some(AclPermissions::ACCESS), false) {
         Ok(Some(series)) => {
             let (start, end) = date_range.get_series_range(&series, None, false);

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -4,7 +4,7 @@ use crate::common::constants::{REDUCER_KEY, SOURCE_KEY};
 use crate::common::replies::{
     IntoRawCtx, is_resp3_client, reply_label_ex, reply_with_array, reply_with_bulk_string,
     reply_with_labels, reply_with_labels_map, reply_with_map, reply_with_multi_samples,
-    reply_with_sample_ex, reply_with_samples,
+    reply_with_sample_ex, reply_with_samples, reply_with_slice,
 };
 use crate::labels::Label;
 use crate::series::request_types::{MRangeOptions, MRangeSeriesResult, SeriesResultData};
@@ -79,7 +79,9 @@ impl MRangeReplyShape {
 pub fn reply_with_mrange_series_result(ctx: &Context, series: &MRangeSeriesResult) {
     reply_with_array(ctx, 3);
 
-    reply_with_bulk_string(ctx, &series.key);
+    // Raw bytes, not a `&str`: key names are binary-safe, so the client must get back exactly
+    // the name it used.
+    reply_with_slice(ctx, &series.key);
 
     // series.labels has the same count as selected_labels
     reply_with_labels(ctx, &series.labels);
@@ -119,7 +121,7 @@ pub(super) fn reply_with_mrange_series_results(
     // [labels-map, {reducers: [...]}, {sources: [...]}, samples].
     reply_with_map(ctx, series_results.len());
     for series in series_results {
-        reply_with_bulk_string(ctx, &series.key);
+        reply_with_slice(ctx, &series.key);
         if let Some(grouping) = &shape.grouping {
             reply_with_array(ctx, 4);
             let labels: Vec<&Label> = series
@@ -138,7 +140,7 @@ pub(super) fn reply_with_mrange_series_results(
             reply_with_bulk_string(ctx, "sources");
             reply_with_array(ctx, series.sources.len());
             for source in &series.sources {
-                reply_with_bulk_string(ctx, source);
+                reply_with_slice(ctx, source);
             }
         } else {
             reply_with_array(ctx, 3);
@@ -162,7 +164,7 @@ pub(super) fn reply_with_mget_values<C: IntoRawCtx>(ctx: C, values: &[MGetValue]
         // RESP3: map keyed by series key; each value is [labels-map, sample].
         reply_with_map(raw_ctx, values.len());
         for value in values {
-            reply_with_bulk_string(raw_ctx, value.key.as_str());
+            reply_with_slice(raw_ctx, &value.key);
             reply_with_array(raw_ctx, 2);
             reply_with_fanout_labels_map(raw_ctx, &value.labels);
             reply_with_fanout_sample(raw_ctx, &value.sample);
@@ -194,7 +196,7 @@ fn reply_with_fanout_labels_map<C: IntoRawCtx>(ctx: C, labels: &[FanoutLabel]) {
 fn reply_with_mget_value<C: IntoRawCtx>(ctx: C, value: &MGetValue) -> Status {
     let raw_ctx = ctx.into_raw();
     reply_with_array(raw_ctx, 3);
-    reply_with_bulk_string(raw_ctx, value.key.as_str());
+    reply_with_slice(raw_ctx, &value.key);
     reply_with_fanout_labels(raw_ctx, &value.labels);
     reply_with_fanout_sample(raw_ctx, &value.sample);
     Status::Ok

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -23,6 +23,15 @@ pub fn create_key_string(ctx: &Context, key: &[u8]) -> ValkeyString {
     ValkeyString::create_from_slice(ctx.ctx, key)
 }
 
+/// Render a binary key name for a log line or an error message.
+///
+/// Lossy on purpose, and only for human-readable diagnostics: a key holding a non-UTF-8 byte
+/// still has to appear in a message somehow. Never build a client reply out of this — reply with
+/// the raw bytes (`reply_with_slice`) so the caller gets back exactly the name it used.
+pub fn key_for_display(key: &[u8]) -> std::borrow::Cow<'_, str> {
+    String::from_utf8_lossy(key)
+}
+
 // Safety: RedisModule_GetSelectedDb is safe to call
 pub fn get_current_db(ctx: &Context) -> i32 {
     unsafe { RedisModule_GetSelectedDb.unwrap()(ctx.ctx) }

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -40,6 +40,17 @@ pub fn is_real_user_client(ctx: &Context) -> bool {
     true
 }
 
+/// Whether this server is a replica.
+///
+/// Server-level state, not client state: `RM_GetContextFlags` reads it from the server, so this
+/// is valid from a detached/thread-safe context as well as from a command context. Used to keep
+/// a cluster fanout write from being applied locally when the coordinator's cluster map is stale
+/// enough to have addressed us as a primary (see `MDelFanoutCommand::get_local_response`).
+#[inline]
+pub fn is_replica(ctx: &Context) -> bool {
+    ctx.get_flags().contains(ContextFlags::SLAVE)
+}
+
 /// Whether the current execution context forbids blocking the client — inside `MULTI`, a Lua
 /// script, or a nested module call.
 ///

--- a/src/common/context.rs
+++ b/src/common/context.rs
@@ -3,10 +3,25 @@ use std::os::raw::c_int;
 use valkey_module::{
     Context, ContextFlags, RedisModule_GetSelectedDb, RedisModule_SelectDb, Status, ValkeyError,
     ValkeyModule_GetServerInfo, ValkeyModule_ServerInfoGetFieldSigned, ValkeyModuleCtx,
-    ValkeyModuleServerInfoData, ValkeyResult, raw,
+    ValkeyModuleServerInfoData, ValkeyResult, ValkeyString, raw,
 };
 
 use crate::fanout::{FANOUT_ACL_USER, fanout_acl_scope_active, is_clustered};
+
+/// Build a `ValkeyString` from raw key bytes without going through `CString`.
+///
+/// `Context::create_string` funnels its argument through `CString::new(..).unwrap()`, so any
+/// byte string holding an interior NUL panics. Valkey key names are binary-safe, so that is not
+/// a corrupt-input-only concern: `TS.CREATE "a\0b"` is a legal key, and the same bytes come back
+/// out of an RDB, a `RESTORE`, a rename, or the postings index. Worse, most of those paths run
+/// inside a keyspace-notification or data-type callback, which is `extern "C"` and cannot unwind
+/// — the panic becomes an `abort`, taking the whole server down with it.
+///
+/// Every conversion of keyspace-derived bytes into a `ValkeyString` must go through here.
+/// `create_string` stays fine for module-authored literals and formatted numbers.
+pub fn create_key_string(ctx: &Context, key: &[u8]) -> ValkeyString {
+    ValkeyString::create_from_slice(ctx.ctx, key)
+}
 
 // Safety: RedisModule_GetSelectedDb is safe to call
 pub fn get_current_db(ctx: &Context) -> i32 {

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -8,6 +8,7 @@ pub mod encoding;
 pub mod hash;
 pub mod humanize;
 pub mod logging;
+pub mod module_options;
 pub mod pool;
 pub mod rdb;
 pub mod replies;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -8,6 +8,7 @@ pub mod encoding;
 pub mod hash;
 pub mod humanize;
 pub mod logging;
+pub mod module_info;
 pub mod module_options;
 pub mod pool;
 pub mod rdb;

--- a/src/common/module_info.rs
+++ b/src/common/module_info.rs
@@ -1,0 +1,54 @@
+//! The module's `INFO` sections.
+//!
+//! Module sections are emitted only for an explicit `INFO modules`, `INFO everything`/`INFO all`,
+//! or `INFO <section>` — never for a bare `INFO` — which is what makes it acceptable for the
+//! memory section to walk the term dictionary.
+
+use crate::common::string_interner::InternedString;
+use crate::series::index::index_memory_usage;
+use valkey_module::{InfoContext, ValkeyResult};
+use valkey_module_macros::info_command_handler;
+
+/// `INFO ts_memory`: the module's global heap, which no per-key figure can show.
+///
+/// The section is declared as `memory`; the server prefixes it with the module name, so it lands
+/// as `# ts_memory` with every field prefixed `ts_`.
+///
+/// `MEMORY USAGE <key>` and `TS.INFO memoryUsage` report one series: its chunks, its labels'
+/// amortized share of the interner, and its own struct. The label index is not attached to any
+/// key, so neither of them can see it at all, and on a high-cardinality keyspace it is routinely
+/// the larger half of what the module holds. Everything reported here is *in addition to* the
+/// per-key numbers, with one exception noted on `interned_strings_bytes`.
+///
+/// `terms_bytes` and `id_to_key_bytes` count the entries an adaptive radix tree and a `BTreeMap`
+/// hold without their internal node overhead, so the totals are a floor.
+#[info_command_handler]
+fn memory_info(ctx: &InfoContext, _for_crash_report: bool) -> ValkeyResult<()> {
+    let index = index_memory_usage();
+
+    ctx.builder()
+        .add_section("memory")
+        .field("index_total_bytes", index.total_bytes() as u64)?
+        .field("index_terms_bytes", index.terms_bytes as u64)?
+        .field("index_postings_bytes", index.postings_bytes as u64)?
+        .field("index_id_to_key_bytes", index.id_to_key_bytes as u64)?
+        .field("index_bookkeeping_bytes", index.bookkeeping_bytes as u64)?
+        .field("index_terms", index.term_count as u64)?
+        .field("index_series", index.series_count as u64)?
+        .field("index_databases", index.db_count as u64)?
+        // The pool total, not a per-series share: this is the whole interner, which the
+        // `memoryUsage` of the series holding those labels already divides amongst themselves.
+        // Adding it to the sum of every key's `MEMORY USAGE` therefore double-counts it.
+        //
+        // Both of these are O(1) reads. `TS._DEBUG STRINGPOOLSTATS` has the distribution and the
+        // savings figure, which cost a walk of the pool.
+        .field("interned_strings", InternedString::interned_count() as u64)?
+        .field(
+            "interned_strings_bytes",
+            InternedString::memory_used() as u64,
+        )?
+        .build_section()?
+        .build_info()?;
+
+    Ok(())
+}

--- a/src/common/module_options.rs
+++ b/src/common/module_options.rs
@@ -1,0 +1,41 @@
+//! Cumulative declaration of `ValkeyModule_SetModuleOptions` flags.
+//!
+//! The server API takes the *complete* option bitmask on every call, so two independent
+//! call sites each passing their own flag leaves only whichever ran last. Declarations here
+//! are OR-ed into a process-wide mask and the full mask is re-applied, so the order in which
+//! subsystems declare their options does not matter.
+
+use std::os::raw::c_int;
+use std::sync::atomic::{AtomicI32, Ordering};
+use valkey_module::{Context, raw};
+
+/// `VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS`.
+///
+/// Without this flag the server's `moduleRDBLoadError` reaches `serverPanic` the moment an
+/// RDB/AOF/`TS._RESTORE` stream underruns — inside our own `rdb_load`, before any of the
+/// module's bounds checks or error handling can run. With it, the failed read is recorded on
+/// the `RedisModuleIO` instead; `valkey_module::raw`'s load helpers check `is_io_error` after
+/// every read and surface a short-read `Err`, which the loaders propagate.
+pub const HANDLE_IO_ERRORS: c_int = 1 << 0;
+
+/// `VALKEYMODULE_OPTIONS_HANDLE_ATOMIC_SLOT_MIGRATION`.
+pub const HANDLE_ATOMIC_SLOT_MIGRATION: c_int = 1 << 5;
+
+static DECLARED_OPTIONS: AtomicI32 = AtomicI32::new(0);
+
+/// Adds `flags` to the module's declared options and re-applies the accumulated mask.
+pub fn declare_module_options(ctx: &Context, flags: c_int) {
+    let previous = DECLARED_OPTIONS.fetch_or(flags, Ordering::SeqCst);
+    let combined = previous | flags;
+
+    // SAFETY: `ctx` is a live module context; the API pointer is checked before use because
+    // older servers may not export it.
+    unsafe {
+        let Some(set_opts) = raw::ValkeyModule_SetModuleOptions else {
+            ctx.log_notice("ValkeyModule_SetModuleOptions not available in raw bindings");
+            return;
+        };
+        set_opts(ctx.ctx as *mut raw::ValkeyModuleCtx, combined);
+    }
+    ctx.log_notice(&format!("Declared module options: 0x{combined:x}"));
+}

--- a/src/common/rdb.rs
+++ b/src/common/rdb.rs
@@ -126,9 +126,10 @@ pub const MAX_RDB_COLLECTION_LEN: usize = 16 * 1024 * 1024;
 /// `Vec::with_capacity`/`HashMap::with_capacity`) and rejects it if it exceeds `max`.
 ///
 /// RDB/AOF/`TS._RESTORE` payloads are untrusted: a corrupt or adversarial length field is
-/// otherwise trusted as-is and handed straight to `with_capacity`, and this crate builds with
-/// `panic = "abort"`, so an oversized value there kills the whole process instead of failing the
-/// load with a clean error.
+/// otherwise trusted as-is and handed straight to `with_capacity`, where an oversized value
+/// aborts the process on allocation failure instead of failing the load with a clean error.
+/// An allocation abort is not a panic, so it cannot be caught or reported after the fact --
+/// the length has to be rejected before it reaches the allocator.
 pub fn rdb_load_len(rdb: *mut RedisModuleIO, max: usize) -> ValkeyResult<usize> {
     let len = rdb_load_usize(rdb)?;
     if len > max {

--- a/src/common/string_interner.rs
+++ b/src/common/string_interner.rs
@@ -268,6 +268,26 @@ impl InternedString {
         self.ref_count() == 1
     }
 
+    /// Bytes the pool allocated for this value: the `Arc` control block (the strong and weak
+    /// counts) followed by the payload.
+    ///
+    /// `GetSize` on the inner `Arc<[u8]>` counts the payload only, which understates every
+    /// interned string by a fixed 16 bytes on a 64-bit target -- material for label values,
+    /// which are short.
+    pub fn allocated_size(&self) -> usize {
+        2 * size_of::<usize>() + self.arc.len()
+    }
+
+    /// This holder's share of [`Self::allocated_size`].
+    ///
+    /// A single pool allocation backs every series carrying the same `label=value` pair, so
+    /// charging all of it to each holder would multiply-count it: summing `MEMORY USAGE` over a
+    /// keyspace would report far more memory than the module holds. Splitting it evenly keeps
+    /// that sum equal to the pool's real footprint, which is the number capacity planning wants.
+    pub fn amortized_size(&self) -> usize {
+        self.allocated_size().div_ceil(self.ref_count().max(1))
+    }
+
     /// Return the number of unique interned strings.
     pub fn interned_count() -> usize {
         read_lock(&STRING_POOL).len()

--- a/src/common/string_interner.rs
+++ b/src/common/string_interner.rs
@@ -58,6 +58,16 @@ static STRING_POOL: LazyLock<StringContainer> =
 /// Total memory used by all interned strings.
 static STRING_MEMORY_USED: AtomicUsize = AtomicUsize::new(0);
 
+/// Bytes the pool allocated for `arc`: the `Arc` control block (the strong and weak counts)
+/// followed by the payload.
+///
+/// `GetSize` on `Arc<[u8]>` counts the payload only, which understates every interned string by
+/// a fixed 16 bytes on a 64-bit target -- material for label values, which are short. Every site
+/// that accounts for pool memory goes through here so the counters agree.
+fn arc_allocated_size(arc: &Arc<[u8]>) -> usize {
+    2 * size_of::<usize>() + arc.len()
+}
+
 #[derive(Default)]
 pub struct BucketStats {
     pub count: usize,
@@ -237,7 +247,7 @@ impl InternedString {
         }
 
         // Insert new value
-        let size = val.get_size();
+        let size = arc_allocated_size(&val);
         pool.insert(val.clone());
         STRING_MEMORY_USED.fetch_add(size, std::sync::atomic::Ordering::SeqCst);
 
@@ -269,13 +279,9 @@ impl InternedString {
     }
 
     /// Bytes the pool allocated for this value: the `Arc` control block (the strong and weak
-    /// counts) followed by the payload.
-    ///
-    /// `GetSize` on the inner `Arc<[u8]>` counts the payload only, which understates every
-    /// interned string by a fixed 16 bytes on a 64-bit target -- material for label values,
-    /// which are short.
+    /// counts) followed by the payload. See [`arc_allocated_size`].
     pub fn allocated_size(&self) -> usize {
-        2 * size_of::<usize>() + self.arc.len()
+        arc_allocated_size(&self.arc)
     }
 
     /// This holder's share of [`Self::allocated_size`].
@@ -313,7 +319,7 @@ impl InternedString {
 
         for arc in pool.iter() {
             let ref_count = Arc::strong_count(arc) - 1; // exclude the pool's reference
-            let allocated = arc.get_size();
+            let allocated = arc_allocated_size(arc);
             let bytes = arc.as_ref().len();
 
             let by_ref_stats = stats.by_ref_stats.entry(ref_count).or_default();
@@ -456,7 +462,7 @@ impl Drop for InternedString {
         // Only remove/account if the pool currently contains this arc AND `self` is
         // the last external reference at the moment we hold the write lock.
         if Arc::strong_count(&self.arc) == 2 && pool.remove(&self.arc) {
-            let size = self.arc.get_size();
+            let size = arc_allocated_size(&self.arc);
             STRING_MEMORY_USED.fetch_sub(size, std::sync::atomic::Ordering::SeqCst);
         }
     }

--- a/src/error_consts.rs
+++ b/src/error_consts.rs
@@ -132,6 +132,7 @@ pub const PERMISSION_DENIED: &str = "TSDB: current user doesn't have read permis
 pub const COMMAND_SERIALIZATION_ERROR: &str = "TSDB: command serialization error";
 pub const COMMAND_DESERIALIZATION_ERROR: &str = "TSDB: command deserialization error";
 pub const CLUSTER_MODE_ERROR: &str = "TSDB: cluster mode not supported";
+pub const FANOUT_WRITE_ON_REPLICA: &str = "TSDB: refusing to apply a fanout write on a replica";
 pub const NO_CLUSTER_NODES_AVAILABLE: &str = "TSDB: no cluster nodes available";
 pub const WITH_LABELS_AND_SELECTED_LABELS_SPECIFIED: &str =
     "TSDB: cannot accept WITHLABELS and SELECT_LABELS together";

--- a/src/fanout/cluster_migrations.rs
+++ b/src/fanout/cluster_migrations.rs
@@ -1,3 +1,4 @@
+use crate::common::module_options::{HANDLE_ATOMIC_SLOT_MIGRATION, declare_module_options};
 use crate::common::sync::{read_lock, write_lock};
 use crate::fanout::cluster_map::NUM_SLOTS;
 use crate::fanout::is_clustered;
@@ -361,22 +362,10 @@ pub fn register_atomic_slot_migration_event_handler(
         ctx.log_warning("Failed to subscribe to atomic slot migration events");
     }
     // Declare that this module handles atomic slot migration events, so the
-    // server will permit ASM operations involving this module. This maps to
-    // the VALKEYMODULE_OPTIONS_HANDLE_ATOMIC_SLOT_MIGRATION flag in the
-    // Valkey module API.
-    // VALKEYMODULE_OPTIONS_HANDLE_ATOMIC_SLOT_MIGRATION == (1 << 5)
-    unsafe {
-        if let Some(set_opts) = raw::ValkeyModule_SetModuleOptions {
-            let flag = 1 << 5;
-            set_opts(ctx.ctx as *mut raw::ValkeyModuleCtx, flag);
-            ctx.log_notice(&format!(
-                "Declared module options in init: HANDLE_ATOMIC_SLOT_MIGRATION (0x{:x})",
-                flag
-            ));
-        } else {
-            ctx.log_notice("ValkeyModule_SetModuleOptions not available in raw bindings (init)");
-        }
-    }
+    // server will permit ASM operations involving this module. Declared through
+    // `declare_module_options` because `SetModuleOptions` takes the complete mask:
+    // passing this flag alone would drop the options declared at init.
+    declare_module_options(ctx, HANDLE_ATOMIC_SLOT_MIGRATION);
 }
 
 #[cfg(test)]

--- a/src/labels/metric_name.rs
+++ b/src/labels/metric_name.rs
@@ -5,7 +5,7 @@ use crate::common::string_interner::InternedString;
 use crate::parser::ParseError;
 use crate::parser::metric_name::parse_metric_name;
 use enquote::enquote;
-use get_size2::GetSize;
+use get_size2::{GetSize, GetSizeTracker};
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::str::FromStr;
@@ -57,18 +57,20 @@ impl SeriesLabel for InternedLabel<'_> {
 pub struct MetricName(Vec<InternedString>);
 
 impl GetSize for MetricName {
-    fn get_size(&self) -> usize {
-        self.0
-            .iter()
-            .map(|i| {
-                // we count the full size (stack and heap) only for unique strings
-                if i.is_unique() {
-                    i.get_size()
-                } else {
-                    size_of::<InternedString>()
-                }
-            })
-            .sum()
+    /// `get_heap_size_with_tracker` is the extension point a containing type's derived `GetSize`
+    /// calls. This used to override `get_size` instead, which left `TimeSeries`' derived impl on
+    /// the trait default of zero: a series carrying 40 labels and ~1.9KB of interned strings
+    /// reported a `memoryUsage` of exactly `size_of::<TimeSeries>()`, labels included for free.
+    ///
+    /// The tracker is deliberately not consulted for the strings themselves. It exists to charge
+    /// a shared allocation once per traversal, which here would bill one arbitrary series for a
+    /// label the whole keyspace shares and the rest nothing. [`InternedString::amortized_size`]
+    /// splits it evenly instead, so per-key numbers add up across the keyspace.
+    fn get_heap_size_with_tracker<T: GetSizeTracker>(&self, tracker: T) -> (usize, T) {
+        // The spare capacity is real: `add_label` inserts into the middle of the vector.
+        let vec_bytes = self.0.capacity() * size_of::<InternedString>();
+        let string_bytes: usize = self.0.iter().map(InternedString::amortized_size).sum();
+        (vec_bytes + string_bytes, tracker)
     }
 }
 
@@ -306,5 +308,60 @@ mod tests {
         let display = format!("{metric_name}");
 
         assert_eq!(display, "metric{key1=\"value1\",key2=\"value2\"}");
+    }
+
+    /// The heap accounting has to hang off `get_heap_size_with_tracker`, because that -- not
+    /// `get_size` -- is what a containing type's derived `GetSize` calls. Overriding `get_size`
+    /// alone reported the labels as costing nothing at all from inside `TimeSeries`.
+    #[test]
+    fn test_heap_size_counts_interned_labels() {
+        let empty = MetricName::default().get_heap_size();
+
+        let mut metric_name = MetricName::with_capacity(8);
+        for i in 0..8 {
+            metric_name.add_label(
+                &format!("heap_size_label_{i}"),
+                &format!("a_reasonably_long_label_value_{i}"),
+            );
+        }
+
+        let labelled = metric_name.get_heap_size();
+        let payload: usize = (0..8)
+            .map(|i| format!("heap_size_label_{i}=a_reasonably_long_label_value_{i}").len())
+            .sum();
+
+        assert!(
+            labelled >= empty + payload,
+            "heap size {labelled} does not cover {payload} bytes of label text over the empty \
+             baseline of {empty}",
+        );
+    }
+
+    /// One pool allocation backs every series carrying the same pair, so each holder reports a
+    /// share of it: charging all of it to all of them would make the sum of `MEMORY USAGE` over
+    /// a keyspace exceed what the module holds by the sharing factor.
+    #[test]
+    fn test_shared_labels_are_amortized_across_holders() {
+        let mut only = MetricName::with_capacity(1);
+        only.add_label("amortize_probe", "shared_value_for_the_amortization_test");
+        let sole_holder = only.get_heap_size();
+
+        let mut sharers = Vec::new();
+        for _ in 0..4 {
+            let mut mn = MetricName::with_capacity(1);
+            mn.add_label("amortize_probe", "shared_value_for_the_amortization_test");
+            sharers.push(mn);
+        }
+
+        let per_holder = sharers[0].get_heap_size();
+        assert!(
+            per_holder < sole_holder,
+            "a pair shared five ways ({per_holder}) should cost each holder less than one held \
+             alone ({sole_holder})",
+        );
+        // Every holder agrees, and together they account for the whole allocation once.
+        for mn in &sharers {
+            assert_eq!(mn.get_heap_size(), per_holder);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ extern crate strum_macros;
 extern crate valkey_module_macros;
 
 use crate::commands::register_fanout_operations;
+use crate::common::module_options::{HANDLE_IO_ERRORS, declare_module_options};
 use crate::common::threads::init_thread_pool;
 use crate::config::register_config;
 use crate::fanout::{init_fanout, is_clustered};
@@ -181,6 +182,11 @@ fn assign_command_acl_categories(_ctx: &Context) {}
 
 fn initialize(ctx: &Context, args: &[ValkeyString]) -> Status {
     init_croaring_allocator();
+
+    // Declare this first: until the server knows the module handles IO errors, any short
+    // read while loading a TSDB-TYPE payload panics the server from inside `rdb_load`
+    // rather than returning an error we can report.
+    declare_module_options(ctx, HANDLE_IO_ERRORS);
 
     if let Err(e) = register_config(ctx, args) {
         let msg = format!("Failed to register config: {e}");

--- a/src/parser/number.rs
+++ b/src/parser/number.rs
@@ -78,7 +78,11 @@ pub fn parse_positive_number(str: &str) -> ParseResult<f64> {
 
 pub fn parse_number(str: &str) -> ParseResult<f64> {
     let mut str = str;
-    let ch = str.chars().next().unwrap();
+    // Guard the leading-character read the same way `parse_positive_number` does: an
+    // empty operand reaches here from user input (e.g. `TS.CREATE k IGNORE 5 ""`).
+    let Some(ch) = str.chars().next() else {
+        return Err(InvalidNumber(str.to_string()));
+    };
     let mut is_negative = false;
 
     if ch == '+' {
@@ -133,7 +137,7 @@ pub fn get_number_suffix(s: &str) -> Option<SuffixValue> {
 
 #[cfg(test)]
 mod tests {
-    use crate::parser::number::parse_positive_number;
+    use crate::parser::number::{parse_number, parse_positive_number};
 
     fn expect_failure(s: &str) {
         match parse_positive_number(s) {
@@ -244,5 +248,18 @@ mod tests {
         f("12.34E+abc");
         f("12.34e-");
         f("12.weKB")
+    }
+
+    #[test]
+    fn test_parse_number_empty_is_error_not_panic() {
+        // An empty operand reaches `parse_number` from user input (IGNORE operands,
+        // `CONFIG SET ts.ts-ignore-max-val-diff ""`); it must not panic.
+        assert!(parse_number("").is_err());
+        // A bare sign leaves an empty remainder after the sign is stripped.
+        assert!(parse_number("-").is_err());
+        assert!(parse_number("+").is_err());
+        // Signed parsing still works.
+        assert_eq!(parse_number("-12").unwrap(), -12.0);
+        assert_eq!(parse_number("+12").unwrap(), 12.0);
     }
 }

--- a/src/series/bulk_add.rs
+++ b/src/series/bulk_add.rs
@@ -4,6 +4,7 @@
 //! policies and automatic compaction handling. It is optimized for high-throughput data ingestion
 //! scenarios by leveraging parallel processing and efficient sample merging.
 use crate::common::block_on_keys::signal_timeseries_ready;
+use crate::common::context::create_key_string;
 use crate::common::{Sample, Timestamp};
 use crate::error_consts;
 use crate::series::chunks::{ChunkOps, TimeSeriesChunk};
@@ -481,7 +482,7 @@ fn notify_added(ctx: &Context, event: &str, ids: &[SeriesRef]) {
                 ctx.log_warning("Compaction notification failed: series key not found");
                 continue;
             };
-            let key = ctx.create_string(key.as_ref());
+            let key = create_key_string(ctx, key.as_ref());
             ctx.notify_keyspace_event(NotifyEvent::MODULE, event, &key);
             // The sole caller already gated on the series' sample count having grown, which is
             // exactly the condition that can satisfy a blocked `TS.READ`.

--- a/src/series/bulk_add.rs
+++ b/src/series/bulk_add.rs
@@ -9,7 +9,7 @@ use crate::error_consts;
 use crate::series::chunks::{ChunkOps, TimeSeriesChunk};
 use crate::series::index::with_timeseries_postings;
 use crate::series::ingest_normalize::{NormalizedBatch, normalize_batch};
-use crate::series::{DuplicatePolicy, SampleAddResult, SeriesRef, TimeSeries};
+use crate::series::{DuplicatePolicy, SampleAddResult, SeriesRef, TimeSeries, seal_chunk};
 use orx_parallel::{IterIntoParIter, ParIter, ParallelizableCollection};
 use simd_json::base::{ValueAsArray, ValueAsScalar};
 use simd_json::borrowed::Value;
@@ -359,6 +359,10 @@ pub(super) fn merge_samples_into_series(
             .map(|&(group_pos, samples)| {
                 let mut chunk = TimeSeriesChunk::new(encoding, chunk_size);
                 let res = exec_merge(&mut chunk, samples, resolved_policy);
+                // This group's samples are all this chunk will ever hold: the sort below places
+                // it among chunks that already own every neighbouring timestamp. (The one that
+                // lands last does become the new append target and will regrow once.)
+                seal_chunk(&mut chunk);
                 (group_pos, chunk, res)
             })
             .collect::<Vec<_>>();

--- a/src/series/chunks/chimp/chimp_chunk.rs
+++ b/src/series/chunks/chimp/chimp_chunk.rs
@@ -63,8 +63,19 @@ impl ChimpChunk {
         uncompressed_size as f64 / compressed_size as f64
     }
 
+    /// Bytes of encoded data. This is what `max_size` bounds, what `TS.INFO DEBUG` reports as a
+    /// chunk's `size`, and what `bytes_per_sample` amortizes.
+    ///
+    /// It deliberately excludes the writer's spare capacity and the encoder's own stack bytes.
+    /// The bit stream grows by doubling, so counting `Vec::capacity` reported up to ~2x the data
+    /// actually held: a chunk created with `CHUNK_SIZE 4096` reported 8288. `is_full` has always
+    /// measured the payload, and `UncompressedChunk::size` is likewise `len`-based, so the three
+    /// now agree. It also fed `utilization`, and so `should_split` -- which only governs an
+    /// upsert into an already-sealed chunk; the append path is gated by `is_full` and was
+    /// unaffected. The full allocation is still reported by `memory_usage`, which is what
+    /// `MEMORY USAGE` and `TS.INFO memoryUsage` read.
     pub fn data_size(&self) -> usize {
-        self.encoder.get_size()
+        self.encoder.bytes().len()
     }
 
     /// Estimate the remaining capacity based on the current data size and `max_size`.

--- a/src/series/chunks/gorilla/gorilla_chunk.rs
+++ b/src/series/chunks/gorilla/gorilla_chunk.rs
@@ -53,13 +53,27 @@ impl GorillaChunk {
         (uncompressed_size / compressed_size) as f64
     }
 
+    /// Bytes of encoded data. This is what `max_size` bounds, what `TS.INFO DEBUG` reports as a
+    /// chunk's `size`, and what `bytes_per_sample` amortizes.
+    ///
+    /// It deliberately excludes the writer's spare capacity and the encoder's own stack bytes.
+    /// The bit stream grows by doubling, so counting `Vec::capacity` reported up to ~2x the data
+    /// actually held: a chunk created with `CHUNK_SIZE 4096` reported 8288. `is_full` has always
+    /// measured the payload, and `UncompressedChunk::size` is likewise `len`-based, so the three
+    /// now agree. It also fed `utilization`, and so `should_split` -- which only governs an
+    /// upsert into an already-sealed chunk; the append path is gated by `is_full` and was
+    /// unaffected. The full allocation is still reported by `memory_usage`, which is what
+    /// `MEMORY USAGE` and `TS.INFO memoryUsage` read.
     pub fn data_size(&self) -> usize {
-        self.encoder.get_size()
+        self.encoder.buf().len()
     }
 
     /// estimate remaining capacity based on the current data size and chunk max_size
     pub fn remaining_capacity(&self) -> usize {
-        self.max_size - self.data_size()
+        // Saturating: a merge can push a chunk past `max_size`, and a plain subtraction would
+        // wrap (this crate builds release without `overflow-checks`). `ChimpChunk` already
+        // saturated here.
+        self.max_size.saturating_sub(self.data_size())
     }
 
     /// Estimate the number of samples that can be stored in the remaining capacity

--- a/src/series/chunks/gorilla/gorilla_chunk.rs
+++ b/src/series/chunks/gorilla/gorilla_chunk.rs
@@ -270,7 +270,11 @@ impl Chunk for GorillaChunk {
         Self: Sized,
     {
         let mut left_chunk = GorillaEncoder::new();
-        let mut right_chunk = GorillaChunk::default();
+        // `with_max_size`, not `default()`: the upper half has to inherit the budget the series
+        // was created with. `default()` stamps `DEFAULT_CHUNK_SIZE_BYTES` on it, silently
+        // discarding the user's `CHUNK_SIZE` -- and `save_rdb` writes `max_size` out, so the
+        // wrong budget survives a reload. `ChimpChunk::split` already inherits it.
+        let mut right_chunk = GorillaChunk::with_max_size(self.max_size);
 
         if self.is_empty() {
             return Ok(self.clone());
@@ -411,6 +415,95 @@ mod tests {
             .interval(Duration::from_millis(1000))
             .build()
             .generate()
+    }
+
+    /// A split half inherits the source's `max_size`.
+    ///
+    /// This used to build the upper half with `default()`, stamping `DEFAULT_CHUNK_SIZE_BYTES`
+    /// on it and discarding whatever `CHUNK_SIZE` the series was created with -- measured at 4096
+    /// for a source of 1024. Since `save_rdb` persists `max_size`, the wrong budget also survived
+    /// a reload. `ChimpChunk` and `UncompressedChunk` both already inherited it.
+    #[test]
+    fn test_split_inherits_the_source_max_size() {
+        for max_size in [256usize, 1024, 16384, 65536] {
+            let mut chunk = GorillaChunk::with_max_size(max_size);
+            for sample in generate_samples(100).iter() {
+                chunk.add_sample(sample).unwrap();
+            }
+
+            let right = chunk.split().unwrap();
+
+            assert_eq!(chunk.max_size, max_size, "source lost its budget");
+            assert_eq!(
+                right.max_size, max_size,
+                "the upper half of a {max_size}-byte chunk was given a {}-byte budget",
+                right.max_size,
+            );
+        }
+    }
+
+    /// Splitting must not lose or reorder samples while it redistributes them.
+    #[test]
+    fn test_split_preserves_every_sample() {
+        let expected = generate_samples(101);
+        let mut chunk = GorillaChunk::with_max_size(8192);
+        for sample in expected.iter() {
+            chunk.add_sample(sample).unwrap();
+        }
+
+        let right = chunk.split().unwrap();
+
+        let actual: Vec<Sample> = chunk.iter().chain(right.iter()).collect();
+        assert_eq!(actual, expected);
+        assert_eq!(chunk.len() + right.len(), expected.len());
+    }
+
+    /// Iterating an empty chunk yields nothing rather than panicking.
+    ///
+    /// `GorillaIterator::new` computed `num_samples - 1` unguarded. `get_range` checks
+    /// `is_empty` first, but `iter`/`range_iter` do not -- and an empty gorilla chunk is
+    /// ordinary: `TimeSeries::append_chunk` creates one before the first sample lands. In a
+    /// debug build that subtraction panicked with "attempt to subtract with overflow"; with no
+    /// FFI panic barrier in the module, that is a server abort.
+    #[test]
+    fn test_iterating_an_empty_chunk_is_not_an_underflow() {
+        let chunk = GorillaChunk::with_max_size(1024);
+        assert!(chunk.is_empty());
+
+        assert_eq!(chunk.iter().count(), 0);
+        assert_eq!(chunk.range_iter(i64::MIN, i64::MAX).count(), 0);
+        assert_eq!(chunk.range_iter(0, 1000).count(), 0);
+        assert_eq!(chunk.get_range(0, 1000).unwrap(), vec![]);
+    }
+
+    /// Splitting a single-sample chunk leaves one half empty, and callers iterate both.
+    ///
+    /// Which half is empty differs by encoding, so this deliberately does not assert a side:
+    /// `mid` is `len / 2` = 0 here, so gorilla and chimp send the only sample to the *upper*
+    /// half and leave the source empty, while `UncompressedChunk::split` special-cases `len == 1`
+    /// and returns an empty upper half instead. Both halves must iterate without underflowing
+    /// and the sample must survive exactly once.
+    ///
+    /// (`split` is only reached from `should_split`/`is_full`, which need a chunk at or past
+    /// `max_size` >= 48 bytes, so a one-sample split does not arise in practice. That asymmetry
+    /// is untested elsewhere and left as-is; this only pins the iterator behaviour.)
+    #[test]
+    fn test_iterating_the_empty_half_of_a_split_is_not_an_underflow() {
+        let sample = Sample {
+            timestamp: 1000,
+            value: 1.0,
+        };
+        let mut chunk = GorillaChunk::with_max_size(1024);
+        chunk.add_sample(&sample).unwrap();
+
+        let right = chunk.split().unwrap();
+
+        assert!(
+            chunk.is_empty() || right.is_empty(),
+            "a one-sample split should leave one half empty"
+        );
+        let all: Vec<Sample> = chunk.iter().chain(right.iter()).collect();
+        assert_eq!(all, vec![sample]);
     }
 
     fn decompress(chunk: &GorillaChunk) -> Vec<Sample> {

--- a/src/series/chunks/gorilla/gorilla_iterator.rs
+++ b/src/series/chunks/gorilla/gorilla_iterator.rs
@@ -26,7 +26,13 @@ impl GorillaIterator<'_> {
         let last_timestamp = encoder.last_ts;
         let last_value = encoder.last_value;
         let reader = BitStreamReader::new(buf);
-        let last_idx = num_samples - 1;
+        // Saturating: an empty encoder has no last sample, and this is reachable. `GorillaChunk`
+        // guards `get_range` with `is_empty`, but `iter`/`range_iter` do not, and a series always
+        // holds at least one chunk -- a freshly appended one is empty until the first sample
+        // lands. A plain `- 1` panicked there ("attempt to subtract with overflow") in any debug
+        // build, which without an FFI panic barrier takes the whole server down. `next` returns
+        // `None` immediately when `num_samples` is zero, so the value is never read.
+        let last_idx = num_samples.saturating_sub(1);
 
         GorillaIterator {
             reader,

--- a/src/series/chunks/timeseries_chunk_tests.rs
+++ b/src/series/chunks/timeseries_chunk_tests.rs
@@ -7,7 +7,7 @@ mod tests {
     use crate::series::chunks::merge::merge_by_capacity;
     use crate::series::{
         DuplicatePolicy, SampleAddResult,
-        chunks::{Chunk, ChunkEncoding, ChunkOps, TimeSeriesChunk},
+        chunks::{Chunk, ChunkEncoding, ChunkOps, MIN_CHUNK_SIZE, TimeSeriesChunk},
     };
     use crate::tests::chunk_utils::encoded_size;
     use crate::tests::generators::{DataGenerator, ValueWorkload};
@@ -1283,6 +1283,70 @@ mod tests {
                 "{chunk_type:?}: memory_usage {filled} does not cover {payload} encoded \
                  bytes over the empty baseline of {empty}",
             );
+        }
+    }
+
+    /// `size()` is the encoded payload, for every encoding.
+    ///
+    /// Gorilla and chimp used to return the encoder's `get_size()` — the bit stream's `Vec`
+    /// *capacity* plus the encoder struct's own stack bytes. The stream grows by doubling, so
+    /// that over-reported the data by up to ~2x (measured: a chimp chunk holding 2282 encoded
+    /// bytes reported 4192), which `TS.INFO DEBUG` surfaces directly as a chunk's `size` and
+    /// `bytesPerSample`. `is_full` always measured the payload; this is the assertion that the
+    /// two agree.
+    #[test]
+    fn test_chunk_size_reports_encoded_bytes() {
+        const SAMPLE_COUNT: usize = 2000;
+
+        for chunk_type in CHUNK_TYPES {
+            let mut chunk = TimeSeriesChunk::new(chunk_type, 1024 * 1024);
+            for sample in generate_random_samples(SAMPLE_COUNT).iter() {
+                chunk.add_sample(sample).unwrap();
+            }
+
+            let reported = chunk.size();
+            let written = match &chunk {
+                TimeSeriesChunk::Uncompressed(c) => c.samples.len() * size_of::<Sample>(),
+                TimeSeriesChunk::Gorilla(c) => c.encoder.buf().len(),
+                TimeSeriesChunk::Chimp(c) => c.encoder.bytes().len(),
+            };
+
+            assert_eq!(
+                reported, written,
+                "{chunk_type:?}: size() reported {reported} for {written} encoded bytes",
+            );
+            // The allocation is still reported in full, and is never smaller than the payload.
+            assert!(
+                chunk.memory_usage() >= reported,
+                "{chunk_type:?}: memory_usage {} is below the {reported} bytes of payload",
+                chunk.memory_usage(),
+            );
+        }
+    }
+
+    /// A compressed chunk pushed past `max_size` must not wrap its remaining capacity.
+    ///
+    /// `GorillaChunk::remaining_capacity` was a plain `max_size - data_size()`, and this crate
+    /// builds release without `overflow-checks`, so an over-full chunk wrapped to a `usize` near
+    /// `usize::MAX` — which `remaining_samples` then divided into a huge sample estimate.
+    #[test]
+    fn test_remaining_capacity_saturates_on_an_over_full_chunk() {
+        for chunk_type in [ChunkEncoding::Gorilla, ChunkEncoding::Chimp] {
+            let mut chunk = TimeSeriesChunk::new(chunk_type, MIN_CHUNK_SIZE);
+            for sample in generate_random_samples(4096).iter() {
+                let _ = chunk.add_sample(sample);
+            }
+            assert!(
+                chunk.size() > MIN_CHUNK_SIZE,
+                "{chunk_type:?}: chunk never exceeded max_size, the guard is untested",
+            );
+
+            let remaining = match &chunk {
+                TimeSeriesChunk::Gorilla(c) => c.remaining_capacity(),
+                TimeSeriesChunk::Chimp(c) => c.remaining_capacity(),
+                TimeSeriesChunk::Uncompressed(_) => unreachable!(),
+            };
+            assert_eq!(remaining, 0, "{chunk_type:?}: remaining capacity wrapped");
         }
     }
 

--- a/src/series/chunks/uncompressed/mod.rs
+++ b/src/series/chunks/uncompressed/mod.rs
@@ -1475,6 +1475,13 @@ mod tests {
     /// `len` elements up front: a multi-terabyte `Vec::with_capacity` request
     /// aborts the process (allocation failure is not a catchable panic), which
     /// turns a malformed fan-out payload into a crash.
+    ///
+    /// Scope: this covers the in-memory fan-out wire path only. It says nothing
+    /// about the RDB path (`load_rdb`'s `rdb_load_len` cap), which reads through
+    /// `RedisModuleIO` and fails differently -- an in-memory buffer returns `Err`
+    /// on a short read whether or not the module declares `HANDLE_IO_ERRORS`,
+    /// so this test passed even while a truncated RDB aborted the server.
+    /// The RDB path is covered end-to-end by `tests/test_rdb_corrupt_load.py`.
     #[test]
     fn test_deserialize_raw_rejects_oversized_len_without_huge_allocation() {
         use crate::common::encoding::write_uvarint;

--- a/src/series/compaction.rs
+++ b/src/series/compaction.rs
@@ -1,5 +1,6 @@
 use crate::aggregators::{AggregationHandler, Aggregator, calc_bucket_start};
 use crate::common::block_on_keys::signal_timeseries_ready;
+use crate::common::context::create_key_string;
 use crate::common::logging::log_warning;
 use crate::common::rdb::{
     RdbSerializable, rdb_load_bool, rdb_load_timestamp, rdb_save_bool, rdb_save_timestamp,
@@ -1049,7 +1050,7 @@ fn notify_compaction(ctx: &Context, ids: &[SeriesRef]) {
                 ctx.log_warning("Compaction notification failed: series key not found");
                 continue;
             };
-            let key = ctx.create_string(key.as_ref());
+            let key = create_key_string(ctx, key.as_ref());
             ctx.notify_keyspace_event(NotifyEvent::MODULE, "ts.add:dest", &key);
             // Callers only reach here for destinations that materialized a sample, so this is
             // the one place both direct and cascaded compaction output can wake a `TS.READ`

--- a/src/series/compaction.rs
+++ b/src/series/compaction.rs
@@ -230,7 +230,7 @@ fn apply_op(ctx: &mut CompactionContext<'_>, op: CompactionOp) -> TsdbResult<()>
 /// back-filling. Comparing against `prev_last` alone is not equivalent — on a series that the
 /// batch itself populates (`prev_last == None`) every item outranks it, so
 /// `TS.MADD k 0 v k 2000 v k 1000 v` would stream as three appends and never recalculate the
-/// bucket `1000` back-fills. That distinction is load-bearing under retention: only the
+/// bucket `1000` back-fills. That distinction is consequential under retention: only the
 /// recalculation reads the source back through the retention-clamped iterator, which is what
 /// drops a sample the pending trim is about to evict.
 ///

--- a/src/series/defrag.rs
+++ b/src/series/defrag.rs
@@ -1,5 +1,5 @@
 use super::chunks::{ChunkOps, merge_by_capacity};
-use super::time_series::TimeSeries;
+use super::time_series::{TimeSeries, seal_chunk};
 use crate::error::TsdbResult;
 
 /// Compact a series in place: drop expired data, then pull each chunk's samples forward into
@@ -47,6 +47,15 @@ pub fn defrag_series(series: &mut TimeSeries) -> TsdbResult {
     series.chunks.retain(|chunk| !chunk.is_empty());
     if series.chunks.len() < saved_len {
         series.chunks.shrink_to_fit();
+    }
+
+    // Every survivor just absorbed samples from its successors, growing its bit stream by
+    // doubling; and defrag is exactly the point at which the caller is asking for memory back.
+    // The last chunk is still the append target, so it is left alone to avoid a regrow on the
+    // next write.
+    let last = series.chunks.len().saturating_sub(1);
+    for chunk in series.chunks[..last].iter_mut() {
+        seal_chunk(chunk);
     }
 
     // Recount instead of adjusting by a delta. `merge_by_capacity` reports how many samples it

--- a/src/series/defrag.rs
+++ b/src/series/defrag.rs
@@ -2,6 +2,12 @@ use super::chunks::{ChunkOps, merge_by_capacity};
 use super::time_series::TimeSeries;
 use crate::error::TsdbResult;
 
+/// Compact a series in place: drop expired data, then pull each chunk's samples forward into
+/// the preceding chunk wherever that chunk still has room, and discard whatever is left empty.
+///
+/// Runs from the module type's `defrag` callback, so it must leave the series' bookkeeping
+/// (`total_samples`, `first_timestamp`, `last_sample`) exactly consistent with the chunks it
+/// produced -- nothing downstream re-derives them.
 pub fn defrag_series(series: &mut TimeSeries) -> TsdbResult {
     series.trim()?;
 
@@ -11,52 +17,161 @@ pub fn defrag_series(series: &mut TimeSeries) -> TsdbResult {
 
     let min_timestamp = series.get_min_timestamp();
     let duplicate_policy = series.sample_duplicates.policy;
-    let mut deleted_count = 0;
-
-    let mut chunks_to_remove = Vec::new();
-    let mut i = 0;
 
     let mut iter = series.chunks.iter_mut();
     // we ensure above that we have at least 2 chunks
     let mut prev_chunk = iter.next().unwrap();
     while let Some(mut chunk) = iter.next() {
-        let count = chunk.len();
-        let is_empty = count == 0;
-        if is_empty {
-            deleted_count += count;
-            chunks_to_remove.push(i);
-            i += 1;
+        if chunk.is_empty() {
             continue;
         }
 
         // while the previous block has capacity merge into it
-        while let Some(deleted) =
-            merge_by_capacity(prev_chunk, chunk, min_timestamp, duplicate_policy)?
-        {
-            deleted_count -= deleted;
-            if chunk.is_empty() {
-                chunks_to_remove.push(i);
-            }
-            i += 1;
-            if let Some(next_chunk) = iter.next() {
-                chunk = next_chunk;
-            } else {
+        while merge_by_capacity(prev_chunk, chunk, min_timestamp, duplicate_policy)?.is_some() {
+            let Some(next_chunk) = iter.next() else {
                 break;
-            }
+            };
+            chunk = next_chunk;
         }
 
-        i += 1;
         prev_chunk = chunk;
     }
 
-    // todo: don't delete last chunk if it's empty
-    // chunks_to_remove.remove(series.chunks.len() - 1);
-
-    for chunk in chunks_to_remove {
-        series.chunks.remove(chunk);
+    // Discard whatever the merges emptied. This used to collect indices during the walk and
+    // remove them afterwards in ascending order, which shifted every later index down by one, so
+    // the wrong chunks were dropped -- and once enough had been, `Vec::remove` ran off the end
+    // and panicked (observed: "removal index (is 2) should be < len (is 2)" on a four-chunk
+    // series). The collected indices were themselves off by one: the counter was seeded before
+    // the first chunk the loop actually visits. Retaining by emptiness needs no index at all.
+    let saved_len = series.chunks.len();
+    series.chunks.retain(|chunk| !chunk.is_empty());
+    if series.chunks.len() < saved_len {
+        series.chunks.shrink_to_fit();
     }
 
-    series.total_samples -= deleted_count;
+    // Recount instead of adjusting by a delta. `merge_by_capacity` reports how many samples it
+    // *wrote into the destination*, which is not a count of samples the series lost: the old code
+    // subtracted it from a counter that no branch could ever raise above zero, underflowing
+    // `usize` on the first merge. In debug that panicked; in release, where this crate leaves
+    // `overflow-checks` off, it wrapped twice and left `total_samples` inflated by exactly the
+    // number of merged samples (observed: 15 reported for a 9-sample series). A merge can also
+    // genuinely drop samples -- one the destination rejects, or one below the retention floor
+    // that the partial merge path filters out -- so summing the chunks is the only exact answer.
+    series.recalculate_total_samples();
+    series.update_first_last_timestamps();
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::Sample;
+    use crate::series::chunks::{ChunkOps, GorillaChunk, TimeSeriesChunk};
+    use std::time::Duration;
+
+    /// A chunk holding `count` samples starting at `start`, with room to spare so the
+    /// defragmenter's capacity check lets it be merged into.
+    fn chunk_with(start: i64, count: i64) -> TimeSeriesChunk {
+        let mut chunk = TimeSeriesChunk::Gorilla(GorillaChunk::with_max_size(1024));
+        for i in 0..count {
+            let timestamp = start + i;
+            chunk
+                .add_sample(&Sample {
+                    timestamp,
+                    value: timestamp as f64,
+                })
+                .unwrap();
+        }
+        chunk
+    }
+
+    fn series_from(chunks: Vec<TimeSeriesChunk>) -> TimeSeries {
+        let mut series = TimeSeries::from_chunks(chunks).unwrap();
+        // Keep `trim()` a no-op so these exercise the merge path alone.
+        series.retention = Duration::ZERO;
+        series
+    }
+
+    fn all_samples(series: &TimeSeries) -> Vec<Sample> {
+        series
+            .chunks
+            .iter()
+            .flat_map(|chunk| chunk.iter())
+            .collect()
+    }
+
+    #[test]
+    fn test_defrag_merges_chunks_without_losing_samples() {
+        let expected: Vec<Sample> = (0..4)
+            .flat_map(|c| (0..3).map(move |i| 1000 + c * 100 + i))
+            .map(|timestamp| Sample {
+                timestamp,
+                value: timestamp as f64,
+            })
+            .collect();
+
+        let mut series = series_from(vec![
+            chunk_with(1000, 3),
+            chunk_with(1100, 3),
+            chunk_with(1200, 3),
+            chunk_with(1300, 3),
+        ]);
+        assert_eq!(series.total_samples, 12);
+
+        defrag_series(&mut series).unwrap();
+
+        // Every emptied chunk is dropped, and the data lands in the one that absorbed it.
+        // Removing the collected indices in ascending order used to shift every later index
+        // down by one, so the wrong chunks were dropped -- including the merge destination.
+        assert_eq!(series.chunks.len(), 1);
+        assert_eq!(all_samples(&series), expected);
+    }
+
+    #[test]
+    fn test_defrag_keeps_total_samples_in_step_with_the_chunks() {
+        let mut series = series_from(vec![
+            chunk_with(1000, 3),
+            chunk_with(1100, 3),
+            chunk_with(1200, 3),
+        ]);
+
+        // `merge_by_capacity` reports samples *written to the destination*, and the old code
+        // subtracted that from a counter that was always zero: a debug build panicked here on
+        // the very first merge, and a release build wrapped `total_samples` around.
+        defrag_series(&mut series).unwrap();
+
+        assert_eq!(series.total_samples, 9);
+        assert_eq!(
+            series.total_samples,
+            series.chunks.iter().map(|c| c.len()).sum::<usize>()
+        );
+        assert_eq!(series.first_timestamp, 1000);
+        assert_eq!(series.last_sample.map(|s| s.timestamp), Some(1202));
+    }
+
+    #[test]
+    fn test_defrag_drops_empty_chunks() {
+        let mut series = series_from(vec![
+            chunk_with(1000, 3),
+            TimeSeriesChunk::Gorilla(GorillaChunk::with_max_size(1024)),
+            chunk_with(1200, 3),
+        ]);
+        // `from_chunks` counts the samples, so the empty chunk contributes nothing.
+        assert_eq!(series.total_samples, 6);
+
+        defrag_series(&mut series).unwrap();
+
+        assert!(series.chunks.iter().all(|chunk| !chunk.is_empty()));
+        assert_eq!(series.total_samples, 6);
+        assert_eq!(all_samples(&series).len(), 6);
+    }
+
+    #[test]
+    fn test_defrag_is_a_noop_below_two_chunks() {
+        let mut series = series_from(vec![chunk_with(1000, 3)]);
+        defrag_series(&mut series).unwrap();
+        assert_eq!(series.chunks.len(), 1);
+        assert_eq!(series.total_samples, 3);
+    }
 }

--- a/src/series/index/bulk_build.rs
+++ b/src/series/index/bulk_build.rs
@@ -22,6 +22,7 @@
 
 use super::postings::BulkIndexEntry;
 use super::{IndexKey, get_db_index};
+use crate::common::context::create_key_string;
 use crate::common::logging::{log_debug, log_notice};
 use crate::common::sync::lock;
 use crate::config::index_build_max_memory;
@@ -96,7 +97,7 @@ pub(crate) fn try_buffer_loaded_key(ctx: &Context, db: i32, key: &[u8]) -> bool 
         return false;
     }
 
-    let valkey_key = ctx.create_string(key);
+    let valkey_key = create_key_string(ctx, key);
     let Ok(Some(mut series)) = get_timeseries_mut(ctx, &valkey_key, false, None) else {
         return true;
     };

--- a/src/series/index/label_querier.rs
+++ b/src/series/index/label_querier.rs
@@ -824,9 +824,9 @@ fn collect_label_names(
     hints: &SearchHints,
 ) -> TsdbResult<LabelQueryResult> {
     let index = get_timeseries_index(ctx);
-    let postings = index.get_postings();
     with_search_filter(hints, |filter| {
         if can_use_unscoped_scan(select_hints) {
+            let postings = index.get_postings();
             return Ok(collect_unscoped_label_names(&postings, hints));
         }
 
@@ -846,7 +846,17 @@ fn collect_label_names(
         // todo! set a max limit on the number of series we scan here, to avoid OOM or stalls for very
         // broad selectors with many matches. We can still apply the filter and return results,
         // but we should avoid scanning an unbounded number of series.
+        //
+        // Resolve the matching series before touching the postings lock: `series_by_selectors`
+        // takes the read lock itself and then takes the *write* lock to record any dangling ids
+        // it found. `RwLock` is not reentrant, so holding a read guard across this call
+        // deadlocked the server as soon as the index had one stale id to repair.
         let matched_series = series_by_selectors(ctx, &opts.selectors, opts.date_range)?;
+
+        // The cardinality lookups are the only use of the postings index here, so take the read
+        // guard afterwards, and only when a lookup is actually going to happen.
+        let postings = need_cardinality.then(|| index.get_postings());
+
         for (ts, _) in matched_series {
             for label in ts.labels.iter() {
                 // DO NOT use `names.insert()`, as it would require an allocation even if the label name is already see
@@ -859,8 +869,8 @@ fn collect_label_names(
 
                 if accepted {
                     // fetch the cardinality
-                    let cardinality = if need_cardinality {
-                        let cardinality = get_label_cardinality(&postings, label.name);
+                    let cardinality = if let Some(postings) = postings.as_ref() {
+                        let cardinality = get_label_cardinality(postings, label.name);
                         if cardinality == 0 {
                             continue;
                         }
@@ -893,10 +903,13 @@ fn collect_label_values(
     }
 
     let index = get_timeseries_index(ctx);
-    let postings = index.get_postings();
 
     with_search_filter(search_hints, |filter| {
         if can_use_unscoped_scan(select_hints) {
+            // The only use of the postings index on this path. Taking the guard here rather than
+            // for the whole function keeps it off the `series_by_selectors` call below, which
+            // locks the same `RwLock` -- for writing, when it has a dangling id to record.
+            let postings = index.get_postings();
             return Ok(collect_unscoped_label_values(
                 &postings,
                 label_name,

--- a/src/series/index/memory.rs
+++ b/src/series/index/memory.rs
@@ -1,0 +1,111 @@
+//! Heap accounting for the label index.
+//!
+//! The index is module-global state, not a value hanging off any key, so it is invisible to
+//! `MEMORY USAGE` and to `TS.INFO memoryUsage` — both of which only ever see one series. On a
+//! high-cardinality keyspace the term dictionary and its posting bitmaps are frequently the
+//! larger half of the module's footprint, so capacity planning from the per-key numbers alone
+//! understates the module by an unbounded factor. [`index_memory_usage`] is what the module's
+//! `INFO` section reports.
+//!
+//! Everything here is measured, not estimated, wherever the underlying structure can be asked:
+//! the roaring bitmaps report their own container bytes, and byte buffers report their lengths.
+//! The two structures that cannot be asked — the adaptive radix tree holding the term dictionary
+//! and the `BTreeMap` holding the forward map — contribute their entries' bytes without their
+//! internal node overhead, so the totals are a floor rather than an exact figure. `INFO` labels
+//! them accordingly.
+
+use super::index_key::IndexKey;
+use super::postings::{KeyType, Postings, PostingsBitmap};
+use super::{TIMESERIES_INDEX, TimeSeriesIndex};
+use crate::series::SeriesRef;
+use std::mem::size_of;
+
+/// A breakdown of the label index's heap footprint, in bytes.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct IndexMemory {
+    /// Databases holding an index.
+    pub db_count: usize,
+    /// Terms in the dictionary: one per `label` and per `label=value` pair.
+    pub term_count: usize,
+    /// Series in the forward map.
+    pub series_count: usize,
+    /// The term dictionary's keys.
+    pub terms_bytes: usize,
+    /// Roaring containers backing the per-term posting lists.
+    pub postings_bytes: usize,
+    /// The `SeriesRef -> key` forward map.
+    pub id_to_key_bytes: usize,
+    /// `all_postings` and the stale-id tombstone set.
+    pub bookkeeping_bytes: usize,
+}
+
+impl IndexMemory {
+    pub fn total_bytes(&self) -> usize {
+        self.terms_bytes + self.postings_bytes + self.id_to_key_bytes + self.bookkeeping_bytes
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.db_count += other.db_count;
+        self.term_count += other.term_count;
+        self.series_count += other.series_count;
+        self.terms_bytes += other.terms_bytes;
+        self.postings_bytes += other.postings_bytes;
+        self.id_to_key_bytes += other.id_to_key_bytes;
+        self.bookkeeping_bytes += other.bookkeeping_bytes;
+    }
+}
+
+/// Bytes the roaring containers of `bitmap` occupy.
+///
+/// `statistics()` walks the containers rather than the values, so this is proportional to
+/// `cardinality / 65536`, not to the cardinality itself.
+pub(super) fn bitmap_heap_size(bitmap: &PostingsBitmap) -> usize {
+    let stats = bitmap.statistics();
+    (stats.n_bytes_array_containers
+        + stats.n_bytes_run_containers
+        + stats.n_bytes_bitset_containers) as usize
+}
+
+impl Postings {
+    /// This index body's heap footprint. Callers hold the postings lock.
+    pub(crate) fn memory_usage(&self) -> IndexMemory {
+        let mut memory = IndexMemory {
+            db_count: 1,
+            series_count: self.id_to_key.len(),
+            ..Default::default()
+        };
+
+        for (key, ids) in self.label_index.iter() {
+            memory.term_count += 1;
+            // `+ 1`: `IndexKey::len` excludes the NUL sentinel the radix tree needs.
+            memory.terms_bytes += size_of::<IndexKey>() + key.len() + 1;
+            memory.postings_bytes += bitmap_heap_size(ids);
+        }
+
+        for key in self.id_to_key.values() {
+            memory.id_to_key_bytes += size_of::<SeriesRef>() + size_of::<KeyType>() + key.len();
+        }
+
+        memory.bookkeeping_bytes =
+            bitmap_heap_size(&self.all_postings) + self.stale_ids.heap_size();
+
+        memory
+    }
+}
+
+impl TimeSeriesIndex {
+    /// This database's index footprint, taken under the postings read lock.
+    pub fn memory_usage(&self) -> IndexMemory {
+        let mut state = ();
+        self.with_postings(&mut state, |postings, _| postings.memory_usage())
+    }
+}
+
+/// The footprint of every database's index, summed.
+pub fn index_memory_usage() -> IndexMemory {
+    let mut total = IndexMemory::default();
+    for index in TIMESERIES_INDEX.pin().values() {
+        total.merge(index.memory_usage());
+    }
+    total
+}

--- a/src/series/index/mod.rs
+++ b/src/series/index/mod.rs
@@ -138,13 +138,19 @@ pub fn get_series_by_id(
         return Ok(None);
     };
     let mut state = 0;
-    index.with_postings(&mut state, |posting, _| {
-        let Some(key) = posting.get_key_by_id(id) else {
-            return Ok(None);
-        };
-        let real_key = ctx.create_string(key.as_ref());
-        get_timeseries_mut(ctx, &real_key, must_exist, permissions)
-    })
+    // Resolve the key under the postings guard, then open it *after* the guard is gone.
+    // Opening a key runs the server's lazy-expiry check, which reaps an expired series through
+    // this module's `unlink` callback -- and that takes the postings write lock on this same
+    // thread. See `series::index::querier::resolve_series_keys`.
+    let real_key = index.with_postings(&mut state, |posting, _| {
+        posting
+            .get_key_by_id(id)
+            .map(|key| ctx.create_string(key.as_ref()))
+    });
+    let Some(real_key) = real_key else {
+        return Ok(None);
+    };
+    get_timeseries_mut(ctx, &real_key, must_exist, permissions)
 }
 
 pub fn get_series_key_by_id(ctx: &Context, id: SeriesRef) -> Option<ValkeyString> {

--- a/src/series/index/mod.rs
+++ b/src/series/index/mod.rs
@@ -190,12 +190,15 @@ pub fn index_series_by_key(ctx: &Context, key: &[u8]) {
     }
 }
 
-pub fn clear_timeseries_index(ctx: &Context) {
-    let db = get_current_db(ctx);
-    let map = TIMESERIES_INDEX.pin();
-    map.remove(&db);
+/// Drops the index for a single database. Takes the db explicitly: the only caller is the
+/// FLUSHDB handler, whose event context should not have its selected db mutated just to
+/// communicate which database was flushed.
+pub fn clear_timeseries_index(db: i32) {
+    TIMESERIES_INDEX.pin().remove(&db);
 }
 
+/// Drops every database's index. Used for the `dbnum == -1` flush -- `FLUSHALL`, and the
+/// implicit flush a replica performs on a full resync.
 pub fn clear_all_timeseries_indexes() {
     TIMESERIES_INDEX.pin().clear();
 }

--- a/src/series/index/mod.rs
+++ b/src/series/index/mod.rs
@@ -7,7 +7,7 @@ mod postings;
 mod querier;
 mod timeseries_index;
 
-use crate::common::context::get_current_db;
+use crate::common::context::{create_key_string, get_current_db};
 use croaring::Portable;
 use papaya::{Guard, HashMap, LocalGuard};
 use std::sync::LazyLock;
@@ -147,7 +147,7 @@ pub fn get_series_by_id(
     let real_key = index.with_postings(&mut state, |posting, _| {
         posting
             .get_key_by_id(id)
-            .map(|key| ctx.create_string(key.as_ref()))
+            .map(|key| create_key_string(ctx, key.as_ref()))
     });
     let Some(real_key) = real_key else {
         return Ok(None);
@@ -161,7 +161,7 @@ pub fn get_series_key_by_id(ctx: &Context, id: SeriesRef) -> Option<ValkeyString
     let mut state = 0;
     index_guard.with_postings(&mut state, |posting, _| {
         let key = posting.get_key_by_id(id)?;
-        Some(ctx.create_string(key.as_ref()))
+        Some(create_key_string(ctx, key.as_ref()))
     })
 }
 
@@ -181,7 +181,7 @@ pub fn remove_series_from_index(ts: &TimeSeries) {
 /// database, and inserts it into the index if not already present.
 pub fn index_series_by_key(ctx: &Context, key: &[u8]) {
     let db = get_current_db(ctx);
-    let valkey_key = ctx.create_string(key);
+    let valkey_key = create_key_string(ctx, key);
     let Ok(Some(mut series)) = get_timeseries_mut(ctx, &valkey_key, false, None) else {
         return;
     };

--- a/src/series/index/mod.rs
+++ b/src/series/index/mod.rs
@@ -1,6 +1,7 @@
 use std::ops::Deref;
 pub(crate) mod bulk_build;
 mod index_key;
+mod memory;
 mod posting_stats;
 mod postings;
 mod querier;
@@ -18,6 +19,7 @@ use crate::series::index::postings::Postings;
 use crate::series::request_types::MatchFilterOptions;
 use crate::series::{SeriesGuardMut, SeriesRef, TimeSeries, get_timeseries_mut};
 pub use index_key::IndexKey;
+pub use memory::{IndexMemory, index_memory_usage};
 pub use posting_stats::*;
 pub use postings::PostingsBitmap;
 pub use querier::*;

--- a/src/series/index/persistence.rs
+++ b/src/series/index/persistence.rs
@@ -14,7 +14,7 @@
 use super::postings::Postings;
 use super::postings::serialization;
 use super::{TIMESERIES_INDEX, get_db_index, index_series_by_key};
-use crate::common::context::{get_current_db, set_current_db};
+use crate::common::context::{create_key_string, get_current_db, set_current_db};
 use crate::common::encoding::{try_read_u8, try_read_uvarint, write_u8, write_uvarint};
 use crate::common::hash::{BuildNoHashHasher, DeterministicHasher};
 use crate::common::logging::{log_debug, log_notice, log_warning};
@@ -582,7 +582,7 @@ fn reconcile_db(db: i32) {
             let save_db = get_current_db(&ctx);
             set_current_db(&ctx, db);
             for (id, key) in &window {
-                let valkey_key = ctx.create_string(key.as_ref());
+                let valkey_key = create_key_string(&ctx, key.as_ref());
                 let key_handle = ctx.open_key(&valkey_key);
                 match key_handle.get_value::<TimeSeries>(&VK_TIME_SERIES_TYPE) {
                     Ok(Some(series)) if series.id == *id => {}

--- a/src/series/index/postings/serialization.rs
+++ b/src/series/index/postings/serialization.rs
@@ -457,7 +457,7 @@ mod tests {
         );
     }
 
-    /// [`MIN_ENTRY_BYTES`] is load-bearing for the entry-count check, and it is derived from a
+    /// [`MIN_ENTRY_BYTES`] is important for the entry-count check, and it is derived from a
     /// croaring format detail. Pin it against what the encoder actually writes.
     #[test]
     fn min_entry_bytes_matches_encoder() {

--- a/src/series/index/postings/stale.rs
+++ b/src/series/index/postings/stale.rs
@@ -32,6 +32,12 @@ impl StaleSet {
         self.ids.cardinality()
     }
 
+    /// Bytes the tombstone bitmap's roaring containers occupy.
+    #[inline]
+    pub(in crate::series::index) fn heap_size(&self) -> usize {
+        crate::series::index::memory::bitmap_heap_size(&self.ids)
+    }
+
     /// How many of `postings`' ids are stale. Cheaper than masking when only the count is wanted.
     #[inline]
     pub(in crate::series::index) fn stale_count_in(&self, postings: &PostingsBitmap) -> u64 {

--- a/src/series/index/querier.rs
+++ b/src/series/index/querier.rs
@@ -127,13 +127,14 @@ pub fn query_labels_distinct(
     // Resolve under the guard, open afterwards. See [`resolve_series_keys`].
     let resolved = {
         let postings = index.get_postings();
-        let ids: Vec<SeriesRef> = if selectors.is_empty() {
-            postings.all_postings.iter().collect()
+        if selectors.is_empty() {
+            // Iterate the bitmap in place: collecting it first would allocate a `Vec` holding
+            // every series id in the database before a single key is resolved.
+            resolve_series_keys(ctx, &postings, postings.all_postings.iter(), &mut stale)
         } else {
             let refs = postings.postings_for_selectors(selectors)?;
-            refs.iter().collect()
-        };
-        resolve_series_keys(ctx, &postings, ids.into_iter(), &mut stale)
+            resolve_series_keys(ctx, &postings, refs.iter(), &mut stale)
+        }
     };
 
     let mut result: BTreeSet<String> = BTreeSet::new();

--- a/src/series/index/querier.rs
+++ b/src/series/index/querier.rs
@@ -25,7 +25,7 @@
 use super::postings::{EMPTY_BITMAP, KeyType, Postings};
 use super::{PostingsBitmap, get_db_index, get_timeseries_index};
 use crate::common::Timestamp;
-use crate::common::context::{get_acl_user, get_current_db};
+use crate::common::context::{create_key_string, get_acl_user, get_current_db};
 use crate::common::hash::IntMap;
 use crate::error_consts;
 use crate::labels::filters::SeriesSelector;
@@ -74,7 +74,7 @@ fn resolve_series_keys(
     let mut resolved = Vec::with_capacity(capacity_estimate);
     for id in ids {
         match postings.get_key_by_id(id) {
-            Some(key) => resolved.push((id, ctx.create_string(key.as_bytes()))),
+            Some(key) => resolved.push((id, create_key_string(ctx, key.as_bytes()))),
             None => stale.push(id),
         }
     }
@@ -442,7 +442,7 @@ pub(super) fn get_guard_from_key<'a>(
     ctx: &'a Context,
     key: &KeyType,
 ) -> ValkeyResult<Option<SeriesGuard<'a>>> {
-    let real_key = ctx.create_string(key.as_bytes());
+    let real_key = create_key_string(ctx, key.as_bytes());
     let perms = Some(AclPermissions::ACCESS);
     get_timeseries(ctx, &real_key, perms, false)
 }

--- a/src/series/index/querier.rs
+++ b/src/series/index/querier.rs
@@ -44,6 +44,43 @@ use valkey_module::{AclPermissions, Context, ValkeyError, ValkeyResult, ValkeySt
 /// capacity keeps the common (empty) case off the heap.
 type StaleIds = SmallVec<[SeriesRef; 8]>;
 
+/// Series ids paired with the key each resolved to, captured under the postings read lock.
+type ResolvedKeys = Vec<(SeriesRef, ValkeyString)>;
+
+/// Turn posting ids into key names while the caller holds the postings read guard, recording
+/// ids that resolve to nothing as stale.
+///
+/// Every query in this module is split around this call for one reason: **no series key may be
+/// opened while the postings lock is held.** `RM_OpenKey` runs the server's lazy-expiry check,
+/// and reaping an expired key calls straight back into this module's `unlink`/`free` callback,
+/// which takes the postings *write* lock — on this same thread, on a non-reentrant `RwLock`.
+/// A single `TS.MRANGE` over a series whose TTL had passed hung the server outright:
+///
+/// ```text
+/// series_by_selectors            [postings read lock held]
+///   -> get_timeseries -> RM_OpenKey -> lookupKey -> expireIfNeeded
+///     -> deleteExpiredKeyAndPropagate -> dbGenericDelete
+///       -> module unlink callback -> remove_series_from_index -> write_lock   [blocks forever]
+/// ```
+///
+/// Resolving to owned `ValkeyString`s first lets the guard drop before any key is touched.
+fn resolve_series_keys(
+    ctx: &Context,
+    postings: &Postings,
+    ids: impl Iterator<Item = SeriesRef>,
+    stale: &mut StaleIds,
+) -> ResolvedKeys {
+    let capacity_estimate = ids.size_hint().1.unwrap_or(8);
+    let mut resolved = Vec::with_capacity(capacity_estimate);
+    for id in ids {
+        match postings.get_key_by_id(id) {
+            Some(key) => resolved.push((id, ctx.create_string(key.as_bytes()))),
+            None => stale.push(id),
+        }
+    }
+    resolved
+}
+
 pub fn series_by_selectors<'a>(
     ctx: &'a Context,
     selectors: &[SeriesSelector],
@@ -55,17 +92,17 @@ pub fn series_by_selectors<'a>(
 
     let db = get_current_db(ctx);
     let index = get_db_index(db);
-    let postings = index.get_postings();
 
     let mut stale = StaleIds::new();
-    // Scoped so the read guard (and the bitmap borrowed from it) is released before we
-    // take the write lock to record stale IDs.
-    let result = {
+    // The read guard is confined to this block: neither opening the keys below nor recording
+    // the stale ids afterwards may happen while it is held. See [`resolve_series_keys`].
+    let resolved = {
+        let postings = index.get_postings();
         let series_refs = postings.postings_for_selectors(selectors)?;
-        collect_series_from_postings(ctx, &postings, series_refs.iter(), range, &mut stale)
+        resolve_series_keys(ctx, &postings, series_refs.iter(), &mut stale)
     };
 
-    drop(postings);
+    let result = collect_series_from_postings(ctx, resolved, range, &mut stale);
     index.mark_ids_as_stale(&stale);
     result
 }
@@ -85,23 +122,22 @@ pub fn query_labels_distinct(
 ) -> ValkeyResult<BTreeSet<String>> {
     let db = get_current_db(ctx);
     let index = get_db_index(db);
-    let postings = index.get_postings();
 
     let mut stale = StaleIds::new();
-    let ids: Vec<SeriesRef> = if selectors.is_empty() {
-        postings.all_postings.iter().collect()
-    } else {
-        let refs = postings.postings_for_selectors(selectors)?;
-        refs.iter().collect()
+    // Resolve under the guard, open afterwards. See [`resolve_series_keys`].
+    let resolved = {
+        let postings = index.get_postings();
+        let ids: Vec<SeriesRef> = if selectors.is_empty() {
+            postings.all_postings.iter().collect()
+        } else {
+            let refs = postings.postings_for_selectors(selectors)?;
+            refs.iter().collect()
+        };
+        resolve_series_keys(ctx, &postings, ids.into_iter(), &mut stale)
     };
 
     let mut result: BTreeSet<String> = BTreeSet::new();
-    for id in ids {
-        let Some(key) = postings.get_key_by_id(id) else {
-            stale.push(id);
-            continue;
-        };
-        let k = ctx.create_string(key.as_bytes());
+    for (id, k) in resolved {
         // TS.QUERYLABELS contract: silently omit series the caller may not read rather
         // than erroring on the first unreadable match (that is the coarse gate the
         // label-search commands use, and it is deliberately not applied here).
@@ -129,7 +165,6 @@ pub fn query_labels_distinct(
         }
     }
 
-    drop(postings);
     index.mark_ids_as_stale(&stale);
     Ok(result)
 }
@@ -145,10 +180,10 @@ pub(super) fn series_posting_ids_by_selectors<'a>(
     }
     let db = get_current_db(ctx);
     let index = get_db_index(db);
-    let postings = index.get_postings();
 
     let mut stale = StaleIds::new();
-    let result = {
+    let resolved = {
+        let postings = index.get_postings();
         let series_ids = postings.postings_for_selectors(selectors)?;
         if series_ids.is_empty() {
             return Ok(Cow::Borrowed(&*EMPTY_BITMAP));
@@ -156,10 +191,10 @@ pub(super) fn series_posting_ids_by_selectors<'a>(
         if date_range.is_none() {
             return Ok(Cow::Owned(series_ids.into_owned()));
         }
-        collect_series_from_postings(ctx, &postings, series_ids.iter(), date_range, &mut stale)
+        resolve_series_keys(ctx, &postings, series_ids.iter(), &mut stale)
     };
 
-    drop(postings);
+    let result = collect_series_from_postings(ctx, resolved, date_range, &mut stale);
     index.mark_ids_as_stale(&stale);
 
     let id_iter = result?.into_iter().map(|(guard, _)| guard.id);
@@ -177,15 +212,15 @@ pub fn series_keys_by_selectors(
 
     let db = get_current_db(ctx);
     let index = get_db_index(db);
-    let postings = index.get_postings();
 
     let mut stale = StaleIds::new();
-    let result = {
+    let resolved = {
+        let postings = index.get_postings();
         let series_refs = postings.postings_for_selectors(selectors)?;
-        collect_series_keys(ctx, &postings, series_refs.iter(), range, &mut stale)
+        resolve_series_keys(ctx, &postings, series_refs.iter(), &mut stale)
     };
 
-    drop(postings);
+    let result = collect_series_keys(ctx, resolved, range, &mut stale);
     index.mark_ids_as_stale(&stale);
     result
 }
@@ -206,37 +241,30 @@ pub fn count_series_by_selectors(
 
     let db = get_current_db(ctx);
     let index = get_db_index(db);
-    let postings = index.get_postings();
 
     let mut stale = StaleIds::new();
-    // Scoped so the read guard (and the bitmap borrowed from it) is released before we
-    // take the write lock to record stale IDs.
-    let result = {
+    let resolved = {
+        let postings = index.get_postings();
         let series_refs = postings.postings_for_selectors(selectors)?;
-        count_series_from_postings(ctx, &postings, series_refs.iter(), range, &mut stale)
+        resolve_series_keys(ctx, &postings, series_refs.iter(), &mut stale)
     };
 
-    drop(postings);
+    let result = count_series_from_postings(ctx, resolved, range, &mut stale);
     index.mark_ids_as_stale(&stale);
     result
 }
 
 fn count_series_from_postings(
     ctx: &Context,
-    postings: &Postings,
-    ids: impl Iterator<Item = SeriesRef>,
+    resolved: ResolvedKeys,
     date_range: Option<MetaDateRangeFilter>,
     stale: &mut StaleIds,
 ) -> ValkeyResult<usize> {
-    // Without a date range, nothing about the series contents matters: resolve each posting
-    // to confirm the key still exists and the caller may read it, then drop the guard.
+    // Without a date range, nothing about the series contents matters: open each key just long
+    // enough to confirm it still exists and the caller may read it.
     let Some(date_range) = date_range else {
         let mut count = 0usize;
-        for id in ids {
-            let Some(key) = postings.get_key_by_id(id) else {
-                continue;
-            };
-            let k = ctx.create_string(key.as_bytes());
+        for (id, k) in resolved {
             let perms = Some(AclPermissions::ACCESS);
             if get_timeseries(ctx, &k, perms, false)?.is_some() {
                 count += 1;
@@ -249,14 +277,8 @@ fn count_series_from_postings(
 
     // With a date range we need the series state, so hold the guards (bare pointers, no
     // per-key `ValkeyString` retained) long enough to evaluate the predicate.
-    let capacity_estimate = ids.size_hint().1.unwrap_or(8);
-    let mut guards: Vec<SeriesGuard> = Vec::with_capacity(capacity_estimate);
-    for id in ids {
-        let Some(key) = postings.get_key_by_id(id) else {
-            stale.push(id);
-            continue;
-        };
-        let k = ctx.create_string(key.as_bytes());
+    let mut guards: Vec<SeriesGuard> = Vec::with_capacity(resolved.len());
+    for (id, k) in resolved {
         let perms = Some(AclPermissions::ACCESS);
         if let Some(guard) = get_timeseries(ctx, &k, perms, false)? {
             guards.push(guard);
@@ -292,13 +314,12 @@ fn count_series_from_postings(
 
 fn collect_series_keys(
     ctx: &Context,
-    postings: &Postings,
-    ids: impl Iterator<Item = SeriesRef>,
+    resolved: ResolvedKeys,
     date_range: Option<MetaDateRangeFilter>,
     stale: &mut StaleIds,
 ) -> ValkeyResult<Vec<ValkeyString>> {
     if let Some(date_range) = date_range {
-        let series = collect_series_from_postings(ctx, postings, ids, Some(date_range), stale)?;
+        let series = collect_series_from_postings(ctx, resolved, Some(date_range), stale)?;
         let keys = series.into_iter().map(|g| g.1).collect();
         return Ok(keys);
     }
@@ -307,28 +328,17 @@ fn collect_series_keys(
     // filter regardless of the caller's per-key read access. Command-level ACL
     // (can the user run TS.QUERYINDEX at all) is already enforced by the server,
     // so we must NOT drop keys the caller lacks read (ACCESS) permission on here.
-    let keys = ids
-        .filter_map(|id| {
-            if let Some(key) = postings.get_key_by_id(id) {
-                Some(ctx.create_string(key.as_bytes()))
-            } else {
-                stale.push(id);
-                None
-            }
-        })
-        .collect();
-
-    Ok(keys)
+    // Ids that resolved to no key were already recorded by `resolve_series_keys`.
+    Ok(resolved.into_iter().map(|(_, key)| key).collect())
 }
 
 fn collect_series_from_postings<'a>(
     ctx: &'a Context,
-    postings: &Postings,
-    ids: impl Iterator<Item = SeriesRef>,
+    resolved: ResolvedKeys,
     date_range: Option<MetaDateRangeFilter>,
     stale: &mut StaleIds,
 ) -> ValkeyResult<Vec<(SeriesGuard<'a>, ValkeyString)>> {
-    let result = get_multi_series_by_id(ctx, postings, ids, stale)?;
+    let result = get_multi_series_by_id(ctx, resolved, stale)?;
 
     if result.is_empty() {
         return Ok(result);
@@ -344,19 +354,11 @@ fn collect_series_from_postings<'a>(
 
 fn get_multi_series_by_id<'a>(
     ctx: &'a Context,
-    postings: &Postings,
-    ids: impl Iterator<Item = SeriesRef>,
+    resolved: ResolvedKeys,
     stale: &mut StaleIds,
 ) -> ValkeyResult<Vec<(SeriesGuard<'a>, ValkeyString)>> {
-    let capacity_estimate = ids.size_hint().1.unwrap_or(8);
-    let mut result = Vec::with_capacity(capacity_estimate);
-    for id in ids {
-        let Some(key) = postings.get_key_by_id(id) else {
-            stale.push(id);
-            continue;
-        };
-
-        let k = ctx.create_string(key.as_bytes());
+    let mut result = Vec::with_capacity(resolved.len());
+    for (id, k) in resolved {
         let perms = Some(AclPermissions::ACCESS);
         if let Some(guard) = get_timeseries(ctx, &k, perms, false)? {
             result.push((guard, k));

--- a/src/series/index/server_events.rs
+++ b/src/series/index/server_events.rs
@@ -13,8 +13,8 @@ use crate::series::index::persistence::{
     on_loading_ended, on_loading_failed, on_loading_started, should_skip_load_indexing,
 };
 use crate::series::index::{
-    TIMESERIES_INDEX, clear_timeseries_index, get_db_index, get_timeseries_index,
-    get_timeseries_index_for_db, index_series_by_key,
+    TIMESERIES_INDEX, clear_all_timeseries_indexes, clear_timeseries_index, get_db_index,
+    get_timeseries_index, get_timeseries_index_for_db, index_series_by_key,
 };
 use crate::series::series_data_type::VK_TIME_SERIES_TYPE;
 use crate::series::tasks::remove_all_stale_series_internal;
@@ -23,7 +23,10 @@ use range_set_blaze::RangeSetBlaze;
 use std::os::raw::c_void;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{LazyLock, Mutex, RwLock};
-use valkey_module::server_events::{LoadingSubevent, PersistenceSubevent};
+use valkey_module::server_events::{
+    FLUSH_SERVER_EVENTS_LIST, FlushSubevent, LoadingSubevent, PersistenceSubevent,
+    SWAPDB_SERVER_EVENTS_LIST,
+};
 use valkey_module::{Context, MODULE_CONTEXT, NotifyEvent, ValkeyResult, logging, raw};
 use valkey_module_macros::{loading_event_handler, persistence_event_handler};
 
@@ -574,6 +577,34 @@ pub(crate) fn generic_key_events_handler(
     );
 }
 
+/// Re-dispatch a server event to the `valkey-module` handlers this module's own subscription
+/// displaced.
+///
+/// `RM_SubscribeToServerEvent` keeps exactly one callback per (module, event) and *replaces* an
+/// existing one rather than chaining. `valkey-module` subscribes its own dispatcher for any event
+/// that has `#[..._event_handler]` functions, and it does so before `initialize` runs — so every
+/// raw subscription taken here silently discards that dispatcher and everything behind it. This
+/// module subscribes to FLUSHDB and SWAPDB directly because it needs the event payload
+/// (`RedisModuleFlushInfo::dbnum`, `RedisModuleSwapDbInfo`), which the macro surface does not
+/// expose, so the dispatcher has to be driven from here instead.
+///
+/// This is not hypothetical: `series_data_type::flushed_event_handler` — the `IS_FLUSHING` flag
+/// that lets the per-key `free`/`unlink` callbacks skip index maintenance during a flush — never
+/// ran at all, leaving the flag permanently false and that fast path dead.
+fn dispatch_displaced_handlers<T: Copy>(
+    ctx: *mut raw::RedisModuleCtx,
+    handlers: &[fn(&Context, T)],
+    payload: T,
+) {
+    if handlers.is_empty() {
+        return;
+    }
+    let ctx = Context::new(ctx);
+    for handler in handlers {
+        handler(&ctx, payload);
+    }
+}
+
 unsafe extern "C" fn on_flush_event(
     ctx: *mut raw::RedisModuleCtx,
     _eid: raw::RedisModuleEvent,
@@ -584,14 +615,28 @@ unsafe extern "C" fn on_flush_event(
         let fi: &raw::RedisModuleFlushInfo = unsafe { &*(data as *mut raw::RedisModuleFlushInfo) };
 
         if fi.dbnum == -1 {
+            // FLUSHALL, and the implicit flush a replica performs on a full resync: every
+            // database is gone. The per-key `free`/`unlink` callbacks that would otherwise
+            // retire each series are deliberately skipped while a flush is in progress, so
+            // dropping the indexes here is the only thing that retires them — leaving this to
+            // clear the delayed-keys map alone left the whole index dangling, every id pointing
+            // at a key that no longer exists.
+            clear_all_timeseries_indexes();
             clear_delayed_keys_map();
         } else {
-            let ctx = Context::new(ctx);
-            set_current_db(&ctx, fi.dbnum);
-            clear_timeseries_index(&ctx);
+            clear_timeseries_index(fi.dbnum);
             clear_delayed_keys_in_db(fi.dbnum);
         }
     };
+
+    // After the index work, so `IS_FLUSHING` stays set across it and is cleared only once the
+    // index agrees with the (now empty) keyspace.
+    let flush_sub_event = if sub_event == raw::REDISMODULE_SUBEVENT_FLUSHDB_START {
+        FlushSubevent::Started
+    } else {
+        FlushSubevent::Ended
+    };
+    dispatch_displaced_handlers(ctx, &FLUSH_SERVER_EVENTS_LIST, flush_sub_event);
 }
 
 fn swap_timeseries_index_dbs(from_db: i32, to_db: i32) {
@@ -603,9 +648,9 @@ fn swap_timeseries_index_dbs(from_db: i32, to_db: i32) {
 }
 
 unsafe extern "C" fn on_swap_db_event(
-    _ctx: *mut raw::RedisModuleCtx,
+    ctx: *mut raw::RedisModuleCtx,
     eid: raw::RedisModuleEvent,
-    _sub_event: u64,
+    sub_event: u64,
     data: *mut c_void,
 ) {
     if eid.id == raw::REDISMODULE_EVENT_SWAPDB {
@@ -617,6 +662,11 @@ unsafe extern "C" fn on_swap_db_event(
 
         swap_timeseries_index_dbs(from_db, to_db);
     }
+
+    // This module has no `#[swapdb_event_handler]` today, so this list is empty and the call
+    // costs nothing — but see `dispatch_displaced_handlers`: without it, the first one added
+    // would silently never run.
+    dispatch_displaced_handlers(ctx, &SWAPDB_SERVER_EVENTS_LIST, sub_event);
 }
 
 pub(crate) fn register_server_event_handlers(ctx: &Context) -> ValkeyResult<()> {

--- a/src/series/index/server_events.rs
+++ b/src/series/index/server_events.rs
@@ -1,6 +1,8 @@
 //! This module subscribes to Valkey events to ensure secondary index consistency.
 //!
-use crate::common::context::{get_current_db, register_server_event_handler, set_current_db};
+use crate::common::context::{
+    create_key_string, get_current_db, register_server_event_handler, set_current_db,
+};
 use crate::common::hash::BuildNoHashHasher;
 use crate::common::logging::{log_debug, log_notice};
 use crate::common::sync::{lock, read_lock, write_lock};
@@ -87,7 +89,7 @@ fn index_timeseries_in_batch(db: i32, batch: &[Box<[u8]>]) -> usize {
     let mut postings = write_lock(&index.inner);
 
     for key_name in batch.iter() {
-        let valkey_key = ctx.create_string(key_name.as_ref());
+        let valkey_key = create_key_string(&ctx, key_name.as_ref());
         let writeable_key = ctx.open_key_writable(&valkey_key);
         let Ok(Some(series)) = writeable_key.get_value::<TimeSeries>(&VK_TIME_SERIES_TYPE) else {
             skipped += 1;
@@ -461,7 +463,7 @@ fn loading_event_handler(_ctx: &Context, loading_event: LoadingSubevent) {
 fn handle_key_move(ctx: &Context, key: &[u8], old_db: i32) {
     let new_db = get_current_db(ctx);
     // fetch the series from the new
-    let valkey_key = ctx.create_string(key);
+    let valkey_key = create_key_string(ctx, key);
     let Ok(Some(mut series)) = get_timeseries_mut(ctx, &valkey_key, false, None) else {
         logging::log_warning("Failed to load series for key move");
         return;
@@ -479,7 +481,7 @@ fn handle_key_move(ctx: &Context, key: &[u8], old_db: i32) {
 
 fn handle_key_rename(ctx: &Context, _old_key: &[u8], new_key: &[u8]) {
     let index = get_timeseries_index(ctx);
-    let key = ctx.create_string(new_key);
+    let key = create_key_string(ctx, new_key);
     let Ok(Some(series)) = get_timeseries(ctx, &key, None, false) else {
         logging::log_warning("Failed to load series for key rename");
         return;
@@ -518,7 +520,7 @@ fn handle_key_restore(ctx: &Context, key: &[u8]) {
 /// key type, so non-timeseries keys are ignored quietly.
 fn handle_key_copy(ctx: &Context, key: &[u8]) {
     let db = get_current_db(ctx);
-    let valkey_key = ctx.create_string(key);
+    let valkey_key = create_key_string(ctx, key);
     let Ok(Some(mut series)) = get_timeseries_mut(ctx, &valkey_key, false, None) else {
         return;
     };

--- a/src/series/index/timeseries_index.rs
+++ b/src/series/index/timeseries_index.rs
@@ -243,51 +243,57 @@ impl TimeSeriesIndex {
         let mut keys: Vec<ValkeyString> = Vec::new();
         let mut missing_keys: Vec<SeriesRef> = Vec::new();
 
-        let postings = read_lock(&self.inner);
-
-        // get keys from ids
-        let ids = postings.postings_for_selectors(filters)?;
-
-        let mut expected_count = ids.cardinality() as usize;
-        if expected_count == 0 {
-            return Ok(Vec::new());
-        }
-
-        keys.reserve(expected_count);
-
-        let current_user = get_acl_user(ctx);
-        let is_user_client = is_acl_enforced(ctx);
-
         let cloned_perms = acl_permissions.as_ref().map(clone_permissions);
-        let can_access_all_keys = has_all_keys_permissions(ctx, &current_user, acl_permissions);
 
-        for series_ref in ids.iter() {
-            let key = postings.get_key_by_id(series_ref);
-            match key {
-                Some(key) => {
-                    let real_key = ctx.create_string(key.as_ref());
-                    if is_user_client
-                        && !can_access_all_keys
-                        && let Some(perms) = &cloned_perms
-                    {
-                        // check if the user has permission for this key
-                        if ctx
-                            .acl_check_key_permission(&current_user, &real_key, perms)
-                            .is_err()
+        // The read guard is confined to this block. Recording the dangling ids collected below
+        // needs the *write* lock, and `RwLock` is not reentrant: asking for it while this thread
+        // still held the read guard deadlocked the server -- and did so on the self-healing path,
+        // which only runs once the index is already inconsistent.
+        let expected_count = {
+            let postings = read_lock(&self.inner);
+
+            // get keys from ids
+            let ids = postings.postings_for_selectors(filters)?;
+
+            let expected_count = ids.cardinality() as usize;
+            if expected_count == 0 {
+                return Ok(Vec::new());
+            }
+
+            keys.reserve(expected_count);
+
+            let current_user = get_acl_user(ctx);
+            let is_user_client = is_acl_enforced(ctx);
+            let can_access_all_keys = has_all_keys_permissions(ctx, &current_user, acl_permissions);
+
+            for series_ref in ids.iter() {
+                let key = postings.get_key_by_id(series_ref);
+                match key {
+                    Some(key) => {
+                        let real_key = ctx.create_string(key.as_ref());
+                        if is_user_client
+                            && !can_access_all_keys
+                            && let Some(perms) = &cloned_perms
                         {
-                            break;
+                            // check if the user has permission for this key
+                            if ctx
+                                .acl_check_key_permission(&current_user, &real_key, perms)
+                                .is_err()
+                            {
+                                break;
+                            }
                         }
+                        keys.push(real_key);
                     }
-                    keys.push(real_key);
-                }
-                None => {
-                    // this should not happen, but in case it does, we log an error and continue
-                    missing_keys.push(series_ref);
+                    None => {
+                        // this should not happen, but in case it does, we log an error and continue
+                        missing_keys.push(series_ref);
+                    }
                 }
             }
-        }
 
-        expected_count -= missing_keys.len();
+            expected_count - missing_keys.len()
+        };
 
         if keys.len() != expected_count {
             // User does not have permission to read some keys, or some keys are missing

--- a/src/series/index/timeseries_index.rs
+++ b/src/series/index/timeseries_index.rs
@@ -6,7 +6,7 @@ use std::sync::{RwLock, RwLockReadGuard};
 use super::posting_stats::{PostingStat, PostingsStats, StatsMaxHeap};
 use super::postings::{Postings, PostingsBitmap};
 use crate::common::constants::METRIC_NAME_LABEL;
-use crate::common::context::{get_acl_user, is_acl_enforced};
+use crate::common::context::{create_key_string, get_acl_user, is_acl_enforced};
 use crate::common::hash::DeterministicHasher;
 use crate::common::sync::{read_lock, write_lock};
 use crate::error_consts;
@@ -270,7 +270,7 @@ impl TimeSeriesIndex {
                 let key = postings.get_key_by_id(series_ref);
                 match key {
                     Some(key) => {
-                        let real_key = ctx.create_string(key.as_ref());
+                        let real_key = create_key_string(ctx, key.as_ref());
                         if is_user_client
                             && !can_access_all_keys
                             && let Some(perms) = &cloned_perms

--- a/src/series/mrange.rs
+++ b/src/series/mrange.rs
@@ -2,6 +2,7 @@ use crate::aggregators::{
     EmptyFillBounds, PartialReducer, PartialRowReducer, PartialSampleReducer, PartialState,
 };
 use crate::common::constants::{REDUCER_KEY, SOURCE_KEY};
+use crate::common::context::key_for_display;
 use crate::common::{MultiSample, Sample, Timestamp};
 use crate::error_consts;
 use crate::iterators::create_sample_iterator_adapter;
@@ -23,7 +24,8 @@ use valkey_module::{Context, ValkeyError, ValkeyResult};
 
 struct MRangeSeriesMeta<'a> {
     series: &'a TimeSeries,
-    source_key: String,
+    /// The series key, verbatim. Binary, not `String` — see `MRangeSeriesResult::key`.
+    source_key: Vec<u8>,
     latest: Option<Sample>,
     group_label_value: Option<String>,
 }
@@ -55,7 +57,7 @@ impl SampleLimit {
 /// into mergeable partial states.
 pub(crate) struct GroupPartialsResult {
     pub group_label_value: String,
-    pub source_keys: Vec<String>,
+    pub source_keys: Vec<Vec<u8>>,
     /// Ascending; `states` holds `column_count` entries per timestamp.
     pub timestamps: Vec<Timestamp>,
     /// Row-major: bucket i, column j at `states[i * column_count + j]`.
@@ -99,7 +101,7 @@ pub(crate) fn process_mrange_group_partials(
         .iter()
         .map(|(guard, key)| MRangeSeriesMeta {
             series: guard,
-            source_key: key.to_string(),
+            source_key: key.as_slice().to_vec(),
             group_label_value: None,
             latest: get_latest(&options.range, ctx, guard),
         })
@@ -121,7 +123,7 @@ pub(crate) fn process_mrange_group_partials(
         .into_iter()
         .iter_into_par()
         .map(|(label_value, group_data)| {
-            let mut source_keys: Vec<String> = group_data
+            let mut source_keys: Vec<Vec<u8>> = group_data
                 .series
                 .iter()
                 .map(|m| m.source_key.clone())
@@ -202,7 +204,7 @@ pub(crate) fn process_mrange_query(
         .iter()
         .map(|(guard, key)| MRangeSeriesMeta {
             series: guard,
-            source_key: key.to_string(),
+            source_key: key.as_slice().to_vec(),
             group_label_value: None,
             latest: {
                 // This is done upfront to enable parallel series processing below
@@ -415,7 +417,7 @@ fn handle_grouping(
                 )))
             };
             let labels = group_data.labels;
-            let key = format!("{}={}", grouping.group_label, label_value);
+            let key = format!("{}={}", grouping.group_label, label_value).into_bytes();
             MRangeSeriesResult {
                 key,
                 group_label_value: Some(label_value),
@@ -567,9 +569,16 @@ pub(crate) fn build_mrange_grouped_labels(
     group_label_name: &str,
     group_label_value: &str,
     reducer_name_str: &str,
-    source_identifiers: &[String],
+    source_identifiers: &[Vec<u8>],
 ) -> Vec<Label> {
-    let sources = source_identifiers.join(",");
+    // The `__source__` label is a label *value*, and labels are UTF-8 strings throughout the
+    // module, so a source key holding a non-UTF-8 byte cannot round-trip here. This is the one
+    // place a key name is rendered lossily; the reply's own key field stays raw bytes.
+    let sources = source_identifiers
+        .iter()
+        .map(|key| key_for_display(key))
+        .collect::<Vec<_>>()
+        .join(",");
     vec![
         Label {
             name: group_label_name.into(),
@@ -598,7 +607,7 @@ fn collect_group_label_values(metas: &mut Vec<MRangeSeriesMeta>, grouping: &Rang
 struct GroupedSeriesData<'a> {
     series: Vec<MRangeSeriesMeta<'a>>,
     labels: Vec<Label>,
-    source_keys: Vec<String>,
+    source_keys: Vec<Vec<u8>>,
 }
 
 fn group_series_by_label<'a>(
@@ -700,7 +709,12 @@ mod tests {
     }
 
     fn keys_of(results: &[MRangeSeriesResult]) -> Vec<&str> {
-        let mut keys: Vec<&str> = results.iter().map(|r| r.key.as_str()).collect();
+        // Keys are bytes; every key these tests build is ASCII, so the unwrap doubles as an
+        // assertion that nothing mangled them on the way through.
+        let mut keys: Vec<&str> = results
+            .iter()
+            .map(|r| std::str::from_utf8(&r.key).expect("test keys are ASCII"))
+            .collect();
         keys.sort();
         keys
     }
@@ -795,7 +809,7 @@ mod tests {
         sort_mrange_results(&mut results, false);
 
         assert_eq!(results.len(), 2);
-        assert_eq!(results[0].key, "a");
+        assert_eq!(results[0].key, b"a");
         let rows = rows_of(&results[0]);
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].timestamp, 0);
@@ -824,7 +838,7 @@ mod tests {
         let results = handle_grouping(metas, options.clone()).unwrap();
 
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].key, "region=us");
+        assert_eq!(results[0].key, b"region=us");
         let rows = rows_of(&results[0]);
         // ts 0: avg 2+10=12, max 3+12=15; ts 100: a only; ts 200: b only
         assert_eq!(rows.len(), 3);

--- a/src/series/multi_del.rs
+++ b/src/series/multi_del.rs
@@ -181,7 +181,7 @@ fn fetch_series_batch<'a>(
     let mut result: Vec<SeriesGuardMut<'a>> = Vec::with_capacity(batch_size);
     let mut keys: Vec<ValkeyString> = Vec::with_capacity(batch_size);
 
-    // Two phases per round, and the split is load-bearing: opening a key runs the server's
+    // Two phases per round, and the split is important: opening a key runs the server's
     // lazy-expiry check, which reaps an expired series through this module's `unlink` callback
     // and takes the postings *write* lock on this same thread. Holding the read guard across
     // `get_timeseries` therefore deadlocks. See `series::index::querier::resolve_series_keys`.

--- a/src/series/multi_del.rs
+++ b/src/series/multi_del.rs
@@ -17,6 +17,24 @@ use valkey_module::{
     AclPermissions, Context, NotifyEvent, ValkeyError, ValkeyResult, ValkeyString,
 };
 
+/// Apply `TS.MDEL` on this node and propagate its *effects* to this node's replicas and AOF.
+///
+/// The command itself is deliberately not replicated verbatim by any caller:
+///
+/// * In cluster mode each shard runs its own slice inside a fanout RPC handler. That context has
+///   no client argv for `ReplicateVerbatim` to copy, and a replica replaying `TS.MDEL` would fan
+///   the command out across the cluster a second time. Before this, the clustered branch simply
+///   returned without replicating at all, so a cluster-mode `TS.MDEL` never reached any replica.
+/// * Even standalone, a verbatim replay re-resolves both the filter and the timestamp bounds on
+///   the replica. Wall-clock bounds (`TimestampValue::Now` and `Relative`) resolve through
+///   `as_timestamp` against whichever node is evaluating them, so a replica applying the replayed
+///   command can delete a different window than the primary did.
+///
+/// Propagating resolved effects avoids both: `DEL <key>` per key removed, and
+/// `TS.DEL <key> <start> <end>` with absolute millisecond bounds per series whose range changed.
+/// `TS.DEL` is the exact operation performed here (`remove_range` followed by
+/// `CompactionOp::RemoveRange`), so the replica re-derives the same downstream compaction the
+/// primary did, the same way it does for a client-issued `TS.DEL`.
 pub fn delete_series_by_selectors(
     ctx: &Context,
     selectors: &[SeriesSelector],
@@ -52,7 +70,12 @@ fn handle_delete_keys(ctx: &Context, filters: &[SeriesSelector]) -> ValkeyResult
     let keys = index.keys_for_selectors(ctx, filters, Some(AclPermissions::DELETE))?;
     let mut total_deleted = 0;
     for key in keys {
-        total_deleted += delete_key(ctx, &ctx.create_string(key.as_ref()))?;
+        let key = ctx.create_string(key.as_ref());
+        if delete_key(ctx, &key)? == 0 {
+            continue;
+        }
+        total_deleted += 1;
+        ctx.replicate("DEL", &[&key]);
     }
     Ok(total_deleted)
 }
@@ -98,6 +121,8 @@ fn delete_range_batch(
     end_ts: Timestamp,
 ) -> ValkeyResult<usize> {
     let mut total_deleted = 0;
+    let start_arg = ctx.create_string(start_ts.to_string());
+    let end_arg = ctx.create_string(end_ts.to_string());
     let mut series = series;
     let res = series
         .par_mut()
@@ -128,6 +153,8 @@ fn delete_range_batch(
                     end: end_ts,
                 },
             )?;
+            // Propagate the resolved effect; see `delete_series_by_selectors`.
+            ctx.replicate("TS.DEL", &[&keys[i], &start_arg, &end_arg]);
         }
     }
 

--- a/src/series/multi_del.rs
+++ b/src/series/multi_del.rs
@@ -176,52 +176,61 @@ fn fetch_series_batch<'a>(
     };
 
     let index = get_timeseries_index(ctx);
-    let postings_guard = index.get_postings();
 
     let mut stale_ids: SmallVec<[SeriesRef; 8]> = SmallVec::new();
     let mut result: Vec<SeriesGuardMut<'a>> = Vec::with_capacity(batch_size);
     let mut keys: Vec<ValkeyString> = Vec::with_capacity(batch_size);
 
-    let postings = postings_guard.deref();
-    // Read ids in chunks until we gather `buf_size` valid series or cursor is exhausted.
-    for id in cursor.by_ref() {
-        let Some(k) = postings.get_key_by_id(id) else {
-            stale_ids.push(id);
-            continue;
-        };
+    // Two phases per round, and the split is load-bearing: opening a key runs the server's
+    // lazy-expiry check, which reaps an expired series through this module's `unlink` callback
+    // and takes the postings *write* lock on this same thread. Holding the read guard across
+    // `get_timeseries` therefore deadlocks. See `series::index::querier::resolve_series_keys`.
+    //
+    // Keep going until the batch is full or the cursor runs dry, so an all-stale round still
+    // reports progress rather than looking like the end of the postings.
+    while result.len() < batch_size {
+        let wanted = batch_size - result.len();
+        let mut resolved: Vec<(SeriesRef, ValkeyString)> = Vec::with_capacity(wanted);
 
-        let key = ctx.create_string(k.as_bytes());
-
-        if is_user_client
-            && !has_all_keys_permission
-            && ctx
-                .acl_check_key_permission(&user, &key, &AclPermissions::DELETE)
-                .is_err()
         {
-            continue;
-        }
-
-        match get_timeseries(ctx, &key) {
-            Err(_) => {
-                stale_ids.push(id);
-                continue;
-            }
-            Ok(None) => {
-                stale_ids.push(id);
-                continue;
-            }
-            Ok(Some(series)) => {
-                result.push(series);
-                keys.push(key);
+            let postings_guard = index.get_postings();
+            let postings = postings_guard.deref();
+            for id in cursor.by_ref() {
+                match postings.get_key_by_id(id) {
+                    Some(k) => resolved.push((id, ctx.create_string(k.as_bytes()))),
+                    None => stale_ids.push(id),
+                }
+                if resolved.len() == wanted {
+                    break;
+                }
             }
         }
 
-        if result.len() >= batch_size {
+        let exhausted = resolved.len() < wanted;
+
+        for (id, key) in resolved {
+            if is_user_client
+                && !has_all_keys_permission
+                && ctx
+                    .acl_check_key_permission(&user, &key, &AclPermissions::DELETE)
+                    .is_err()
+            {
+                continue;
+            }
+
+            match get_timeseries(ctx, &key) {
+                Err(_) | Ok(None) => stale_ids.push(id),
+                Ok(Some(series)) => {
+                    result.push(series);
+                    keys.push(key);
+                }
+            }
+        }
+
+        if exhausted {
             break;
         }
     }
-
-    drop(postings_guard);
 
     if !stale_ids.is_empty() {
         let mut postings_guard = index.get_postings_mut();

--- a/src/series/multi_del.rs
+++ b/src/series/multi_del.rs
@@ -1,5 +1,5 @@
 use crate::common::Timestamp;
-use crate::common::context::{get_acl_user, is_acl_enforced};
+use crate::common::context::{create_key_string, get_acl_user, is_acl_enforced};
 use crate::config::num_threads;
 use crate::labels::filters::SeriesSelector;
 use crate::series::index::{PostingsBitmap, get_timeseries_index, with_timeseries_postings};
@@ -70,7 +70,7 @@ fn handle_delete_keys(ctx: &Context, filters: &[SeriesSelector]) -> ValkeyResult
     let keys = index.keys_for_selectors(ctx, filters, Some(AclPermissions::DELETE))?;
     let mut total_deleted = 0;
     for key in keys {
-        let key = ctx.create_string(key.as_ref());
+        let key = create_key_string(ctx, key.as_ref());
         if delete_key(ctx, &key)? == 0 {
             continue;
         }
@@ -197,7 +197,7 @@ fn fetch_series_batch<'a>(
             let postings = postings_guard.deref();
             for id in cursor.by_ref() {
                 match postings.get_key_by_id(id) {
-                    Some(k) => resolved.push((id, ctx.create_string(k.as_bytes()))),
+                    Some(k) => resolved.push((id, create_key_string(ctx, k.as_bytes()))),
                     None => stale_ids.push(id),
                 }
                 if resolved.len() == wanted {

--- a/src/series/request_types.rs
+++ b/src/series/request_types.rs
@@ -411,13 +411,18 @@ impl SeriesResultData {
 
 #[derive(Default, Clone, Debug)]
 pub(crate) struct MRangeSeriesResult {
-    pub key: String,
+    /// The series key, verbatim. Valkey key names are binary-safe, so this is
+    /// raw bytes rather than a `String`: routing them through `String` means a
+    /// lossy UTF-8 conversion, and the client would get a mangled name back for
+    /// any key holding a non-UTF-8 byte. For a GROUPBY result this instead holds
+    /// the synthetic `<label>=<value>` group name.
+    pub key: Vec<u8>,
     pub group_label_value: Option<String>,
     pub labels: Vec<Label>,
     /// Source series keys backing a GROUPBY group (sorted). Empty for
     /// non-grouped results. RESP3 replies report these in the per-group
     /// `sources` metadata map regardless of WITHLABELS.
-    pub sources: Vec<String>,
+    pub sources: Vec<Vec<u8>>,
     pub data: SeriesResultData,
 }
 

--- a/src/series/series_data_type.rs
+++ b/src/series/series_data_type.rs
@@ -41,7 +41,7 @@ pub static VK_TIME_SERIES_TYPE: ValkeyType = ValkeyType::new(
         aux_load: Some(aux_load),
         aux_save: None,
         aux_save_triggers: REDISMODULE_AUX_BEFORE_RDB as i32,
-        free_effort: None,
+        free_effort: Some(free_effort),
         unlink: Some(unlink),
         copy: Some(copy),
         defrag: Some(defrag),
@@ -144,13 +144,47 @@ unsafe extern "C" fn mem_usage(value: *const c_void) -> usize {
     series.memory_usage()
 }
 
+/// How much work freeing this value is, in allocations.
+///
+/// Without this callback the server assumes 1, which is below its `LAZYFREE_THRESHOLD` of 64, so
+/// every series -- a multi-million-sample one included -- was freed synchronously on the main
+/// thread and `UNLINK`, `lazyfree-lazy-expire` and friends did nothing for this type.
+///
+/// Registering it means `free` can now run on a lazyfree thread for any sizeable series, which
+/// is why that callback no longer touches the index at all -- see the comment there.
+unsafe extern "C" fn free_effort(_key: *mut RedisModuleString, value: *const c_void) -> usize {
+    if value.is_null() {
+        return 1;
+    }
+    let series = unsafe { &*value.cast::<TimeSeries>() };
+    series.free_effort()
+}
+
+/// Drop the value. Deliberately nothing else -- in particular, no index work.
+///
+/// The server reaches this through exactly one call site (`freeModuleObject`, from
+/// `decrRefCount`), and only from three places above it: `dbGenericDelete` and `dbOverwrite`,
+/// both of which fire `unlink` first, and `emptyDbStructure`, where a flush retires whole
+/// indexes at once. So `unlink` is the sole owner of index retirement and this callback has
+/// nothing left to do.
+///
+/// It used to call `remove_series_from_index` here as well, which was not merely redundant:
+///
+///   * on every `DEL`/`UNLINK` it took the index write lock to remove an id that `unlink` had
+///     removed moments earlier, logging "Tried to remove non-existing series id" each time --
+///     one spurious warning per deleted series, reproduced at 8 for 8 deletes; and
+///   * on a `FLUSHALL ASYNC` it did the same per key. `IS_FLUSHING` does not cover that: the
+///     flush-end event fires as soon as `emptyData` returns, while the bio thread is still
+///     draining the queue, so most of those frees see the flag already cleared and go on to
+///     search an index that has just been emptied wholesale.
+///
+/// That second case is the reason this matters more now than it did. `free_effort` routinely
+/// puts this callback on a lazyfree thread, so the redundant write lock would be taken from a
+/// background thread, contending with main-thread queries for no result.
 #[allow(unused)]
 unsafe extern "C" fn free(value: *mut c_void) {
     let sm = value.cast::<TimeSeries>();
-    let series = unsafe { Box::from_raw(sm) };
-    // todo: it may be helpful to push index deletion to a background thread
-    remove_series_from_index(&series);
-    drop(series);
+    drop(unsafe { Box::from_raw(sm) });
 }
 
 #[allow(non_snake_case, unused)]
@@ -175,6 +209,8 @@ unsafe extern "C" fn copy(
     Box::into_raw(Box::new(new_series)).cast::<c_void>()
 }
 
+/// Retire the series from the index. This is the *only* place that happens for a single key --
+/// see `free` for why, and for the paths the server guarantees reach here first.
 unsafe extern "C" fn unlink(_key: *mut RedisModuleString, value: *const c_void) {
     if value.is_null() {
         return;
@@ -193,10 +229,15 @@ unsafe extern "C" fn defrag(
     }
     // Convert the pointer to a TimeSeries so we can operate on it.
     let series: &mut TimeSeries = unsafe { &mut *(*value).cast::<TimeSeries>() };
-    match defrag_series(series) {
-        Ok(_) => 0,
-        Err(_) => 1,
+    if let Err(e) = defrag_series(series) {
+        logging::log_warning(format!("TSDB: Error defragmenting series: {e:?}"));
     }
+    // Always "done". A non-zero return asks the server to call us again with the cursor it
+    // passed, and `defrag_series` is not incremental -- it compacts the whole series in one
+    // call. Returning 1 on failure, as this did, would have spun `moduleLateDefrag` on a series
+    // that fails every time. That path was unreachable while `free_effort` was unregistered
+    // (effort 1 always defragged inline); registering it makes a large series take it.
+    0
 }
 
 /// # Safety

--- a/src/series/tasks/utils.rs
+++ b/src/series/tasks/utils.rs
@@ -1,3 +1,4 @@
+use crate::common::context::create_key_string;
 use crate::series::index::{TIMESERIES_INDEX, get_timeseries_index, with_timeseries_postings};
 use crate::series::{SeriesGuardMut, SeriesRef, TimeSeries, get_timeseries_mut};
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -57,7 +58,7 @@ pub(super) fn fetch_series_batch(
                     continue;
                 };
 
-                let key = ctx.create_string(k.as_ref());
+                let key = create_key_string(ctx, k.as_ref());
                 let Ok(Some(series)) = get_timeseries_mut(ctx, &key, false, None) else {
                     stale_ids.push(id);
                     continue;

--- a/src/series/time_series.rs
+++ b/src/series/time_series.rs
@@ -966,6 +966,29 @@ impl TimeSeries {
         size_of::<Self>() + self.get_heap_size()
     }
 
+    /// The number of heap allocations dropping this series will release.
+    ///
+    /// This is the `free_effort` the server compares against its `LAZYFREE_THRESHOLD` (64) to
+    /// decide between freeing the value inline and handing it to a background thread. Leaving
+    /// the callback unregistered means the server assumes 1, so a series of any size was always
+    /// freed synchronously on the main thread -- `UNLINK` and every `lazyfree-lazy-*` setting
+    /// were inert for this type. The same figure also decides whether active defrag handles the
+    /// value inline or defers it to the incremental `defragLater` queue.
+    ///
+    /// Counting allocations, not bytes, is what the server's own estimators do (a quicklist
+    /// reports its node count, a stream its macro nodes): the cost being modelled is the number
+    /// of `free` calls, not the volume.
+    pub fn free_effort(&self) -> usize {
+        // The chunk vector, plus one buffer per chunk -- a bit stream for the compressed
+        // encodings, a sample vector for the uncompressed one.
+        let chunks = 1 + self.chunks.len();
+        // The label vector, plus one interned string per label. Shared pairs survive the drop,
+        // so this is an upper bound; labels are a rounding error next to chunks either way.
+        let labels = 1 + self.labels.len();
+        let rules = 1 + self.rules.len();
+        chunks + labels + rules
+    }
+
     /// Returns the minimum timestamp of the time series, considering the retention period.
     pub(crate) fn get_min_timestamp(&self) -> Timestamp {
         if self.retention.is_zero() {

--- a/src/series/time_series.rs
+++ b/src/series/time_series.rs
@@ -1001,7 +1001,12 @@ impl TimeSeries {
 
         let right = &self.chunks[start_idx..];
         let (idx, _found) = find_last_ge_index(right, end);
-        let end_idx = start_idx + idx;
+        // Clamped because every caller slices `chunks[start_idx..=end_idx]`. Past
+        // `LINEAR_SCAN_MAX` chunks `find_last_ge_index` binary-searches, and a binary search
+        // for a timestamp beyond the last chunk returns the insertion point - one past the
+        // end - where the linear scan it replaces returns the last chunk. `TS.RANGE ... +`
+        // over a series with more than 16 chunks is exactly that query.
+        let end_idx = (start_idx + idx).min(len - 1);
 
         // imagine this scenario:
         // chunk start timestamps = [10, 20, 30, 40]

--- a/src/series/time_series.rs
+++ b/src/series/time_series.rs
@@ -34,6 +34,27 @@ use valkey_module::{ValkeyError, ValkeyResult};
 pub type TimeseriesId = u64;
 pub type SeriesRef = u64;
 
+/// Hand a sealed chunk's unused buffer back to the allocator.
+///
+/// A compressed chunk's bit stream is a `Vec` grown by doubling, so a chunk that has just
+/// reached `chunk_size_bytes` holds up to twice that in allocation. Measured over a 20,000
+/// sample series at `CHUNK_SIZE 4096`: 208,069 bytes of `MEMORY USAGE` against 109,537 bytes of
+/// encoded data, a 1.90x overhang that lives as long as the series does. On an append-only
+/// workload that is every chunk but the last.
+///
+/// Only call this where a chunk provably stops being the append target -- it is the definition
+/// of "sealed" here, not a general-purpose compaction. It costs nothing on the other side:
+/// `upsert_sample` and the out-of-order path of `merge_samples` discard the buffer and re-encode
+/// into a fresh one regardless, so a later back-fill into a sealed chunk neither benefits from
+/// nor pays for the shrink. An in-order `merge_samples` into a sealed chunk does append in place
+/// and will regrow, but from a smaller base and still by doubling, so the cost stays amortized
+/// O(1) per byte.
+pub(crate) fn seal_chunk(chunk: &mut TimeSeriesChunk) {
+    if let Err(e) = chunk.optimize() {
+        logging::log_warning(format!("TSDB: Error compacting a sealed chunk: {e:?}"));
+    }
+}
+
 /// Represents a time series consisting of chunks of samples, each with a timestamp and value.
 #[derive(Clone, Debug, Hash, PartialEq, GetSize)]
 pub struct TimeSeries {
@@ -312,6 +333,11 @@ impl TimeSeries {
 
     /// (Possibly) add a new chunk and append the given sample.
     fn add_chunk_with_sample(&mut self, sample: Sample) -> TsdbResult<()> {
+        // Reached only when the tail chunk is full, so the chunk we are leaving behind will
+        // never be the append target again: seal it before the new one takes over.
+        if let Some(sealed) = self.chunks.last_mut() {
+            seal_chunk(sealed);
+        }
         let mut chunk = self.create_chunk();
         chunk.add_sample(&sample)?;
         self.chunks.push(chunk);
@@ -469,7 +495,11 @@ impl TimeSeries {
                 .par_mut()
                 .filter(|c| c.is_full())
                 .flat_map(|chunks| {
-                    if let Ok(split_chunk) = chunks.split() {
+                    if let Ok(mut split_chunk) = chunks.split() {
+                        // `split` re-encodes both halves from scratch, so both arrive with a
+                        // doubling-grown buffer around half a chunk of data.
+                        seal_chunk(chunks);
+                        seal_chunk(&mut split_chunk);
                         Some(split_chunk)
                     } else {
                         errored.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -480,7 +510,9 @@ impl TimeSeries {
         } else {
             let mut new_chunks = Vec::with_capacity(std::cmp::max(2, self.chunks.len() / 6));
             for c in self.chunks.iter_mut().filter(|c| c.is_full()) {
-                if let Ok(split_chunk) = c.split() {
+                if let Ok(mut split_chunk) = c.split() {
+                    seal_chunk(c);
+                    seal_chunk(&mut split_chunk);
                     new_chunks.push(split_chunk);
                 } else {
                     errored.store(true, std::sync::atomic::Ordering::Relaxed);

--- a/src/series/time_series_tests.rs
+++ b/src/series/time_series_tests.rs
@@ -1826,4 +1826,112 @@ mod tests {
         let result = ts.increment_sample_value(Some(100), 50.0);
         assert!(result.is_ok());
     }
+
+    /// Every chunk but the tail must be holding a tight buffer.
+    ///
+    /// A compressed chunk's bit stream grows by doubling, so a chunk that has just filled to
+    /// `chunk_size_bytes` is sitting on up to twice that in allocation -- measured at 1.90x over
+    /// a 20,000-sample series before `seal_chunk` was wired into the append path. The tail is
+    /// deliberately left alone: it is still the append target.
+    #[test]
+    fn test_sealed_chunks_do_not_hold_spare_capacity() {
+        for encoding in [
+            ChunkEncoding::Gorilla,
+            ChunkEncoding::Chimp,
+            ChunkEncoding::Uncompressed,
+        ] {
+            let mut series = TimeSeries::with_options(TimeSeriesOptions {
+                chunk_size: Some(1024),
+                chunk_encoding: encoding,
+                ..Default::default()
+            })
+            .unwrap();
+
+            for i in 0..20_000i64 {
+                series.add(1_600_000_000_000 + i * 1000, i as f64 * 1.37, None);
+            }
+            assert!(
+                series.chunks.len() > 4,
+                "{encoding:?}: only {} chunks, the seal path is barely exercised",
+                series.chunks.len()
+            );
+
+            let sealed = &series.chunks[..series.chunks.len() - 1];
+            for (i, chunk) in sealed.iter().enumerate() {
+                let payload = chunk.size();
+                let allocated = chunk.memory_usage() - size_of::<TimeSeriesChunk>();
+                assert!(
+                    allocated <= payload + payload / 8,
+                    "{encoding:?}: sealed chunk {i} holds {allocated} bytes of allocation for \
+                     {payload} bytes of data",
+                );
+            }
+        }
+    }
+
+    /// Sealing must not lose, reorder or corrupt anything it compacts.
+    #[test]
+    fn test_sealing_preserves_every_sample() {
+        for encoding in [ChunkEncoding::Gorilla, ChunkEncoding::Chimp] {
+            let mut series = TimeSeries::with_options(TimeSeriesOptions {
+                chunk_size: Some(1024),
+                chunk_encoding: encoding,
+                ..Default::default()
+            })
+            .unwrap();
+
+            let expected: Vec<Sample> = (0..20_000i64)
+                .map(|i| Sample {
+                    timestamp: 1_600_000_000_000 + i * 1000,
+                    value: i as f64 * 1.37,
+                })
+                .collect();
+            for sample in expected.iter() {
+                series.add(sample.timestamp, sample.value, None);
+            }
+
+            assert_eq!(series.total_samples, expected.len());
+            let actual: Vec<Sample> = series.chunks.iter().flat_map(|c| c.iter()).collect();
+            assert_eq!(
+                actual, expected,
+                "{encoding:?}: sealing altered the samples"
+            );
+        }
+    }
+
+    /// A sealed chunk still accepts a back-fill -- the shrink must not make it look full or
+    /// immutable.
+    #[test]
+    fn test_a_sealed_chunk_still_accepts_a_backfill() {
+        let mut series = TimeSeries::with_options(TimeSeriesOptions {
+            chunk_size: Some(1024),
+            chunk_encoding: ChunkEncoding::Gorilla,
+            ..Default::default()
+        })
+        .unwrap();
+
+        for i in 0..20_000i64 {
+            series.add(1_600_000_000_000 + i * 1000, i as f64, None);
+        }
+        let before = series.total_samples;
+
+        // Land between two existing samples in the first, long-sealed chunk.
+        let backfilled = Sample {
+            timestamp: 1_600_000_000_500,
+            value: -1.0,
+        };
+        assert!(
+            series
+                .add(backfilled.timestamp, backfilled.value, None)
+                .is_ok()
+        );
+
+        assert_eq!(series.total_samples, before + 1);
+        assert_eq!(
+            series.chunks[0]
+                .iter()
+                .find(|s| s.timestamp == backfilled.timestamp),
+            Some(backfilled),
+        );
+    }
 }

--- a/src/series/time_series_tests.rs
+++ b/src/series/time_series_tests.rs
@@ -1934,4 +1934,82 @@ mod tests {
             Some(backfilled),
         );
     }
+
+    /// The server's own `LAZYFREE_THRESHOLD`. Anything at or below this is freed inline; above
+    /// it, the value is handed to a background thread (`lazyfree.c`).
+    const LAZYFREE_THRESHOLD: usize = 64;
+
+    /// A series big enough to be worth a thread hop must report enough effort to get one.
+    ///
+    /// The callback used to be unregistered, which the server reads as an effort of 1 -- so a
+    /// multi-million-sample series was always freed on the main thread and `UNLINK` and the
+    /// `lazyfree-lazy-*` settings did nothing for this type.
+    #[test]
+    fn test_free_effort_crosses_the_lazyfree_threshold_for_a_large_series() {
+        let mut series = TimeSeries::with_options(TimeSeriesOptions {
+            chunk_size: Some(1024),
+            ..Default::default()
+        })
+        .unwrap();
+        for i in 0..200_000i64 {
+            series.add(1_600_000_000_000 + i * 1000, i as f64 * 1.37, None);
+        }
+
+        assert!(
+            series.chunks.len() > LAZYFREE_THRESHOLD,
+            "series only has {} chunks; the threshold is not being exercised",
+            series.chunks.len()
+        );
+        assert!(
+            series.free_effort() > LAZYFREE_THRESHOLD,
+            "a {}-chunk series reports an effort of {}, at or below the threshold of \
+             {LAZYFREE_THRESHOLD}: it would still be freed on the main thread",
+            series.chunks.len(),
+            series.free_effort(),
+        );
+    }
+
+    /// The converse: a small series must stay inline. Handing every value to the bio thread is
+    /// slower than freeing a couple of allocations here, which is the whole reason the server
+    /// has a threshold rather than always deferring.
+    #[test]
+    fn test_free_effort_keeps_a_small_series_inline() {
+        let mut series = create_test_series();
+        for i in 0..10i64 {
+            series.add(1_600_000_000_000 + i * 1000, i as f64, None);
+        }
+        assert!(
+            series.free_effort() <= LAZYFREE_THRESHOLD,
+            "a 10-sample series reports an effort of {}",
+            series.free_effort()
+        );
+    }
+
+    /// Effort tracks the allocation count, so it has to grow with the chunks.
+    #[test]
+    fn test_free_effort_grows_with_the_series() {
+        let build = |samples: i64| {
+            let mut series = TimeSeries::with_options(TimeSeriesOptions {
+                chunk_size: Some(1024),
+                ..Default::default()
+            })
+            .unwrap();
+            for i in 0..samples {
+                series.add(1_600_000_000_000 + i * 1000, i as f64 * 1.37, None);
+            }
+            series
+        };
+
+        let small = build(5_000);
+        let large = build(100_000);
+        assert!(large.chunks.len() > small.chunks.len());
+        assert!(
+            large.free_effort() > small.free_effort(),
+            "{} chunks reports {} effort, {} chunks reports {}",
+            large.chunks.len(),
+            large.free_effort(),
+            small.chunks.len(),
+            small.free_effort(),
+        );
+    }
 }

--- a/src/series/utils.rs
+++ b/src/series/utils.rs
@@ -1,5 +1,5 @@
 use crate::common::constants::METRIC_NAME_LABEL;
-use crate::common::context::get_current_db;
+use crate::common::context::{create_key_string, get_current_db};
 use crate::error_consts;
 use crate::labels::{InternedLabel, Label};
 use crate::series::acl::check_key_permissions;
@@ -222,7 +222,7 @@ fn add_default_compactions(
         let duration_str = bucket_duration.to_string();
         labels.push(Label::new("time_bucket", &duration_str));
 
-        let child_key = ctx.create_string(dest_key);
+        let child_key = create_key_string(ctx, dest_key.as_bytes());
         let options = TimeSeriesOptions {
             src_id: Some(series.id),
             retention: Some(Duration::from_millis(retention)),

--- a/src/tests/chunk_utils.rs
+++ b/src/tests/chunk_utils.rs
@@ -76,20 +76,15 @@ pub fn filled_prefix_len(data: &[Sample], encoding: ChunkEncoding, chunk_size: u
 
 /// The number of bytes a chunk has actually written, for compression reporting.
 ///
-/// [`ChunkOps::size`] is not comparable across encodings: gorilla
-/// and chimp return a `get_size()` heap footprint, which counts buffer *capacity*
-/// and therefore jumps to the next power of two as the buffer grows, while
-/// uncompressed returns the bytes in use. A ratio built on `size()` compares
-/// allocator slack rather than compression — at a 64 KiB budget gorilla reports
-/// ~128 KiB of footprint against uncompressed's exact ~64 KiB.
+/// This existed to work around [`ChunkOps::size`] not being comparable across encodings: gorilla
+/// and chimp used to return a `get_size()` heap footprint, counting the bit stream's *capacity*
+/// and so jumping to the next power of two as it grew, while uncompressed returned the bytes in
+/// use. A ratio built on that compared allocator slack rather than compression — at a 64 KiB
+/// budget gorilla reported ~128 KiB against uncompressed's exact ~64 KiB.
 ///
-/// This returns the used-byte count for every encoding, matching what each
-/// implementation's `is_full()` measures.
+/// `size()` now reports used bytes for every encoding, so this is a thin alias kept for the
+/// reporting tools that name it. Its assertion in `test_chunk_size_reports_encoded_bytes` is what
+/// keeps the two definitions from drifting apart again.
 pub fn encoded_size(chunk: &TimeSeriesChunk) -> usize {
-    match chunk {
-        // `samples.len() * size_of::<Sample>()` — already exact.
-        TimeSeriesChunk::Uncompressed(c) => c.size(),
-        TimeSeriesChunk::Gorilla(c) => c.encoder.buf().len(),
-        TimeSeriesChunk::Chimp(c) => c.encoder.bytes().len(),
-    }
+    chunk.size()
 }

--- a/tests/test_binary_key_names.py
+++ b/tests/test_binary_key_names.py
@@ -10,21 +10,31 @@ is the binary-safe replacement; these tests keep every path that handles keyspac
 
 The same defect is what made a corrupt RDB crash the server rather than fail the load, since a
 mutated byte can land in a key name -- see test_rdb_corrupt_load.py.
+
+`TestNonUtf8KeyNames` covers the other half of binary safety: not crashing is not enough, the
+name in the reply has to be the name the client used. `TS.MGET`/`TS.MRANGE`/`TS.MREVRANGE` used
+to carry the key through a proto3 `string` field and a `to_string_lossy()`, so any non-UTF-8
+byte came back as U+FFFD and the client could not use the returned name to address the series.
 """
 
 import pytest
+import valkey
 from valkeytestframework.conftest import resource_port_tracker
 from valkeytestframework.util.waiters import wait_for_equal
 
 from valkey_timeseries_test_case import ValkeyTimeSeriesTestCaseBase
 
-# An interior NUL is the byte that used to abort the server. The names stay otherwise-valid UTF-8
-# on purpose: `TS.MGET`/`TS.MRANGE`/`TS.MREVRANGE` echo the key name back through a lossy UTF-8
-# conversion, so a byte like \xff comes back as U+FFFD. That is a separate reply-encoding defect,
-# not this one, and mixing the two here would make these tests fail for the wrong reason.
+# An interior NUL is the byte that used to abort the server. These names stay otherwise-valid
+# UTF-8 so a failure here points at the crash defect alone; `TestNonUtf8KeyNames` below adds the
+# bytes that no UTF-8 conversion survives.
 NUL_KEY = b"bin\x00key"
 NUL_KEY_2 = b"bin\x00key2"
 NUL_COPY = b"bin\x00copy"
+
+# Not valid UTF-8 in any position, so a name that survives round-trip proves the bytes were never
+# routed through a `String`.
+RAW_KEY = b"raw\x00k\xff\xfe"
+RAW_KEY_2 = b"raw\x00k2\xfd"
 
 CRASH_MARKERS = ("Guru Meditation", "panicked at", "STACK TRACE", "VALKEY BUG REPORT")
 
@@ -96,3 +106,60 @@ class TestBinaryKeyNames(ValkeyTimeSeriesTestCaseBase):
         assert client.execute_command("TS.QUERYINDEX", "host=bin") == [NUL_KEY]
         assert client.execute_command("TS.GET", NUL_KEY) == [5000, b"5"]
         self._assert_no_crash()
+
+
+class TestNonUtf8KeyNames(ValkeyTimeSeriesTestCaseBase):
+    """The multi-series replies must echo the key name byte for byte."""
+
+    def _resp3_client(self):
+        """A RESP3 (HELLO 3) client against the same server as self.client."""
+        return valkey.Valkey(host=self.server.bind_ip, port=self.server.port, protocol=3)
+
+    def _seed(self, client):
+        for key, value in ((RAW_KEY, 1.0), (RAW_KEY_2, 2.0)):
+            client.execute_command("TS.CREATE", key, "LABELS", "host", "raw", "grp", "g1")
+            client.execute_command("TS.ADD", key, 1000, value)
+
+    def test_mget_and_mrange_echo_the_key_verbatim(self):
+        client = self.server.get_new_client()
+        self._seed(client)
+
+        # KEYS is the reference: whatever the server itself reports is what these must match.
+        expected = sorted([RAW_KEY, RAW_KEY_2])
+        assert sorted(client.execute_command("KEYS", "*")) == expected
+        assert sorted(client.execute_command("TS.QUERYINDEX", "host=raw")) == expected
+
+        for cmd in (
+            ("TS.MGET", "FILTER", "host=raw"),
+            ("TS.MRANGE", "-", "+", "FILTER", "host=raw"),
+            ("TS.MREVRANGE", "-", "+", "FILTER", "host=raw"),
+        ):
+            got = sorted(row[0] for row in client.execute_command(*cmd))
+            assert got == expected, f"{cmd[0]} mangled the key name: {got}"
+
+    def test_resp3_replies_echo_the_key_verbatim(self):
+        """RESP3 keys the map by series name, so a mangled name also collides across series."""
+        client = self._resp3_client()
+        self._seed(client)
+        expected = sorted([RAW_KEY, RAW_KEY_2])
+
+        for cmd in (
+            ("TS.MGET", "FILTER", "host=raw"),
+            ("TS.MRANGE", "-", "+", "FILTER", "host=raw"),
+            ("TS.MREVRANGE", "-", "+", "FILTER", "host=raw"),
+        ):
+            got = sorted(client.execute_command(*cmd).keys())
+            assert got == expected, f"{cmd[0]} mangled the key name: {got}"
+
+    def test_groupby_sources_echo_the_key_verbatim(self):
+        """The RESP3 `sources` metadata lists the group's member keys."""
+        client = self._resp3_client()
+        self._seed(client)
+
+        reply = client.execute_command(
+            "TS.MRANGE", "-", "+", "FILTER", "host=raw", "GROUPBY", "grp", "REDUCE", "sum"
+        )
+        group = reply[b"grp=g1"]
+        sources = next(v for entry in group if isinstance(entry, dict)
+                       for k, v in entry.items() if k == b"sources")
+        assert sorted(sources) == sorted([RAW_KEY, RAW_KEY_2])

--- a/tests/test_binary_key_names.py
+++ b/tests/test_binary_key_names.py
@@ -1,0 +1,98 @@
+"""Regression tests for key names that are not valid C strings.
+
+Valkey key names are binary-safe: `TS.CREATE "a\\x00b"` is a legal key, and those same bytes come
+back out of the postings index, an RDB reload, a `RENAME`, a `COPY`, and a `MOVE`. The module used
+to funnel every one of those conversions through `Context::create_string`, which is
+`CString::new(..).unwrap()` underneath and panics on an interior NUL. Most of the affected call
+sites run inside a keyspace-notification or data-type callback -- `extern "C"`, so the panic could
+not unwind and became an `abort` that took the whole server down. `common::context::create_key_string`
+is the binary-safe replacement; these tests keep every path that handles keyspace-derived bytes on it.
+
+The same defect is what made a corrupt RDB crash the server rather than fail the load, since a
+mutated byte can land in a key name -- see test_rdb_corrupt_load.py.
+"""
+
+import pytest
+from valkeytestframework.conftest import resource_port_tracker
+from valkeytestframework.util.waiters import wait_for_equal
+
+from valkey_timeseries_test_case import ValkeyTimeSeriesTestCaseBase
+
+# An interior NUL is the byte that used to abort the server. The names stay otherwise-valid UTF-8
+# on purpose: `TS.MGET`/`TS.MRANGE`/`TS.MREVRANGE` echo the key name back through a lossy UTF-8
+# conversion, so a byte like \xff comes back as U+FFFD. That is a separate reply-encoding defect,
+# not this one, and mixing the two here would make these tests fail for the wrong reason.
+NUL_KEY = b"bin\x00key"
+NUL_KEY_2 = b"bin\x00key2"
+NUL_COPY = b"bin\x00copy"
+
+CRASH_MARKERS = ("Guru Meditation", "panicked at", "STACK TRACE", "VALKEY BUG REPORT")
+
+
+class TestBinaryKeyNames(ValkeyTimeSeriesTestCaseBase):
+
+    def _assert_no_crash(self):
+        assert self.server.is_alive(), "server died handling a binary key name"
+        for marker in CRASH_MARKERS:
+            assert not self.server.verify_string_in_logfile(marker), \
+                f'binary key name produced "{marker}" in the log'
+
+    def _seed(self, client, key=NUL_KEY):
+        client.execute_command("TS.CREATE", key, "LABELS", "host", "bin")
+        for i in range(1, 6):
+            client.execute_command("TS.ADD", key, 1000 * i, float(i))
+
+    def test_commands_accept_a_nul_in_the_key_name(self):
+        """The read paths resolve ids back to key names through the postings index."""
+        client = self.server.get_new_client()
+        self._seed(client)
+
+        assert client.execute_command("TS.GET", NUL_KEY) == [5000, b"5"]
+        assert client.execute_command("TS.QUERYINDEX", "host=bin") == [NUL_KEY]
+        assert client.execute_command("TS.CARD", "FILTER", "host=bin") == 1
+        assert client.execute_command("TS.MGET", "FILTER", "host=bin")[0][0] == NUL_KEY
+        assert client.execute_command(
+            "TS.MRANGE", "-", "+", "FILTER", "host=bin")[0][0] == NUL_KEY
+        self._assert_no_crash()
+
+    def test_keyspace_events_accept_a_nul_in_the_key_name(self):
+        """RENAME/COPY/MOVE maintain the index from keyspace notifications."""
+        client = self.server.get_new_client()
+        self._seed(client)
+
+        assert client.rename(NUL_KEY, NUL_KEY_2)
+        assert client.execute_command("TS.QUERYINDEX", "host=bin") == [NUL_KEY_2]
+        assert client.rename(NUL_KEY_2, NUL_KEY)
+
+        assert client.execute_command("COPY", NUL_KEY, NUL_COPY)
+        assert sorted(client.execute_command("TS.QUERYINDEX", "host=bin")) == \
+            sorted([NUL_KEY, NUL_COPY])
+        assert client.execute_command("TS.GET", NUL_COPY) == [5000, b"5"]
+
+        assert client.execute_command("MOVE", NUL_COPY, 1)
+        assert client.execute_command("TS.QUERYINDEX", "host=bin") == [NUL_KEY]
+        self._assert_no_crash()
+
+    def test_mdel_accepts_a_nul_in_the_key_name(self):
+        client = self.server.get_new_client()
+        self._seed(client)
+
+        assert client.execute_command("TS.MDEL", "FILTER", "host=bin") == 1
+        assert client.execute_command("TS.QUERYINDEX", "host=bin") == []
+        self._assert_no_crash()
+
+    def test_reload_accepts_a_nul_in_the_key_name(self):
+        """The `loaded` notification -- the path a corrupt RDB used to abort the server on."""
+        client = self.server.get_new_client()
+        self._seed(client)
+
+        client.bgsave()
+        self.server.wait_for_save_done()
+        self.server.restart(remove_rdb=False, remove_nodes_conf=False, connect_client=True)
+        assert self.server.is_alive()
+        wait_for_equal(lambda: self.server.is_rdb_done_loading(), True)
+
+        client = self.server.get_new_client()
+        assert client.execute_command("TS.QUERYINDEX", "host=bin") == [NUL_KEY]
+        assert client.execute_command("TS.GET", NUL_KEY) == [5000, b"5"]
+        self._assert_no_crash()

--- a/tests/test_rdb_corrupt_load.py
+++ b/tests/test_rdb_corrupt_load.py
@@ -1,0 +1,187 @@
+"""Regression tests for a corrupt or truncated RDB. It must fail the load, not crash the server.
+
+The module's RDB bounds checks (`rdb_load_len` / `MAX_RDB_COLLECTION_LEN`, the foreign-encver
+guard, and the uncompressed-chunk sample-capacity cap) all sit behind reads that, without the
+`HANDLE_IO_ERRORS` module option, reach `serverPanic` the moment the stream underruns -- so for a
+truncated payload those checks were unreachable and a corrupt RDB aborted the server during load.
+
+The pre-existing unit coverage for the capacity cap exercises `deserialize_raw` over an in-memory
+buffer, which returns `Err` whether or not the option is declared, so it passes even when the real
+RDB path aborts. These tests drive actual RDB files through actual server startup instead.
+
+A clean outcome is the module either loading the payload or rejecting it with a logged error.
+The failure being guarded against is a module panic: a Guru Meditation / bug report / stack trace.
+
+These tests deliberately assert on the module's verdict *in the log* rather than on the server
+process exiting. On any RDB read error for a file on disk, the server re-parses it through
+`redis_check_rdb_main` to produce a diagnostic, and `rdbLoadCheckModuleValue` (rdb.c) loops
+    while ((opcode = rdbLoadLen(rdb, NULL)) != RDB_MODULE_OPCODE_EOF)
+where a short read makes `rdbLoadLen` return `RDB_LENERR` (UINT64_MAX), never
+`RDB_MODULE_OPCODE_EOF` (0) -- so for some truncation offsets the server spins forever in its
+own check code, after the module has already reported the error correctly. That is a
+valkey-server defect, not a module one, and waiting on process exit would make this suite hang
+on it.
+"""
+
+import os
+import random
+import shutil
+import subprocess
+import time
+
+import pytest
+from valkeytestframework.conftest import resource_port_tracker
+from valkey_timeseries_test_case import ValkeyTimeSeriesTestCaseBase
+from common import VALKEY_SERVER_PATH
+
+# Markers the server emits when it dies on an unhandled module fault, rather than
+# reporting a load failure and exiting cleanly.
+# The module's own rejection line, from `rdb_load` in src/series/series_data_type.rs.
+MODULE_REJECTED = 'Failed to load series from RDB'
+SERVER_READY = 'Ready to accept connections'
+
+CRASH_MARKERS = (
+    'Guru Meditation',
+    'STACK TRACE',
+    'VALKEY BUG REPORT',
+    'Unrecoverable error reading from module datatype',
+    'panicked at',
+    'crashed by signal',
+)
+
+
+class TestRdbCorruptLoad(ValkeyTimeSeriesTestCaseBase):
+
+    def _module_path(self):
+        return self.server.args.get('loadmodule') or os.path.abspath(
+            os.environ['MODULE_PATH']
+        )
+
+    def _good_rdb(self):
+        """Populate a series and return the bytes of a valid RDB containing it."""
+        client = self.client
+        client.execute_command('TS.CREATE', 'rdb_s1', 'LABELS', 'host', 'a', 'region', 'b')
+        for i in range(1, 201):
+            client.execute_command('TS.ADD', 'rdb_s1', 1000 + i * 1000, i)
+        client.execute_command('TS.CREATE', 'rdb_s2', 'LABELS', 'host', 'c')
+        client.execute_command('TS.ADD', 'rdb_s2', 5000, 1.5)
+        client.execute_command('SAVE')
+
+        cfg = client.config_get('dir')['dir'], client.config_get('dbfilename')['dbfilename']
+        path = os.path.join(*cfg)
+        data = open(path, 'rb').read()
+        assert len(data) > 100, f'unexpectedly small RDB at {path}'
+        return data
+
+    def _load_attempt(self, tmpdir, rdb_bytes, port):
+        """Start a server against `rdb_bytes`. Returns (outcome, log text)."""
+        # The server chdir()s to `--dir` while parsing its config, so --logfile and
+        # --dir must both be absolute or it cannot even open its log.
+        tmpdir = os.path.abspath(tmpdir)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+        os.makedirs(tmpdir)
+        open(os.path.join(tmpdir, 'test.rdb'), 'wb').write(rdb_bytes)
+        log = os.path.join(tmpdir, 'srv.log')
+
+        def read_log():
+            # The server echoes fragments of the corrupt payload, so the log is not
+            # guaranteed to be valid UTF-8.
+            if not os.path.exists(log):
+                return ''
+            with open(log, 'rb') as fh:
+                return fh.read().decode('utf-8', 'replace')
+
+        # Child output goes to a file, never a pipe: the RDB check prints enough on a
+        # corrupt file to fill a pipe buffer and block the server forever.
+        console = os.path.join(tmpdir, 'console.out')
+        with open(console, 'wb') as out:
+            proc = subprocess.Popen(
+                [VALKEY_SERVER_PATH, '--port', str(port), '--daemonize', 'no',
+                 '--loadmodule', self._module_path(), '--logfile', log,
+                 '--dir', tmpdir, '--dbfilename', 'test.rdb', '--save', ''],
+                stdout=out, stderr=subprocess.STDOUT,
+            )
+        outcome, deadline = None, time.time() + 20
+        try:
+            while time.time() < deadline:
+                text = read_log()
+                if any(m in text for m in CRASH_MARKERS):
+                    outcome = 'CRASH'
+                    break
+                if MODULE_REJECTED in text:
+                    outcome = 'MODULE_REJECTED'
+                    break
+                if SERVER_READY in text:
+                    outcome = 'LOADED'
+                    break
+                if proc.poll() is not None:
+                    # Server rejected the file before the module was ever asked.
+                    outcome = 'SERVER_REJECTED'
+                    break
+                time.sleep(0.05)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+            proc.wait()
+
+        text = read_log()
+        if not text:
+            # The server failed before opening its log (e.g. a bad config path).
+            with open(console, 'rb') as fh:
+                text = fh.read().decode('utf-8', 'replace')
+        # An exit is only clean if it left no crash marker behind.
+        if any(m in text for m in CRASH_MARKERS):
+            outcome = 'CRASH'
+        return outcome or 'UPSTREAM_HANG', text
+
+    def _marker(self, text):
+        return next((l.strip() for l in text.splitlines()
+                     if any(m in l for m in CRASH_MARKERS)), '(no marker)')
+
+    def test_truncated_rdb_fails_cleanly(self):
+        good = self._good_rdb()
+        port = self.get_bind_port()
+        tmpdir = os.path.join(self.testdir, 'rdb_trunc')
+
+        # Sample the whole file rather than every byte: the interesting region is the
+        # module payload, but the sweep is kept cheap enough for CI.
+        cuts = list(range(1, len(good), max(1, len(good) // 60)))
+        outcomes = {}
+        for cut in cuts:
+            outcome, text = self._load_attempt(tmpdir, good[:cut], port)
+            assert outcome != 'CRASH', \
+                f'truncation at {cut}/{len(good)} bytes panicked the module: {self._marker(text)}'
+            outcomes[outcome] = outcomes.get(outcome, 0) + 1
+
+        # The module must actually have been exercised, or this proves nothing.
+        assert outcomes.get('MODULE_REJECTED', 0) > 0, \
+            f'no truncation reached the module loader; outcomes={outcomes}'
+
+    def test_corrupt_rdb_fails_cleanly(self):
+        good = self._good_rdb()
+        port = self.get_bind_port()
+        tmpdir = os.path.join(self.testdir, 'rdb_corrupt')
+        rng = random.Random(11)
+        outcomes = {}
+
+        for trial in range(40):
+            b = bytearray(good)
+            for _ in range(rng.randint(1, 10)):
+                b[rng.randrange(len(b))] = rng.randrange(256)
+            outcome, text = self._load_attempt(tmpdir, bytes(b), port)
+            assert outcome != 'CRASH', \
+                f'corrupt RDB (trial {trial}) panicked the module: {self._marker(text)}'
+            outcomes[outcome] = outcomes.get(outcome, 0) + 1
+
+        assert outcomes.get('MODULE_REJECTED', 0) > 0, \
+            f'no corrupt payload reached the module loader; outcomes={outcomes}'
+
+    def test_unmodified_rdb_still_loads(self):
+        """Guards the two sweeps above: if the baseline stopped loading they would pass vacuously."""
+        good = self._good_rdb()
+        port = self.get_bind_port()
+        tmpdir = os.path.join(self.testdir, 'rdb_baseline')
+        outcome, text = self._load_attempt(tmpdir, good, port)
+        assert outcome == 'LOADED', (
+            f'valid RDB must load; got {outcome}\n'
+            f'module={self._module_path()}\nLOG:\n{text[-3000:]}')

--- a/tests/test_ts_flush_index.py
+++ b/tests/test_ts_flush_index.py
@@ -1,0 +1,95 @@
+# tests/test_ts_flush_index.py
+"""The secondary index must not outlive the keyspace it describes.
+
+The module subscribes to FLUSHDB directly (it needs `RedisModuleFlushInfo::dbnum`, which the
+`#[flush_event_handler]` surface does not carry). Two things went wrong with that:
+
+  * the `dbnum == -1` case -- FLUSHALL, and the implicit flush a replica performs on a full
+    resync -- dropped only the delayed-keys map, never the indexes themselves; and
+  * that raw subscription silently displaced valkey-module's own flush dispatcher, so
+    `IS_FLUSHING` was never set and the per-key `free`/`unlink` callbacks retired each series
+    from the index one at a time.
+
+The second bug masked the first: the per-key path happened to leave the index correct after a
+FLUSHALL, at O(series) cost. Restoring the dispatcher without closing the `dbnum == -1` gap
+leaves the entire index dangling, every id naming a key that no longer exists -- which is what
+these tests pin.
+"""
+import pytest
+from valkeytestframework.conftest import resource_port_tracker
+from valkey_timeseries_test_case import ValkeyTimeSeriesTestCaseBase
+
+FILTER = "name=flushprobe"
+
+
+class TestFlushIndexConsistency(ValkeyTimeSeriesTestCaseBase):
+    def _seed(self, client, key: str):
+        client.execute_command("TS.CREATE", key, "LABELS", "name", "flushprobe")
+        client.execute_command("TS.ADD", key, 1000, 1.0)
+
+    def _indexed(self, client) -> list:
+        return client.execute_command("TS.QUERYINDEX", FILTER)
+
+    def test_flushdb_clears_the_index(self):
+        client = self.server.get_new_client()
+        self._seed(client, "flush:a")
+        assert self._indexed(client) == [b"flush:a"]
+
+        client.execute_command("FLUSHDB")
+
+        assert self._indexed(client) == []
+        assert client.execute_command("DBSIZE") == 0
+
+    def test_flushall_clears_every_databases_index(self):
+        """The `dbnum == -1` case. With the per-key fast path live, this handler is the only
+        thing that retires the index, so a gap here strands every id in every database."""
+        client = self.server.get_new_client()
+        self._seed(client, "flush:db0")
+        client.execute_command("SELECT", 1)
+        self._seed(client, "flush:db1")
+
+        client.execute_command("SELECT", 0)
+        client.execute_command("FLUSHALL")
+
+        assert self._indexed(client) == [], "db 0 index survived FLUSHALL"
+        client.execute_command("SELECT", 1)
+        assert self._indexed(client) == [], "db 1 index survived FLUSHALL"
+
+    def test_flushdb_leaves_other_databases_alone(self):
+        """The converse guard: a single-database flush must not take the other indexes with it."""
+        client = self.server.get_new_client()
+        self._seed(client, "flush:db0")
+        client.execute_command("SELECT", 1)
+        self._seed(client, "flush:db1")
+
+        client.execute_command("FLUSHDB")  # db 1 only
+        assert self._indexed(client) == []
+
+        client.execute_command("SELECT", 0)
+        assert self._indexed(client) == [b"flush:db0"]
+
+    def test_index_is_usable_again_after_flushall(self):
+        """A stranded index is not just stale, it shadows the rebuilt one."""
+        client = self.server.get_new_client()
+        self._seed(client, "flush:before")
+        client.execute_command("FLUSHALL")
+
+        self._seed(client, "flush:after")
+        assert self._indexed(client) == [b"flush:after"]
+        assert client.execute_command("TS.MRANGE", "-", "+", "FILTER", FILTER) == [
+            [b"flush:after", [], [[1000, b"1"]]]
+        ]
+
+    def test_swapdb_swaps_the_indexes(self):
+        """SWAPDB is handled by the same raw-subscription mechanism; keep it honest."""
+        client = self.server.get_new_client()
+        self._seed(client, "flush:db0")
+        client.execute_command("SELECT", 1)
+        assert self._indexed(client) == []
+
+        client.execute_command("SELECT", 0)
+        client.execute_command("SWAPDB", 0, 1)
+
+        assert self._indexed(client) == []
+        client.execute_command("SELECT", 1)
+        assert self._indexed(client) == [b"flush:db0"]

--- a/tests/test_ts_index_lock_reentrancy.py
+++ b/tests/test_ts_index_lock_reentrancy.py
@@ -1,0 +1,133 @@
+# tests/test_ts_index_lock_reentrancy.py
+"""The postings `RwLock` must never be re-entered on the same thread (INDEX-1).
+
+`std::sync::RwLock` is not reentrant, so a thread that asks for the write lock while it still
+holds the read guard blocks forever. The index has two ways to reach that:
+
+  * a query holds the read guard and then records the dangling ids it found, which needs the
+    write lock; and
+  * a query holds the read guard and *opens a series key*. `RM_OpenKey` runs the server's
+    lazy-expiry check, and reaping an expired key calls back into this module's `unlink`
+    callback, which takes the write lock:
+
+        series_by_selectors                     [postings read lock held]
+          -> get_timeseries -> RM_OpenKey -> lookupKey -> expireIfNeeded
+            -> deleteExpiredKeyAndPropagate -> dbGenericDelete
+              -> unlink -> remove_series_from_index -> write_lock   [blocks forever]
+
+A deadlocked server does not answer, so every check here runs on a connection with a socket
+timeout: a regression shows up as a timeout, not as a hung test run.
+"""
+import os
+import signal
+import time
+
+import pytest
+from valkey import Valkey
+from valkey.exceptions import TimeoutError as ValkeyTimeoutError
+from valkeytestframework.conftest import resource_port_tracker
+from valkey_timeseries_test_case import ValkeyTimeSeriesTestCaseBase
+
+# Generous next to the microseconds these commands need, short enough that a regression is
+# reported quickly.
+DEADLOCK_TIMEOUT_SECS = 10
+
+KEY = "lockprobe:k1"
+
+# Every index reader reachable from the command surface that opens the series keys it matched.
+INDEX_READERS = [
+    ("TS.MRANGE", ["TS.MRANGE", "-", "+", "FILTER", "name=lockprobe"]),
+    ("TS.MREVRANGE", ["TS.MREVRANGE", "-", "+", "FILTER", "name=lockprobe"]),
+    ("TS.MGET", ["TS.MGET", "FILTER", "name=lockprobe"]),
+    ("TS.LABELNAMES", ["TS.LABELNAMES", "FILTER", "name=lockprobe"]),
+    ("TS.LABELVALUES", ["TS.LABELVALUES", "name", "FILTER", "name=lockprobe"]),
+    ("TS.QUERYINDEX", ["TS.QUERYINDEX", "name=lockprobe"]),
+    ("TS.MDEL", ["TS.MDEL", "FILTER", "name=lockprobe"]),
+    ("TS.CARD", ["TS.CARD", "FILTER", "name=lockprobe"]),
+]
+
+
+class TestIndexLockReentrancy(ValkeyTimeSeriesTestCaseBase):
+    def _timeout_client(self) -> Valkey:
+        return Valkey(
+            host=self.server.bind_ip,
+            port=self.server.port,
+            socket_timeout=DEADLOCK_TIMEOUT_SECS,
+        )
+
+    @staticmethod
+    def _kill_server(pid: int):
+        """Reap a deadlocked server so the fixture teardown does not block on its shutdown.
+
+        Only reached on failure. The pid is captured up front, before the command under test:
+        a wedged server cannot answer `INFO` either, so asking it for its own pid afterwards
+        would block just as hard as the command that hung.
+        """
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+
+    def _series_pending_expiry(self, client: Valkey):
+        """A series that is logically expired but still physically present.
+
+        Turning off active expiry pins the state a live server only passes through briefly --
+        and that a replica holds indefinitely, since it waits for the primary's DEL.
+        """
+        client.execute_command("DEBUG", "SET-ACTIVE-EXPIRE", 0)
+        client.execute_command("TS.CREATE", KEY, "LABELS", "name", "lockprobe")
+        client.execute_command("TS.ADD", KEY, 1000, 1.0)
+        client.execute_command("PEXPIRE", KEY, 1)
+        time.sleep(0.05)
+
+    def _run(self, client: Valkey, pid: int, label: str, command):
+        """Run `command`, turning a deadlock into a reported failure rather than a hung run."""
+        started = time.time()
+        try:
+            return client.execute_command(*command)
+        except ValkeyTimeoutError:
+            # `valkey.exceptions.TimeoutError` does not derive from the builtin one -- catching
+            # the builtin here would let the timeout escape, skipping the kill below and wedging
+            # the fixture teardown, which shuts the server down over a connection that has no
+            # timeout of its own.
+            self._kill_server(pid)
+            pytest.fail(
+                f"{label} did not return within {DEADLOCK_TIMEOUT_SECS}s over a series pending "
+                f"expiry: the postings read guard was still held when the lazy expire took the "
+                f"index write lock (waited {time.time() - started:.1f}s)"
+            )
+
+    @pytest.mark.parametrize("name,command", INDEX_READERS, ids=[c[0] for c in INDEX_READERS])
+    def test_expired_series_does_not_deadlock(self, name, command):
+        client = self._timeout_client()
+        pid = int(client.info("server")["process_id"])
+        self._series_pending_expiry(client)
+
+        self._run(client, pid, name, command)
+
+    def test_expired_series_still_reads_correctly(self):
+        """The deadlock fix must not resurrect an expired series."""
+        client = self._timeout_client()
+        pid = int(client.info("server")["process_id"])
+        self._series_pending_expiry(client)
+
+        assert (
+            self._run(
+                client, pid, "TS.MRANGE",
+                ["TS.MRANGE", "-", "+", "FILTER", "name=lockprobe"],
+            )
+            == []
+        )
+        assert client.execute_command("EXISTS", KEY) == 0
+
+    def test_live_series_reads_normally(self):
+        """Guard against the checks above passing because nothing matched in the first place."""
+        client = self._timeout_client()
+        pid = int(client.info("server")["process_id"])
+        client.execute_command("TS.CREATE", KEY, "LABELS", "name", "lockprobe")
+        client.execute_command("TS.ADD", KEY, 1000, 1.0)
+
+        assert self._run(
+            client, pid, "TS.MRANGE", ["TS.MRANGE", "-", "+", "FILTER", "name=lockprobe"]
+        ) == [[KEY.encode(), [], [[1000, b"1"]]]]
+        assert client.execute_command("TS.QUERYINDEX", "name=lockprobe") == [KEY.encode()]

--- a/tests/test_ts_lazyfree.py
+++ b/tests/test_ts_lazyfree.py
@@ -1,0 +1,195 @@
+# tests/test_ts_lazyfree.py
+"""A large series must be freed off the main thread (FREE-1).
+
+The module type registered no `free_effort` callback. The server reads that as an effort of 1,
+which is below its `LAZYFREE_THRESHOLD` of 64, so *every* series -- a multi-million-sample one
+included -- was freed synchronously on the main thread: `UNLINK` and the whole `lazyfree-lazy-*`
+family did nothing at all for this type.
+
+Registering the callback moves the `free` callback onto a bio thread for anything sizeable, which
+in turn matters for what `free` is allowed to do. It used to redo the index removal that `unlink`
+had already performed moments earlier on the main thread, logging a warning about the missing id
+every single time; that redundant write-lock acquisition would now happen from a background
+thread. `unlink` therefore records the retirement on the series and `free` only acts as a
+backstop -- so these tests also pin that every removal path still leaves the index clean.
+"""
+import time
+
+import pytest
+from valkeytestframework.conftest import resource_port_tracker
+from valkey_timeseries_test_case import ValkeyTimeSeriesTestCaseBase
+
+# `LAZYFREE_THRESHOLD` in the server's lazyfree.c. Effort must exceed it, not merely reach it.
+LAZYFREE_THRESHOLD = 64
+
+# The smallest legal chunk size, so a modest sample count still produces enough chunks to carry
+# the series over the threshold without writing millions of samples in a test.
+TINY_CHUNK = 48
+
+SPURIOUS_REMOVAL_WARNING = "Tried to remove non-existing series id"
+
+
+class TestLazyFree(ValkeyTimeSeriesTestCaseBase):
+    def _lazyfreed(self, client) -> int:
+        return int(client.info("memory")["lazyfreed_objects"])
+
+    def _drain(self, client, timeout=5.0):
+        """Wait for the bio thread to catch up, so counters are stable before we read them."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if int(client.info("memory")["lazyfree_pending_objects"]) == 0:
+                return
+            time.sleep(0.02)
+        raise AssertionError("lazyfree queue never drained")
+
+    def _many_chunk_series(self, client, key: str, samples: int = 400, over_threshold=True):
+        """A series in many small chunks, so its free effort clears the threshold cheaply.
+
+        `over_threshold=False` for the index tests, which only need a series to delete and would
+        otherwise pay for chunks they do not use.
+        """
+        client.execute_command(
+            "TS.CREATE", key, "CHUNK_SIZE", TINY_CHUNK, "ENCODING", "UNCOMPRESSED",
+            "LABELS", "name", "lazyprobe", "key", key,
+        )
+        pipe = client.pipeline(transaction=False)
+        for i in range(samples):
+            pipe.execute_command("TS.ADD", key, 1600000000000 + i * 1000, float(i))
+        pipe.execute()
+        if over_threshold:
+            chunks = self._chunk_count(client, key)
+            assert chunks > LAZYFREE_THRESHOLD, (
+                f"{key} only has {chunks} chunks; the threshold is not being exercised"
+            )
+
+    @staticmethod
+    def _chunk_count(client, key: str) -> int:
+        flat = client.execute_command("TS.INFO", key)
+        info = {flat[i]: flat[i + 1] for i in range(0, len(flat), 2)}
+        return info[b"chunkCount"]
+
+    def _indexed(self, client) -> list:
+        return sorted(client.execute_command("TS.QUERYINDEX", "name=lazyprobe"))
+
+    # ---- the headline behaviour ---------------------------------------------------
+
+    def test_unlinking_a_large_series_is_handed_to_the_lazyfree_thread(self):
+        client = self.server.get_new_client()
+        self._many_chunk_series(client, "lazy:big")
+        self._drain(client)
+        before = self._lazyfreed(client)
+
+        client.execute_command("UNLINK", "lazy:big")
+        self._drain(client)
+
+        assert self._lazyfreed(client) == before + 1, (
+            "the series was freed on the main thread: with no free_effort the server assumes an "
+            "effort of 1 and never defers"
+        )
+
+    def test_a_small_series_is_still_freed_inline(self):
+        """The converse guard. Deferring everything is slower than freeing two allocations
+        here, which is why the server has a threshold rather than always deferring."""
+        client = self.server.get_new_client()
+        client.execute_command("TS.CREATE", "lazy:small", "LABELS", "name", "lazyprobe")
+        client.execute_command("TS.ADD", "lazy:small", 1000, 1.0)
+        self._drain(client)
+        before = self._lazyfreed(client)
+
+        client.execute_command("UNLINK", "lazy:small")
+        self._drain(client)
+
+        assert self._lazyfreed(client) == before
+
+    def test_lazy_expiry_of_a_large_series_is_deferred(self):
+        """`lazyfree-lazy-expire` routes an expired key through the same effort check."""
+        client = self.server.get_new_client()
+        client.execute_command("CONFIG", "SET", "lazyfree-lazy-expire", "yes")
+        self._many_chunk_series(client, "lazy:expiring")
+        self._drain(client)
+        before = self._lazyfreed(client)
+
+        client.execute_command("PEXPIRE", "lazy:expiring", 1)
+        deadline = time.time() + 5.0
+        while time.time() < deadline and client.execute_command("EXISTS", "lazy:expiring"):
+            time.sleep(0.02)
+        assert client.execute_command("EXISTS", "lazy:expiring") == 0
+        self._drain(client)
+
+        assert self._lazyfreed(client) == before + 1
+
+    # ---- the index must survive the rearrangement ---------------------------------
+
+    def test_delete_does_not_log_a_spurious_index_warning(self):
+        """`free` used to redo `unlink`'s work, warning about the id it had just removed."""
+        client = self.server.get_new_client()
+        self._many_chunk_series(client, "lazy:quiet", samples=120, over_threshold=False)
+        client.execute_command("UNLINK", "lazy:quiet")
+        self._drain(client)
+        # The warning is emitted from `free`, which may now run on a bio thread.
+        time.sleep(0.2)
+
+        assert not self.server.verify_string_in_logfile(SPURIOUS_REMOVAL_WARNING)
+
+    @pytest.mark.parametrize("command", ["DEL", "UNLINK"])
+    def test_index_is_clean_after_an_explicit_delete(self, command):
+        client = self.server.get_new_client()
+        self._many_chunk_series(client, "lazy:idx", samples=120, over_threshold=False)
+        assert self._indexed(client) == [b"lazy:idx"]
+
+        client.execute_command(command, "lazy:idx")
+        self._drain(client)
+
+        assert self._indexed(client) == []
+
+    def test_index_is_clean_after_an_overwrite(self):
+        """`dbOverwrite` fires `unlink` before freeing the old value."""
+        client = self.server.get_new_client()
+        self._many_chunk_series(client, "lazy:over", samples=120, over_threshold=False)
+        assert self._indexed(client) == [b"lazy:over"]
+
+        client.execute_command("SET", "lazy:over", "now a string")
+        self._drain(client)
+
+        assert self._indexed(client) == []
+
+    def test_index_is_clean_after_expiry(self):
+        client = self.server.get_new_client()
+        self._many_chunk_series(client, "lazy:exp", samples=120, over_threshold=False)
+        client.execute_command("PEXPIRE", "lazy:exp", 1)
+
+        deadline = time.time() + 5.0
+        while time.time() < deadline and client.execute_command("EXISTS", "lazy:exp"):
+            time.sleep(0.02)
+        assert client.execute_command("EXISTS", "lazy:exp") == 0
+        self._drain(client)
+
+        assert self._indexed(client) == []
+
+    def test_index_follows_a_rename(self):
+        """RENAME overwrites the destination, so the destination's series is retired while the
+        source's must survive under its new name."""
+        client = self.server.get_new_client()
+        self._many_chunk_series(client, "lazy:src", samples=120, over_threshold=False)
+        self._many_chunk_series(client, "lazy:dst", samples=120, over_threshold=False)
+        assert self._indexed(client) == [b"lazy:dst", b"lazy:src"]
+
+        client.execute_command("RENAME", "lazy:src", "lazy:dst")
+        self._drain(client)
+
+        assert self._indexed(client) == [b"lazy:dst"]
+        assert client.execute_command("TS.INFO", "lazy:dst") is not None
+
+    def test_index_is_clean_after_an_async_flush(self):
+        """An async flush frees every value on the bio thread and retires the index wholesale
+        rather than key by key."""
+        client = self.server.get_new_client()
+        for i in range(5):
+            self._many_chunk_series(client, f"lazy:flush{i}", samples=120, over_threshold=False)
+
+        client.execute_command("FLUSHALL", "ASYNC")
+        self._drain(client)
+
+        assert self._indexed(client) == []
+        assert client.execute_command("DBSIZE") == 0
+        assert not self.server.verify_string_in_logfile(SPURIOUS_REMOVAL_WARNING)

--- a/tests/test_ts_mdel_replication_cme.py
+++ b/tests/test_ts_mdel_replication_cme.py
@@ -1,0 +1,165 @@
+# tests/test_ts_mdel_replication_cme.py
+"""Cluster-mode replication coverage for TS.MDEL.
+
+TS.MDEL is the module's only fanout command that writes, and the clustered path had two defects
+that together diverged every replica in the cluster:
+
+  * the fanout inherited the `FanoutClientCommand` default target mode, which picks one *random*
+    node per shard -- primaries and replicas alike -- so a shard's deletes could be applied
+    directly on a replica while its primary kept the data; and
+  * the clustered branch returned before any replication at all, so the deletes a primary *did*
+    apply never reached that primary's replicas.
+
+Neither was observable from the rest of the suite: `ValkeyTimeSeriesClusterTestCase` defaults to
+`REPLICAS_COUNT = 0`, and with no replicas both bugs are inert. These tests run three shards with
+one replica each and compare every replica against its own primary.
+"""
+import pytest
+from valkey import Valkey, ValkeyCluster
+from valkeytestframework.conftest import resource_port_tracker
+from valkey_timeseries_test_case import ValkeyTimeSeriesClusterTestCase
+
+SAMPLES = [(1, 10.0), (2, 20.0), (3, 30.0), (4, 40.0), (5, 50.0)]
+
+
+class TestTsMDelReplicationCluster(ValkeyTimeSeriesClusterTestCase):
+    CLUSTER_SIZE = 3
+    REPLICAS_COUNT = 1
+
+    # ------------------------------------------------------------------ helpers
+
+    def _shard_index_for_slot(self, slot: int) -> int:
+        """Which shard owns `slot`, given the even split the harness performs at setup."""
+        for idx, (start, end) in enumerate(self._split_range_pairs(0, 16384, self.CLUSTER_SIZE)):
+            if start <= slot < end:
+                return idx
+        raise AssertionError(f"slot {slot} is outside every shard range")
+
+    def _hash_tag_for_shard(self, client: Valkey, shard_index: int) -> str:
+        """A hash tag whose slot is owned by `shard_index`."""
+        for i in range(0, 4096):
+            tag = f"t{i}"
+            slot = int(client.execute_command("CLUSTER KEYSLOT", tag))
+            if self._shard_index_for_slot(slot) == shard_index:
+                return tag
+        raise AssertionError(f"no hash tag found for shard {shard_index}")
+
+    def _create_series(self, cluster: ValkeyCluster, tags: list) -> dict:
+        """One `cpu` series and one `mem` series per shard, so every shard takes part in the
+        delete. Returns {shard_index: (cpu_key, mem_key)}."""
+        keys = {}
+        for shard_index, tag in enumerate(tags):
+            cpu = f"mdelrepl:cpu:{{{tag}}}"
+            mem = f"mdelrepl:mem:{{{tag}}}"
+            cluster.execute_command("TS.CREATE", cpu, "LABELS", "name", "cpu")
+            cluster.execute_command("TS.CREATE", mem, "LABELS", "name", "mem")
+            for key in (cpu, mem):
+                for ts, value in SAMPLES:
+                    cluster.execute_command("TS.ADD", key, ts, value)
+            keys[shard_index] = (cpu, mem)
+        return keys
+
+    def _sync_all_replicas(self):
+        for rg in self.replication_groups:
+            rg.wait_for_replica_offset_to_sync_up(0)
+
+    def _primary_dbsizes(self) -> list:
+        return [rg.get_primary_connection().execute_command("DBSIZE") for rg in self.replication_groups]
+
+    def _readonly_replica(self, shard_index: int) -> Valkey:
+        """A replica connection that serves its shard's slots locally instead of redirecting."""
+        replica = self.replication_groups[shard_index].get_replica_connection(0)
+        replica.execute_command("READONLY")
+        return replica
+
+    def _flush_cluster(self, cluster: ValkeyCluster):
+        for rg in self.replication_groups:
+            rg.get_primary_connection().execute_command("FLUSHALL")
+
+    # ------------------------------------------------------------------- tests
+
+    def test_mdel_series_deletion_reaches_replicas(self):
+        """A whole-series TS.MDEL must leave every replica agreeing with its own primary."""
+        cluster = self.new_cluster_client()
+        coordinator = self.new_client_for_primary(0)
+
+        tags = [self._hash_tag_for_shard(coordinator, i) for i in range(self.CLUSTER_SIZE)]
+        self._create_series(cluster, tags)
+        self._sync_all_replicas()
+
+        assert sum(self._primary_dbsizes()) == 2 * self.CLUSTER_SIZE
+
+        deleted = coordinator.execute_command("TS.MDEL", "FILTER", "name=cpu")
+        assert int(deleted) == self.CLUSTER_SIZE
+
+        # The primaries applied it (this is the targeting half of MDEL-1: a slice routed to a
+        # replica would leave that shard's primary untouched).
+        assert sum(self._primary_dbsizes()) == self.CLUSTER_SIZE
+
+        self._sync_all_replicas()
+
+        # ...and so did every replica (the replication half).
+        for shard_index, rg in enumerate(self.replication_groups):
+            primary_size = rg.get_primary_connection().execute_command("DBSIZE")
+            replica_size = rg.get_replica_connection(0).execute_command("DBSIZE")
+            assert replica_size == primary_size, (
+                f"shard {shard_index}: replica holds {replica_size} keys but its primary holds "
+                f"{primary_size} -- the TS.MDEL deletion did not replicate"
+            )
+
+    def test_mdel_range_deletion_reaches_replicas(self):
+        """A range TS.MDEL must remove the same samples on each replica as on its primary."""
+        cluster = self.new_cluster_client()
+        coordinator = self.new_client_for_primary(0)
+
+        tags = [self._hash_tag_for_shard(coordinator, i) for i in range(self.CLUSTER_SIZE)]
+        keys = self._create_series(cluster, tags)
+        self._sync_all_replicas()
+
+        deleted = coordinator.execute_command("TS.MDEL", 2, 4, "FILTER", "name=cpu")
+        # Three samples (2, 3, 4) removed from one cpu series per shard.
+        assert int(deleted) == 3 * self.CLUSTER_SIZE
+
+        self._sync_all_replicas()
+
+        for shard_index, (cpu, mem) in keys.items():
+            primary = self.replication_groups[shard_index].get_primary_connection()
+            replica = self._readonly_replica(shard_index)
+
+            assert primary.execute_command("TS.RANGE", cpu, "-", "+") == [[1, b"10"], [5, b"50"]]
+            for key in (cpu, mem):
+                assert replica.execute_command("TS.RANGE", key, "-", "+") == primary.execute_command(
+                    "TS.RANGE", key, "-", "+"
+                ), f"shard {shard_index}: replica disagrees with its primary on {key}"
+
+    def test_mdel_always_deletes_on_the_primary(self):
+        """Every shard's slice must land on that shard's primary, on every attempt.
+
+        The former default target mode chose uniformly between a shard's primary and its replica,
+        so a single round left at least one primary untouched roughly seven times in eight. Five
+        rounds make an accidental pass vanishingly unlikely while keeping the test quick.
+        """
+        cluster = self.new_cluster_client()
+        coordinator = self.new_client_for_primary(0)
+        tags = [self._hash_tag_for_shard(coordinator, i) for i in range(self.CLUSTER_SIZE)]
+
+        for round_index in range(5):
+            self._flush_cluster(cluster)
+            self._create_series(cluster, tags)
+
+            deleted = coordinator.execute_command("TS.MDEL", "FILTER", "name=cpu")
+            assert int(deleted) == self.CLUSTER_SIZE
+
+            sizes = self._primary_dbsizes()
+            assert all(size == 1 for size in sizes), (
+                f"round {round_index}: primaries hold {sizes}; every shard should have had its "
+                f"cpu series deleted and kept its mem series"
+            )
+
+        # The replica guard must never have fired: with primary-only targeting no shard's slice
+        # is ever delivered to a replica.
+        for rg in self.replication_groups:
+            log = rg.replicas[0].logfile
+            with open(log, "rb") as handle:
+                contents = handle.read().decode("utf-8", "replace")
+            assert "refusing to apply a fanout write on a replica" not in contents

--- a/tests/test_ts_memory_reporting.py
+++ b/tests/test_ts_memory_reporting.py
@@ -1,0 +1,205 @@
+# tests/test_ts_memory_reporting.py
+"""`MEMORY USAGE`, `TS.INFO memoryUsage` and `INFO ts_memory` must be usable for capacity
+planning (MEM-1).
+
+Three separate accounting defects made them not so:
+
+  * `MetricName` implemented `GetSize::get_size`, but a containing type's derived impl calls
+    `get_heap_size_with_tracker`, which was left on its default of zero. A series' labels
+    therefore cost nothing at all: `TS.INFO memoryUsage` for a seven-label series reported
+    exactly `size_of::<TimeSeries>()`.
+  * the compressed chunk encodings reported the bit stream's `Vec` *capacity* plus the encoder
+    struct as their `size`. The stream grows by doubling, so `TS.INFO DEBUG` reported ~2x the
+    bytes actually encoded -- a chunk created with `CHUNK_SIZE 4096` reported 8288 -- and
+    `bytesPerSample` with it.
+  * the label index hangs off no key at all, so neither `MEMORY USAGE` nor `TS.INFO` could ever
+    see it, and nothing else reported it either.
+
+The per-key assertions here are deliberately structural (A costs more than B, X is bounded by
+Y) rather than pinned to byte counts, which are a function of struct layout.
+"""
+import pytest
+from valkeytestframework.conftest import resource_port_tracker
+from valkey_timeseries_test_case import ValkeyTimeSeriesTestCaseBase
+
+CHUNK_SIZE = 4096
+# A chunk is sealed once its payload reaches CHUNK_SIZE, so it can overshoot by at most the
+# encoding of one sample. Generous next to the ~2x the capacity-based figure reported.
+CHUNK_SIZE_SLACK = 256
+
+LONG_LABELS = [
+    "instance", "host-0000000000.prod.example.internal",
+    "job", "node_exporter_with_a_long_job_name",
+    "region", "us-east-1-availability-zone-alpha",
+    "service", "checkout_api_backend_service",
+    "team", "platform_reliability_engineering",
+]
+
+
+class TestMemoryReporting(ValkeyTimeSeriesTestCaseBase):
+    @staticmethod
+    def _ts_info(client, key: str) -> dict:
+        flat = client.execute_command("TS.INFO", key)
+        return {flat[i]: flat[i + 1] for i in range(0, len(flat), 2)}
+
+    @staticmethod
+    def _chunks(client, key: str) -> list:
+        flat = client.execute_command("TS.INFO", key, "DEBUG")
+        info = {flat[i]: flat[i + 1] for i in range(0, len(flat), 2)}
+        return [{c[i]: c[i + 1] for i in range(0, len(c), 2)} for c in info[b"Chunks"]]
+
+    @staticmethod
+    def _ts_memory(client) -> dict:
+        """The `ts_memory` fields, as ints. The client parses INFO for us, but only into
+        `str -> str`; an absent section comes back as an empty mapping."""
+        parsed = client.execute_command("INFO", "ts_memory")
+        return {
+            k: int(v)
+            for k, v in parsed.items()
+            if k.startswith("ts_") and str(v).lstrip("-").isdigit()
+        }
+
+    def _fill(self, client, key: str, samples: int):
+        pipe = client.pipeline(transaction=False)
+        for i in range(samples):
+            pipe.execute_command("TS.ADD", key, 1600000000000 + i * 1000, i * 1.37)
+        pipe.execute()
+
+    # ---- labels -----------------------------------------------------------------
+
+    def test_labels_are_counted_in_memory_usage(self):
+        """The headline symptom: a labelled series used to report the same bytes as a bare one."""
+        client = self.server.get_new_client()
+        client.execute_command("TS.CREATE", "mem:bare")
+        client.execute_command("TS.CREATE", "mem:labelled", "LABELS", *LONG_LABELS)
+
+        bare = self._ts_info(client, "mem:bare")[b"memoryUsage"]
+        labelled = self._ts_info(client, "mem:labelled")[b"memoryUsage"]
+
+        label_bytes = sum(len(x) for x in LONG_LABELS)
+        assert labelled >= bare + label_bytes, (
+            f"a series carrying {label_bytes} bytes of label text reported {labelled} against "
+            f"{bare} for an identical series with no labels"
+        )
+
+    def test_memory_usage_grows_with_label_count(self):
+        client = self.server.get_new_client()
+        client.execute_command("TS.CREATE", "mem:few", "LABELS", *LONG_LABELS[:2])
+        client.execute_command("TS.CREATE", "mem:many", "LABELS", *LONG_LABELS)
+
+        few = client.execute_command("MEMORY", "USAGE", "mem:few")
+        many = client.execute_command("MEMORY", "USAGE", "mem:many")
+        assert many > few
+
+    def test_shared_labels_are_not_counted_once_per_series(self):
+        """Interned pairs are shared, so each holder reports a share rather than the whole thing.
+
+        Charging every holder the full allocation would make the sum of `MEMORY USAGE` over a
+        keyspace exceed what the module actually holds, by the sharing factor.
+        """
+        client = self.server.get_new_client()
+        client.execute_command("TS.CREATE", "mem:sole", "LABELS", *LONG_LABELS, "uniq", "sole")
+        sole = client.execute_command("MEMORY", "USAGE", "mem:sole")
+
+        for i in range(8):
+            client.execute_command(
+                "TS.CREATE", f"mem:shared{i}", "LABELS", *LONG_LABELS, "uniq", f"s{i}"
+            )
+        shared = client.execute_command("MEMORY", "USAGE", "mem:shared0")
+
+        assert shared < sole, (
+            f"a series sharing its labels nine ways reported {shared}, no less than the {sole} "
+            f"reported when it held them alone"
+        )
+
+    # ---- chunks -----------------------------------------------------------------
+
+    @pytest.mark.parametrize("encoding", ["COMPRESSED", "UNCOMPRESSED"])
+    def test_chunk_size_is_bounded_by_the_configured_chunk_size(self, encoding):
+        """`size` is the encoded payload, not the bit stream's doubled `Vec` capacity."""
+        client = self.server.get_new_client()
+        key = f"mem:chunks:{encoding}"
+        client.execute_command(
+            "TS.CREATE", key, "CHUNK_SIZE", CHUNK_SIZE, "ENCODING", encoding
+        )
+        self._fill(client, key, 20000)
+
+        chunks = self._chunks(client, key)
+        assert len(chunks) > 1, "series never filled a chunk, the bound is untested"
+        for chunk in chunks:
+            assert chunk[b"size"] <= CHUNK_SIZE + CHUNK_SIZE_SLACK, (
+                f"{encoding}: a chunk configured at {CHUNK_SIZE} bytes reports "
+                f"{chunk[b'size']} -- the reported size is counting allocator slack"
+            )
+
+    def test_bytes_per_sample_is_bounded_by_the_uncompressed_size(self):
+        """A compressed sample cannot cost more than the 16 raw bytes it replaces."""
+        client = self.server.get_new_client()
+        client.execute_command("TS.CREATE", "mem:bps", "CHUNK_SIZE", CHUNK_SIZE)
+        self._fill(client, "mem:bps", 20000)
+
+        for chunk in self._chunks(client, "mem:bps"):
+            if chunk[b"samples"] < 16:
+                continue  # header overhead dominates; the estimate is documented as unreliable
+            assert 0 < float(chunk[b"bytesPerSample"]) <= 16.0, chunk
+
+    def test_memory_usage_covers_the_encoded_payload(self):
+        """The allocation is still reported in full -- `size` shrinking must not shrink this."""
+        client = self.server.get_new_client()
+        client.execute_command("TS.CREATE", "mem:cover", "CHUNK_SIZE", CHUNK_SIZE)
+        self._fill(client, "mem:cover", 20000)
+
+        payload = sum(c[b"size"] for c in self._chunks(client, "mem:cover"))
+        reported = self._ts_info(client, "mem:cover")[b"memoryUsage"]
+        assert reported >= payload, f"memoryUsage {reported} is below {payload} bytes of payload"
+
+    # ---- the index --------------------------------------------------------------
+
+    def test_info_reports_index_memory(self):
+        client = self.server.get_new_client()
+        empty = self._ts_memory(client)
+        assert empty, "the module publishes no ts_memory INFO section"
+        assert empty["ts_index_total_bytes"] == 0
+
+        for i in range(200):
+            client.execute_command(
+                "TS.CREATE", f"mem:idx{i}", "LABELS", *LONG_LABELS, "uniq", f"series_{i}"
+            )
+
+        filled = self._ts_memory(client)
+        assert filled["ts_index_series"] == 200
+        assert filled["ts_index_terms"] > 0
+        assert filled["ts_index_total_bytes"] > 0
+        assert filled["ts_index_total_bytes"] == (
+            filled["ts_index_terms_bytes"]
+            + filled["ts_index_postings_bytes"]
+            + filled["ts_index_id_to_key_bytes"]
+            + filled["ts_index_bookkeeping_bytes"]
+        )
+
+    def test_index_memory_is_released_on_flush(self):
+        client = self.server.get_new_client()
+        for i in range(200):
+            client.execute_command(
+                "TS.CREATE", f"mem:drop{i}", "LABELS", *LONG_LABELS, "uniq", f"series_{i}"
+            )
+        assert self._ts_memory(client)["ts_index_total_bytes"] > 0
+
+        client.execute_command("FLUSHALL")
+
+        after = self._ts_memory(client)
+        assert after["ts_index_total_bytes"] == 0
+        assert after["ts_index_series"] == 0
+
+    def test_index_memory_is_reported_across_databases(self):
+        client = self.server.get_new_client()
+        for db in (0, 1):
+            client.execute_command("SELECT", db)
+            for i in range(50):
+                client.execute_command(
+                    "TS.CREATE", f"mem:db{db}:{i}", "LABELS", *LONG_LABELS, "uniq", f"s{i}"
+                )
+
+        totals = self._ts_memory(client)
+        assert totals["ts_index_series"] == 100
+        assert totals["ts_index_databases"] >= 2

--- a/tests/test_ts_memory_reporting.py
+++ b/tests/test_ts_memory_reporting.py
@@ -153,6 +153,30 @@ class TestMemoryReporting(ValkeyTimeSeriesTestCaseBase):
         reported = self._ts_info(client, "mem:cover")[b"memoryUsage"]
         assert reported >= payload, f"memoryUsage {reported} is below {payload} bytes of payload"
 
+    def test_sealed_chunks_do_not_hold_double_their_payload(self):
+        """A chunk that is no longer the append target hands its spare capacity back.
+
+        The bit stream is a `Vec` grown by doubling, so a chunk that has just filled to
+        `CHUNK_SIZE` sits on up to twice that in allocation, for the life of the series.
+        Measured over this series before the seal was wired in: 208,069 bytes reported for
+        109,537 bytes of encoded data. Only the tail chunk may still carry slack.
+        """
+        client = self.server.get_new_client()
+        client.execute_command("TS.CREATE", "mem:sealed", "CHUNK_SIZE", CHUNK_SIZE)
+        self._fill(client, "mem:sealed", 20000)
+
+        chunks = self._chunks(client, "mem:sealed")
+        assert len(chunks) > 4, "series barely chunked, the seal path is untested"
+
+        payload = sum(c[b"size"] for c in chunks)
+        reported = self._ts_info(client, "mem:sealed")[b"memoryUsage"]
+        # One tail chunk of slack, plus per-chunk struct overhead.
+        budget = payload + CHUNK_SIZE * 2 + len(chunks) * 256
+        assert reported <= budget, (
+            f"memoryUsage {reported} against {payload} bytes of payload in {len(chunks)} "
+            f"chunks: sealed chunks are still holding their doubled buffers"
+        )
+
     # ---- the index --------------------------------------------------------------
 
     def test_info_reports_index_memory(self):

--- a/tests/test_ts_read.py
+++ b/tests/test_ts_read.py
@@ -1606,7 +1606,7 @@ class TestTsReadOnReplica(ReplicationTestCase):
     while working perfectly on the primary.
 
     TS.READ is `readonly`, so serving it from a replica is the expected deployment shape for
-    fanning reads out — which makes this path load-bearing rather than incidental.
+    fanning reads out — which makes this path consequential rather than incidental.
     """
 
     REPLICAS_COUNT = 1

--- a/tests/test_ts_replication.py
+++ b/tests/test_ts_replication.py
@@ -250,6 +250,64 @@ class TestTimeSeriesReplication(ReplicationTestCase):
         assert result[1][0] == 4000
         assert result[2][0] == 5000
 
+    def test_replication_ts_mdel_series(self):
+        """TS.MDEL without a range replicates the keys it removed.
+
+        `TS.MDEL` is not replicated verbatim (see `delete_series_by_selectors`): a verbatim replay
+        would re-evaluate the filter, and the timestamp bounds, on the replica. It propagates the
+        resolved effects instead, so this pins that the replica ends up with the same keyspace.
+        """
+        client = self.client
+
+        for name in ("cpu", "cpu2", "mem"):
+            key = f"ts:mdel_series:{name}"
+            metric = "cpu" if name.startswith("cpu") else "mem"
+            client.execute_command(f"TS.CREATE {key} LABELS name {metric}")
+            client.execute_command(f"TS.ADD {key} 1000 10")
+
+        self.wait_for_replication()
+
+        deleted = client.execute_command("TS.MDEL FILTER name=cpu")
+        assert deleted == 2
+
+        self.wait_for_replication()
+
+        replica = self.replicas[0].client
+        for name in ("cpu", "cpu2"):
+            key = f"ts:mdel_series:{name}"
+            assert client.execute_command(f"EXISTS {key}") == 0
+            assert replica.execute_command(f"EXISTS {key}") == 0
+        assert replica.execute_command("EXISTS ts:mdel_series:mem") == 1
+
+    def test_replication_ts_mdel_range(self):
+        """TS.MDEL with a range replicates the samples it removed, and only those."""
+        client = self.client
+
+        keys = ["ts:mdel_range:cpu", "ts:mdel_range:mem"]
+        for key in keys:
+            metric = "cpu" if key.endswith("cpu") else "mem"
+            client.execute_command(f"TS.CREATE {key} LABELS name {metric}")
+            for ts in (1000, 2000, 3000, 4000, 5000):
+                client.execute_command(f"TS.ADD {key} {ts} {ts}")
+
+        self.wait_for_replication()
+
+        deleted = client.execute_command("TS.MDEL 2000 3000 FILTER name=cpu")
+        assert deleted == 2
+
+        self.wait_for_replication()
+
+        replica = self.replicas[0].client
+        for key in keys:
+            assert replica.execute_command(f"TS.RANGE {key} - +") == client.execute_command(
+                f"TS.RANGE {key} - +"
+            )
+        assert [row[0] for row in replica.execute_command("TS.RANGE ts:mdel_range:cpu - +")] == [
+            1000,
+            4000,
+            5000,
+        ]
+
     def test_replication_ts_alter(self):
         """Test that TS.ALTER replicates correctly"""
         key = "ts:alter"

--- a/tests/test_ts_restore_malformed.py
+++ b/tests/test_ts_restore_malformed.py
@@ -78,6 +78,8 @@ class TestTimeseriesRestoreMalformed(ValkeyTimeSeriesTestCaseBase):
                 client.execute_command('TS._RESTORE', f'garbage{i}', blob)
             except Exception as e:
                 assert 'failed to deserialize' in str(e), f'unexpected error for {blob!r}: {e}'
+            else:
+                raise AssertionError(f'TS._RESTORE accepted a garbage payload: {blob!r}')
             assert client.ping()
         assert self.server.is_alive()
 
@@ -95,6 +97,8 @@ class TestTimeseriesRestoreMalformed(ValkeyTimeSeriesTestCaseBase):
                 client.execute_command('TS._RESTORE', f'trunc{cut}', payload[:cut])
             except Exception as e:
                 assert 'failed to deserialize' in str(e), f'unexpected error at cut {cut}: {e}'
+            else:
+                raise AssertionError(f'TS._RESTORE accepted a payload truncated to {cut} bytes')
             assert client.ping(), f'server died on truncation at {cut} bytes'
         assert self.server.is_alive()
 

--- a/tests/test_ts_restore_malformed.py
+++ b/tests/test_ts_restore_malformed.py
@@ -1,0 +1,116 @@
+"""Regression tests for a malformed TS._RESTORE, ensuring that a malformed or truncated payload must not abort the server.
+
+`TS._RESTORE` reconstructs a series through the module type's `rdb_load`. Without the
+`HANDLE_IO_ERRORS` module option, the server's `moduleRDBLoadError` reaches `serverPanic` the
+moment the payload stream underruns -- inside `rdb_load`, before the handler's null check or any
+of the module's own bounds checks can run. With the option declared, the short read is recorded
+on the RedisModuleIO instead and surfaces as a clean error.
+
+The command is registered `write timeseries admin`, so `+@timeseries` grants it; a truncated or
+corrupt payload is reachable by any client holding that category.
+"""
+
+import os
+import random
+import re
+
+from valkeytestframework.util.waiters import *
+from valkeytestframework.valkey_test_case import ValkeyAction
+from valkey_timeseries_test_case import ValkeyTimeSeriesTestCaseBase
+from valkeytestframework.conftest import resource_port_tracker
+
+
+class TestTimeseriesRestoreMalformed(ValkeyTimeSeriesTestCaseBase):
+
+    def _genuine_payload(self, key='payload_src'):
+        """Produce a real TS._RESTORE payload by way of the command-format AOF.
+
+        `aof_rewrite` emits `TS._RESTORE key <blob>`, where the blob is what the type's
+        `rdb_save` produced -- the exact input shape this command reads in production.
+        """
+        client = self.client
+        client.config_set('aof-use-rdb-preamble', 'no')
+
+        # Populate before enabling AOF so the rewrite this triggers already contains the series.
+        client.execute_command('TS.CREATE', key, 'LABELS', 'host', 'a', 'region', 'b')
+        for i in range(1, 201):
+            client.execute_command('TS.ADD', key, 1000 + i * 1000, i)
+
+        client.config_set('appendonly', 'yes')
+        wait_for_equal(lambda: client.info('persistence')['aof_rewrite_in_progress'], 0, timeout=30)
+
+        # The harness gives each server its own per-port `appenddirname`.
+        server_dir = client.config_get('dir')['dir']
+        aof_dir = os.path.join(server_dir, client.config_get('appenddirname')['appenddirname'])
+        needle = b'TS._RESTORE\r\n$%d\r\n%s\r\n' % (len(key), key.encode())
+
+        def find_payload():
+            """Return the base-AOF bytes carrying this key's TS._RESTORE, once written."""
+            if not os.path.isdir(aof_dir):
+                return None
+            for name in os.listdir(aof_dir):
+                if not name.endswith('.base.aof'):
+                    continue
+                data = open(os.path.join(aof_dir, name), 'rb').read()
+                if needle in data:
+                    return data
+            return None
+
+        # The rewrite lands asynchronously; poll rather than racing it.
+        wait_for_true(lambda: find_payload() is not None, timeout=30)
+        data = find_payload()
+        assert data is not None
+
+        i = data.index(needle)
+        p = data.index(b'\r\n', i + len(needle) - 2) + 2
+        m = re.match(rb'\$(\d+)\r\n', data[p:])
+        assert m, 'could not locate the TS._RESTORE payload bulk string'
+        start = p + m.end()
+        payload = data[start:start + int(m.group(1))]
+        assert len(payload) > 0
+        return payload
+
+    def test_restore_garbage_payload_does_not_crash(self):
+        """Payloads that are not module output at all are rejected, not fatal."""
+        client = self.client
+        for i, blob in enumerate([b'', b'garbage', b'\x01\x02\x03', b'A' * 32, b'\x00' * 256]):
+            try:
+                client.execute_command('TS._RESTORE', f'garbage{i}', blob)
+            except Exception as e:
+                assert 'failed to deserialize' in str(e), f'unexpected error for {blob!r}: {e}'
+            assert client.ping()
+        assert self.server.is_alive()
+
+    def test_restore_truncated_payload_does_not_crash(self):
+        """Every truncation of a genuine payload underruns the stream mid-parse."""
+        client = self.client
+        payload = self._genuine_payload()
+
+        # The untruncated payload must still restore cleanly, or the test proves nothing.
+        assert client.execute_command('TS._RESTORE', 'restored', payload)
+        assert self.ts_info('restored')['totalSamples'] == 200
+
+        for cut in list(range(0, len(payload), 7)) + [len(payload) - 1]:
+            try:
+                client.execute_command('TS._RESTORE', f'trunc{cut}', payload[:cut])
+            except Exception as e:
+                assert 'failed to deserialize' in str(e), f'unexpected error at cut {cut}: {e}'
+            assert client.ping(), f'server died on truncation at {cut} bytes'
+        assert self.server.is_alive()
+
+    def test_restore_corrupt_payload_does_not_crash(self):
+        """Bit-flips inside a full-length payload hit the interior decoders."""
+        client = self.client
+        payload = self._genuine_payload(key='fuzz_src')
+        rng = random.Random(7)
+
+        for trial in range(300):
+            b = bytearray(payload)
+            for _ in range(rng.randint(1, 8)):
+                b[rng.randrange(len(b))] = rng.randrange(256)
+            try:
+                client.execute_command('TS._RESTORE', f'fuzz{trial}', bytes(b))
+            except Exception:
+                pass  # any clean error is fine; only a dead server is a failure
+            assert client.ping(), f'server died on corrupt payload, trial {trial}'
+        assert self.server.is_alive()


### PR DESCRIPTION
This pull request updates the minimum supported Rust version to 1.96.0, upgrades several dependencies, and introduces new module infrastructure for reporting memory usage and declaring module options. It also improves correctness and safety in clustered and replicated environments, especially for the `TS.MDEL` command, and enhances error handling and documentation.

**Rust and Dependency Upgrades:**

* Updated the minimum supported Rust version to 1.96.0 in `Cargo.toml`, `.github/workflows/ci.yml`, and documentation (`AGENTS.md`). [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L5-R5) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL26-R26) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL159-R159) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL185-R185) [[5]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L65-R65)
* Upgraded multiple dependencies to their latest versions, including `bon`, `croaring`, `get-size2`, `itertools`, `valkey-module`, `valkey-module-macros`, `simd-json`, `statrs`, and `serial_test`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R23) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L39-R48) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L61-R61)

**New Module Infrastructure:**

* Added `src/common/module_info.rs` to expose a new `INFO ts_memory` section, reporting global heap usage, label interner stats, and index memory figures for improved observability.
* Added `src/common/module_options.rs` to manage cumulative declaration of `ValkeyModule_SetModuleOptions` flags, ensuring all required options are set without overwriting each other.
* Refactored atomic slot migration option declaration to use the new `declare_module_options` helper. [[1]](diffhunk://#diff-97efe4d6502d241377d37800530dbd33c6fb9cc45c2192436d6a7053b77363f2R1) [[2]](diffhunk://#diff-97efe4d6502d241377d37800530dbd33c6fb9cc45c2192436d6a7053b77363f2L364-R368)

**Cluster and Replication Correctness:**

* Modified `TS.MDEL` fanout logic to ensure writes only target primaries, never replicas, and added explicit error handling and context checks to prevent divergence during failover scenarios. [[1]](diffhunk://#diff-a289fedd5253c2adf9bf677d57f06d42ec87bc45b1a7d1ebc50c30cfff2f01aaR41-R57) [[2]](diffhunk://#diff-a289fedd5253c2adf9bf677d57f06d42ec87bc45b1a7d1ebc50c30cfff2f01aaR68-R71) [[3]](diffhunk://#diff-af9507d3cb6bc7e620e8537a445a2e110cf82f92cd015899e6202150e990ab84R43-R53) [[4]](diffhunk://#diff-3497f28552c7f042626d48da7d949653c9d78d232a745f4999dc40c04d1ace75R135)
* Improved documentation and comments to clarify the rationale and behavior of these changes. [[1]](diffhunk://#diff-a289fedd5253c2adf9bf677d57f06d42ec87bc45b1a7d1ebc50c30cfff2f01aaR41-R57) [[2]](diffhunk://#diff-a289fedd5253c2adf9bf677d57f06d42ec87bc45b1a7d1ebc50c30cfff2f01aaR68-R71)

**Memory Usage and Safety Improvements:**

* Enhanced memory usage reporting for interned strings with new methods to calculate allocated and amortized size, and improved safety when parsing durations and RDB payloads. [[1]](diffhunk://#diff-ebcd0400a4f966f67b1a722c59a40887341ae655fdd9df75b16229be30039669R271-R290) [[2]](diffhunk://#diff-38837f9286591841af1f35a0c2c888f597064dc95c3d0a3b9ab88d1df5c5678eL1455-R1458) [[3]](diffhunk://#diff-18d724d018e7ca0bdadfab684c353b30338045653edf2989a1e6ac57fd7fd96dL129-R132)
* Guard against panics when parsing empty string arguments
* Declare HANDLE_IO_ERRORS module option to prevent server panics on malformed TS._RESTORE
* Add end-to-end regression tests for corrupt and truncated RDB loads
* Correct defrag chunk removal and total sample accounting
* Release postings read lock before opening keys or marking stale ids
* Clear every database index on FLUSHALL and re-dispatch displaced flush/swapdb handlers
* Report free effort so large series are freed off the main thread
* Have GorillaChunk split inherit the source's max_size

**Documentation Updates:**

* Clarified language in technical documentation for accuracy and precision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ts_memory` details to `INFO`, including index, series, and interner memory usage.
  * Preserved binary key names across multi-series responses and grouped source metadata.
  * Added support for lazy freeing of large time series.

* **Bug Fixes**
  * Improved `TS.MDEL` replication and ensured fanout deletions run on primary nodes.
  * Prevented crashes from malformed inputs, truncated persistence data, and empty numeric arguments.
  * Fixed index consistency after `FLUSHDB`, `FLUSHALL`, and `SWAPDB`.
  * Resolved deadlocks during index queries involving expired series.
  * Corrected chunk size, capacity, splitting, and memory accounting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->