### PR TITLE
Chore: Parallel integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,14 @@ jobs:
 
       # tests/compat needs a live RedisTimeSeries reference server; it is covered
       # by the compat-smoke job below.
+      #
+      # -n auto spreads the suite over the runner's cores. loadscope keeps a test
+      # class on one worker, which several classes here rely on for their per-class
+      # directories under test-data/. Ports and working directories are partitioned
+      # per worker in tests/conftest.py; see
+      # docs/plans/parallel-integration-tests-plan.md.
       - name: Run integration tests
-        run: python3 -m pytest --cache-clear -v "tests/" --ignore=tests/compat
+        run: python3 -m pytest --cache-clear -v -n auto --dist=loadscope "tests/" --ignore=tests/compat
 
   # RedisTimeSeries compatibility smoke gate (docs/plans/rts-compatibility-test-plan.md §8):
   # Tier A smoke subset diffed against the pinned redis:8.10 reference image,
@@ -233,6 +239,12 @@ jobs:
 
       # tests/compat needs a live RedisTimeSeries reference server; it is covered
       # by the compat-smoke job above.
+      #
+      # Deliberately serial. The leak attribution below reads the test name from the
+      # two lines above each LeakSanitizer report, which only holds while pytest
+      # output is ordered; xdist interleaves workers and prefixes lines with [gwN].
+      # Routing sanitizer output to per-server files would lift this restriction --
+      # see docs/plans/parallel-integration-tests-plan.md section 3.6.
       - name: Run integration tests
         run: |
           python3 -m pytest --capture=sys --cache-clear -v "tests/" --ignore=tests/compat -m "not skip_for_asan" 2>&1 | tee test_output.tmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         server_version: ["unstable", "8.1"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -100,7 +100,7 @@ jobs:
     env:
       SERVER_VERSION: "8.1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # No protobuf compiler is installed here on purpose: build.rs parses
       # proto/v1/*.proto with protox (pure Rust), so protoc is never invoked. The
@@ -157,7 +157,7 @@ jobs:
   build-macos-latest:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -183,7 +183,7 @@ jobs:
       matrix:
         server_version: ["unstable", "8.1"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ Quick start (commands you can run)
     - To run ASAN integration pass: `ASAN_BUILD=true SERVER_VERSION=unstable ./build.sh`
     - Run a subset of Python integration tests: `TEST_PATTERN="test_ts_add" SERVER_VERSION=unstable ./build.sh`
     - Include the compatibility suite: `RTS_COMPAT=1 SERVER_VERSION=unstable ./build.sh`
+    - Run the integration tests in parallel: `SERVER_VERSION=unstable ./build.sh --parallel`
+      (or `-j8` for a fixed worker count). Serial is the default.
 - Benchmarks: `cargo bench --features enable-system-alloc` (see Benchmarks below — the feature is mandatory).
 - Compression report: `tools/compression_report.sh` (add `--check` to fail on regressions against a saved baseline).
 - Latency report: `tools/latency_report.sh`. Wire-payload report: `tools/wire_report.sh` (see Benchmarks below).
@@ -51,6 +53,15 @@ Key ENV and behavior (from `./build.sh`)
   `tests/build/binaries/$SERVER_VERSION/valkey-server`. Defaults to `unstable` if not set, which tracks the latest main or branch.
 - `ASAN_BUILD`: when set runs tests with LeakSanitizer checks and fails on leaks.
 - `TEST_PATTERN`: passed to pytest `-k` to select tests.
+- `PARALLEL_WORKERS` (equivalently `--parallel[=N]` / `-j[=N]`): number of pytest-xdist workers for the
+  integration phase. `auto` means one per core capped at 32; `0` and `1` both mean serial, which is the
+  default. Each worker gets its own port band and its own `test-data/<worker>` directory
+  (`tests/conftest.py`), so tests do not need to know they are sharing a machine. Two phases ignore this
+  knob on purpose: the compatibility suite always runs serially because its fixtures share one reference
+  server on a fixed port, and the ASAN job stays serial because its leak attribution depends on ordered
+  pytest output. See `docs/plans/parallel-integration-tests-plan.md`.
+- `CLUSTER_MEET_TIMEOUT`: seconds to wait for cluster formation in cluster tests (default 60). Raise it on a
+  slow or heavily loaded runner rather than lowering the worker count.
 - `RTS_COMPAT=1` / `COMPAT_REFERENCE_URL` (or the `./build.sh compat` argument): any of them adds a second
   pytest phase that runs the differential compatibility suite. Unset (the default), `build.sh` never collects
   `tests/compat`, because those tests need a live RedisTimeSeries reference server. In compat mode `build.sh`

--- a/build.sh
+++ b/build.sh
@@ -2,13 +2,20 @@
 
 # Script to run format checks valkey-timeseries module, build it and generate .so files, run unit and integration tests.
 #
-# Usage: ./build.sh [clean|compat]
+# Usage: ./build.sh [--parallel[=N] | -j[=N]] [clean|compat]
 #
 #   (no argument)  format checks, build, unit tests, integration tests
 #   clean          remove build artifacts and exit
 #   compat         also run the RedisTimeSeries compatibility suite (tests/compat),
 #                  provisioning and starting a reference server first.
 #                  Equivalent to RTS_COMPAT=1 ./build.sh
+#
+#   --parallel[=N] run the integration tests across N pytest-xdist workers.
+#   -j[=N]         N may be "auto" (one per core, capped at 32), or an integer;
+#                  0 and 1 both mean serial. Defaults to serial when not given.
+#                  Also settable as PARALLEL_WORKERS. The compatibility suite
+#                  always runs serially: it shares one reference server and a
+#                  fixed port. See docs/plans/parallel-integration-tests-plan.md.
 #
 # See docs/rts-compat-build-integration-plan.md for the compatibility integration.
 
@@ -21,7 +28,10 @@ cd "$SCRIPT_DIR"
 echo "Script Directory: $SCRIPT_DIR"
 
 usage() {
-    sed -n '3,14p' "${BASH_SOURCE[0]}" | sed -e 's/^# \{0,1\}//'
+    # Print the header comment block (from line 3 to the first blank/non-comment
+    # line) rather than a hardcoded range, so editing the header cannot silently
+    # truncate --help.
+    awk 'NR<3 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "${BASH_SOURCE[0]}"
 }
 
 # Optional environment knobs, defaulted so `set -u` does not trip over them.
@@ -32,13 +42,62 @@ COMPAT_REFERENCE_URL="${COMPAT_REFERENCE_URL:-}"
 
 RUN_COMPAT=false
 
-if [ "$#" -gt 1 ]; then
-    echo "ERROR: too many arguments: $*" >&2
-    usage >&2
+# Serial by default: parallelism is opt-in so that an unattended run of this script
+# behaves exactly as it did before, and so a failure is never blamed on concurrency
+# nobody asked for.
+PARALLEL_WORKERS="${PARALLEL_WORKERS:-0}"
+
+is_valid_parallel_workers() {
+    [ "$1" = "auto" ] || [ "$1" = "logical" ] || [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+POSITIONAL=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --parallel|-j)
+            shift
+            if [ "$#" -gt 0 ] && [[ "$1" != -* ]] && is_valid_parallel_workers "$1"; then
+                PARALLEL_WORKERS="$1"
+                shift
+            else
+                PARALLEL_WORKERS="auto"
+            fi
+            ;;
+        --parallel=*|-j=*)
+            PARALLEL_WORKERS="${1#*=}"
+            shift
+            if ! is_valid_parallel_workers "$PARALLEL_WORKERS"; then
+                echo "ERROR: invalid worker count '$PARALLEL_WORKERS'; expected auto, logical or an integer." >&2
+                exit 2
+            fi
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            echo "ERROR: unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            if [ -n "$POSITIONAL" ]; then
+                echo "ERROR: too many arguments: $POSITIONAL $1" >&2
+                usage >&2
+                exit 2
+            fi
+            POSITIONAL="$1"
+            shift
+            ;;
+    esac
+done
+
+if ! is_valid_parallel_workers "$PARALLEL_WORKERS"; then
+    echo "ERROR: invalid PARALLEL_WORKERS='$PARALLEL_WORKERS'; expected auto, logical or an integer." >&2
     exit 2
 fi
 
-case "${1:-}" in
+case "$POSITIONAL" in
     "")
         ;;
     clean)
@@ -52,16 +111,41 @@ case "${1:-}" in
     compat)
         RUN_COMPAT=true
         ;;
-    -h|--help)
-        usage
-        exit 0
-        ;;
     *)
-        echo "ERROR: unknown argument: $1" >&2
+        echo "ERROR: unknown argument: $POSITIONAL" >&2
         usage >&2
         exit 2
         ;;
 esac
+
+# Resolve "auto" to a worker count once, here, so both the log line and the pytest
+# invocation agree. The cap keeps a 64-core machine from starting 192 valkey-servers.
+resolve_workers() {
+    local requested="$1"
+    if [ "$requested" = "auto" ] || [ "$requested" = "logical" ]; then
+        local cores
+        if [ "$(uname)" = "Darwin" ]; then
+            cores=$(sysctl -n hw.ncpu)
+        else
+            cores=$(nproc)
+        fi
+        if [ "$cores" -gt 32 ]; then cores=32; fi
+        if [ "$cores" -lt 1 ]; then cores=1; fi
+        echo "$cores"
+    else
+        echo "$requested"
+    fi
+}
+
+XDIST_ARGS=()
+RESOLVED_WORKERS=$(resolve_workers "$PARALLEL_WORKERS")
+if [ "$RESOLVED_WORKERS" -gt 1 ]; then
+    # loadscope keeps a test class on one worker. Several classes here share
+    # per-class directories under test-data/, so splitting a class across workers
+    # would reintroduce exactly the collisions the port bands remove.
+    XDIST_ARGS=(-n "$RESOLVED_WORKERS" --dist=loadscope)
+    echo "Integration tests will run across $RESOLVED_WORKERS workers."
+fi
 
 # The compatibility suite needs a live reference server. It runs when asked for
 # explicitly (`./build.sh compat`, RTS_COMPAT=1) or when an external reference is
@@ -291,6 +375,9 @@ assert_something_ran() {
 # tests/compat is excluded here and run on its own below, so that a compat failure is
 # attributable and the reference server is only up while it is actually needed.
 PHASE1_ARGS=("$SCRIPT_DIR/tests/" "--ignore=$SCRIPT_DIR/tests/compat")
+if [ "${#XDIST_ARGS[@]}" -gt 0 ]; then
+    PHASE1_ARGS+=("${XDIST_ARGS[@]}")
+fi
 if [ -n "$TEST_PATTERN" ]; then
     PHASE1_ARGS+=(-k "$TEST_PATTERN")
 else
@@ -335,6 +422,9 @@ if [ "$RUN_COMPAT" = true ]; then
     # a silent skip rather than a failure.
     export COMPAT_STRICT_SKIPS=1
 
+    # Deliberately serial, whatever --parallel said. The compat fixtures are
+    # session-scoped around a single reference server on a fixed port, and each
+    # worker would FLUSHALL the others' data out from under them.
     PHASE2_ARGS=("$SCRIPT_DIR/tests/compat" -rs)
     if [ -n "$TEST_PATTERN" ]; then
         PHASE2_ARGS+=(-k "$TEST_PATTERN")

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,10 @@ RUN_COMPAT=false
 PARALLEL_WORKERS="${PARALLEL_WORKERS:-0}"
 
 is_valid_parallel_workers() {
-    [ "$1" = "auto" ] || [ "$1" = "logical" ] || [[ "$1" =~ ^[0-9]+$ ]]
+    # An explicit count must fit within the 100 port bands tests/parallel_ports.py
+    # hands out (MAX_WORKERS); a higher xdist worker index has no port band and
+    # crashes at collection time.
+    [ "$1" = "auto" ] || [ "$1" = "logical" ] || { [[ "$1" =~ ^[0-9]+$ ]] && [ "$1" -le 100 ]; }
 }
 
 POSITIONAL=""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ requires-python=">=3.11,<3.12"
 keywords = ["timeseries", "gorilla", "compression"]
 dependencies = [
     "valkey",
-    "pytest==6.2.5",
+    "pytest==7.4.3",
+    "pytest-xdist>=3.5.0",
     "pytest-html",
     "PyYAML",
     "hypothesis",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 valkey
 pytest==7.4.3
+# Parallel integration test execution (see docs/plans/parallel-integration-tests-plan.md).
+# Serial runs are unaffected: without -n the plugin is inert.
+pytest-xdist>=3.5.0
 PyYAML
 # Compat suite only: PyYAML powers the divergence registry (tests/compat), and
 # hypothesis drives the opt-in differential fuzzer (tests/compat/test_compat_fuzz.py,

--- a/tests/common.py
+++ b/tests/common.py
@@ -21,7 +21,10 @@ SERVER_PATH = f"{os.path.dirname(os.path.realpath(__file__))}/build/binaries/{SE
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 SERVER_VERSION = os.environ.get("SERVER_VERSION", "unstable")
 VALKEY_SERVER_PATH = f"{SCRIPT_DIR}/build/binaries/{SERVER_VERSION}/valkey-server"
-TEST_DIR = f"{ROOT_PATH}/test-data"
+# TEST_DIR is overridable so that each pytest-xdist worker can be given its own
+# directory (tests/conftest.py sets it before this module is imported). Serial runs
+# see the unsuffixed default and are unaffected.
+TEST_DIR = os.environ.get("TEST_DIR") or f"{ROOT_PATH}/test-data"
 LOGS_DIR = f"{TEST_DIR}/logs"
 
 if "VALKEY_SERVER_PATH" in os.environ:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,96 @@
-import sys
+"""Integration-suite conftest.
+
+Two jobs:
+
+1. Put the vendored valkey-test-framework on ``sys.path`` (it lives under
+   ``tests/build/`` and is cloned by ``build.sh``).
+2. Make the suite safe to run under ``pytest-xdist``. See
+   ``docs/plans/parallel-integration-tests-plan.md``.
+
+The parallel-safety work is entirely inert when xdist is not in use: with no
+``PYTEST_XDIST_WORKER`` in the environment everything below resolves to a single
+"master" worker that owns the whole port band and the unsuffixed test directory,
+so a serial run behaves as it always has.
+"""
+
 import os
+import sys
+
+import pytest
 
 # Set the path to find and use the valkey-test-framework
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), 'build')))
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), 'build/valkeytestframework')))
+
+
+# ---------------------------------------------------------------------------
+# per-worker filesystem isolation
+# ---------------------------------------------------------------------------
+#
+# Server artifacts are already named by port (logfile_<port>, testrdb-<port>.rdb)
+# or by test name, so they do not collide across workers once ports are disjoint.
+# Giving each worker its own directory anyway keeps one worker's logs together,
+# which matters a great deal when triaging a failure out of interleaved output.
+#
+# This must happen before `common` is imported by any test module, which is why it
+# lives at conftest import time rather than in a fixture.
+
+_WORKER_ID = os.environ.get("PYTEST_XDIST_WORKER")
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_ROOT_DIR = os.path.dirname(_TESTS_DIR)
+
+if _WORKER_ID:
+    _base_test_dir = os.environ.get("TEST_DIR") or os.path.join(_ROOT_DIR, "test-data")
+    if os.path.basename(os.path.normpath(_base_test_dir)) != _WORKER_ID:
+        _worker_test_dir = os.path.join(_base_test_dir, _WORKER_ID)
+        os.makedirs(_worker_test_dir, exist_ok=True)
+        os.environ["TEST_DIR"] = _worker_test_dir
+        # common.py derives LOGS_DIR from TEST_DIR unless it is set explicitly;
+        # keep an explicit LOGS_DIR consistent with the worker directory too.
+        _base_logs_dir = os.environ.get("LOGS_DIR")
+        if _base_logs_dir and os.path.basename(os.path.normpath(_base_logs_dir)) != _WORKER_ID:
+            _worker_logs_dir = os.path.join(_base_logs_dir, _WORKER_ID)
+            os.makedirs(_worker_logs_dir, exist_ok=True)
+            os.environ["LOGS_DIR"] = _worker_logs_dir
+
+
+from parallel_ports import SafePortTracker  # noqa: E402  (needs sys.path above)
+
+
+# ---------------------------------------------------------------------------
+# collision-free ports
+# ---------------------------------------------------------------------------
+#
+# The tracker itself lives in tests/parallel_ports.py; see the note there on why it
+# is not defined in this file.
+
+
+@pytest.fixture(scope="function", autouse=True)
+def resource_port_tracker(request):
+    """Per-test port tracker.
+
+    Test modules import this name from ``valkeytestframework.conftest`` directly,
+    so the definition there is replaced as well (below) rather than relying on
+    this one shadowing it.
+    """
+    with SafePortTracker(request.node.nodeid) as tracker:
+        yield tracker
+
+
+# Replace the framework's tracker in place. `resource_port_tracker` there looks
+# `PortTracker` up in its own module globals when the fixture runs, so rebinding the
+# attribute is enough to redirect every existing caller.
+#
+# The framework is vendored, so this is patched rather than fixed upstream; when the
+# banded tracker lands in valkey-test-framework this block goes away.
+try:
+    import valkeytestframework.conftest as _fw_conftest
+
+    _fw_conftest.PortTracker = SafePortTracker
+    _fw_conftest.resource_port_tracker = resource_port_tracker
+except (ImportError, AttributeError) as exc:  # pragma: no cover - broken checkout
+    raise RuntimeError(
+        "could not patch valkeytestframework.conftest.PortTracker; tests would "
+        "allocate ports from the unsafe framework tracker"
+    ) from exc

--- a/tests/parallel_ports.py
+++ b/tests/parallel_ports.py
@@ -1,0 +1,163 @@
+"""Collision-free port allocation for parallel integration runs.
+
+Lives in its own module rather than in ``conftest.py`` because three importable
+``conftest`` modules sit on ``sys.path`` during a run (this suite's, and one in each
+copy of the vendored framework), so ``from conftest import ...`` does not reliably
+name this one.
+
+See docs/plans/parallel-integration-tests-plan.md.
+"""
+
+import fcntl
+import os
+import socket
+import tempfile
+
+
+class SafePortTracker(object):
+    """Hand out ports that no other worker or process will take.
+
+    Replaces the valkey-test-framework ``PortTracker``, which walks a hash chain
+    over one shared range and *unlinks* its lock files on release. Two weaknesses
+    matter once tests run concurrently:
+
+      * unlinking means two processes can hold ``flock`` on two different inodes
+        that share one path, so the lock stops excluding anything;
+      * the bind probe closes its socket before valkey-server binds, leaving a
+        window in which another worker can win the same port.
+
+    Both are addressed here. Each xdist worker owns a disjoint band, so the common
+    case never contends at all; the file locks remain as a guard against processes
+    outside this suite, and are held (never unlinked) for the life of the fixture.
+
+    Port layout, kept below the Linux ephemeral floor of 32768:
+
+        client ports   10000 + 100 * worker_idx, 100 per worker  -> [10000, 19999]
+        cluster bus    client port + 10000                       -> [20000, 29999]
+
+    A serial run is not under xdist and owns the entire client band rather than a
+    100-port slice, so it has as much room as it ever had.
+    """
+
+    CLUSTER_BUS_PORT_OFFSET = 10000
+
+    BASE_PORT = 10000
+    PORTS_PER_WORKER = 100
+    MAX_WORKERS = 100
+
+    LOCKS_DIR = os.path.join(
+        tempfile.gettempdir(),
+        "valkey_ts_port_locks_%d" % (os.getuid() if hasattr(os, "getuid") else 0),
+    )
+
+    # Monotonic, per-process. Cycling rather than restarting at the band's base
+    # keeps consecutive tests on one worker off a port whose previous socket is
+    # still in TIME_WAIT.
+    _port_offset = 0
+
+    def __init__(self, node_id=None):
+        self.node_id = node_id
+        os.makedirs(self.LOCKS_DIR, exist_ok=True)
+        self.locked_fds = {}
+
+        worker = os.environ.get("PYTEST_XDIST_WORKER", "master")
+        if worker.startswith("gw"):
+            try:
+                self.worker_idx = int(worker[2:])
+            except ValueError:
+                self.worker_idx = 0
+            if self.worker_idx >= self.MAX_WORKERS:
+                raise RuntimeError(
+                    "xdist worker index %d exceeds the %d supported by the port "
+                    "bands in tests/conftest.py" % (self.worker_idx, self.MAX_WORKERS)
+                )
+            self.band_start = self.BASE_PORT + self.worker_idx * self.PORTS_PER_WORKER
+            self.band_size = self.PORTS_PER_WORKER
+        else:
+            # Not under xdist: no one to collide with, so take the whole band.
+            self.worker_idx = 0
+            self.band_start = self.BASE_PORT
+            self.band_size = self.PORTS_PER_WORKER * self.MAX_WORKERS
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for fd in list(self.locked_fds.values()):
+            self._unlock_fd(fd)
+        self.locked_fds.clear()
+
+    @staticmethod
+    def _unlock_fd(fd):
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+    def _try_lock_port(self, port):
+        """Return an open, flocked fd for `port`, or None if it is unavailable.
+
+        The lock file is deliberately never removed: an unlinked lock file lets a
+        second process create a fresh inode at the same path and lock that
+        instead, which excludes nobody.
+        """
+        lock_path = os.path.join(self.LOCKS_DIR, "port_%d.lock" % port)
+        fd = None
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o666)
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (OSError, BlockingIOError):
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            return None
+
+        # The lock only excludes other users of this tracker. Something outside the
+        # suite may hold the port, so confirm it can actually be bound.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind(("0.0.0.0", port))
+            except OSError:
+                self._unlock_fd(fd)
+                return None
+
+        return fd
+
+    def get_unused_port(self):
+        """Reserve a client port together with its cluster-bus port."""
+        for _ in range(self.band_size):
+            candidate = self.band_start + (SafePortTracker._port_offset % self.band_size)
+            SafePortTracker._port_offset += 1
+
+            wanted = (candidate, candidate + self.CLUSTER_BUS_PORT_OFFSET)
+            acquired = {}
+            for port in wanted:
+                fd = self._try_lock_port(port)
+                if fd is None:
+                    break
+                acquired[port] = fd
+            else:
+                self.locked_fds.update(acquired)
+                return candidate
+
+            # Partial acquisition: release before trying the next candidate, or the
+            # band leaks a lock per failed attempt.
+            for fd in acquired.values():
+                self._unlock_fd(fd)
+
+        raise RuntimeError(
+            "no free port in band [%d, %d) for worker %d after %d attempts"
+            % (
+                self.band_start,
+                self.band_start + self.band_size,
+                self.worker_idx,
+                self.band_size,
+            )
+        )

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
 
-# Sometimes processes are left running when test is cancelled.
-# Therefore, before build start, we kill all running test processes left from previous test run.
-echo "Kill old running test"
-pkill -9 -x Pytest || true
-pkill -9 -f "valkey-server.*:" || true
-pkill -9 -f Valgrind || true
-pkill -9 -f "valkey-benchmark" || true
+# A cancelled run can leave servers behind, so clean up before starting -- but only
+# our own. The previous version killed every valkey-server and every pytest on the
+# host, which is antisocial on a shared machine and fatal when two runs overlap.
+#
+# The match is on the module every server in this suite loads. Matching the
+# test-data path instead would miss the standalone tests, whose servers are started
+# with a relative logfile and a cwd, so their command line never mentions it.
+kill_our_servers() {
+  pkill -9 -f "valkey-server.*libvalkey_timeseries" 2>/dev/null || true
+}
+
+echo "Killing servers left over from a previous run of this suite"
+kill_our_servers
+
+# A cancelled run must not leave servers holding their ports.
+trap kill_our_servers EXIT INT TERM
 
 os_type=$(uname)
 MODULE_EXT=".so"
@@ -19,6 +28,71 @@ elif [[ "$os_type" == "Windows" ]]; then
 else
   echo "Unsupported OS type: $os_type"
   exit 1
+fi
+
+# Serial unless asked otherwise; see docs/plans/parallel-integration-tests-plan.md.
+PARALLEL_WORKERS="${PARALLEL_WORKERS:-0}"
+
+is_valid_parallel_workers() {
+  [ "$1" = "auto" ] || [ "$1" = "logical" ] || [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+PASSTHRU=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --parallel|-j)
+      shift
+      if [ "$#" -gt 0 ] && [[ "$1" != -* ]] && is_valid_parallel_workers "$1"; then
+        PARALLEL_WORKERS="$1"
+        shift
+      else
+        PARALLEL_WORKERS="auto"
+      fi
+      ;;
+    --parallel=*|-j=*)
+      PARALLEL_WORKERS="${1#*=}"
+      shift
+      if ! is_valid_parallel_workers "$PARALLEL_WORKERS"; then
+        echo "ERROR: invalid worker count '$PARALLEL_WORKERS'; expected auto, logical or an integer." >&2
+        exit 2
+      fi
+      ;;
+    *)
+      PASSTHRU+=("$1")
+      shift
+      ;;
+  esac
+done
+set -- "${PASSTHRU[@]+"${PASSTHRU[@]}"}"
+
+if ! is_valid_parallel_workers "$PARALLEL_WORKERS"; then
+  echo "ERROR: invalid PARALLEL_WORKERS='$PARALLEL_WORKERS'; expected auto, logical or an integer." >&2
+  exit 2
+fi
+
+resolve_workers() {
+  if [ "$1" = "auto" ] || [ "$1" = "logical" ]; then
+    local cores
+    if [ "$(uname)" = "Darwin" ]; then
+      cores=$(sysctl -n hw.ncpu)
+    else
+      cores=$(nproc)
+    fi
+    [ "$cores" -gt 32 ] && cores=32
+    [ "$cores" -lt 1 ] && cores=1
+    echo "$cores"
+  else
+    echo "$1"
+  fi
+}
+
+XDIST_ARGS=()
+RESOLVED_WORKERS=$(resolve_workers "$PARALLEL_WORKERS")
+if [ "$RESOLVED_WORKERS" -gt 1 ]; then
+  # loadscope: several classes keep per-class state under test-data/, so a class
+  # must not be split across workers.
+  XDIST_ARGS=(-n "$RESOLVED_WORKERS" --dist=loadscope)
+  echo "Running integration tests across $RESOLVED_WORKERS workers"
 fi
 
 BUILD=${BUILD:-debug}
@@ -90,8 +164,9 @@ if [[ ! -z "${TEST_PATTERN}" ]] ; then
     export TEST_PATTERN="-k ${TEST_PATTERN}"
 fi
 
+PYTEST_ARGS=(--cache-clear -vvv ${TEST_FLAG:-} "${XDIST_ARGS[@]+"${XDIST_ARGS[@]}"}" ./)
 if [[ ! -z "${TEST_PATTERN}" ]] ; then
-    python -m pytest --cache-clear -vvv ${TEST_FLAG} ./ ${TEST_PATTERN}
+    python -m pytest "${PYTEST_ARGS[@]}" ${TEST_PATTERN}
 else
-    python -m pytest --cache-clear -vvv ${TEST_FLAG} ./
+    python -m pytest "${PYTEST_ARGS[@]}"
 fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,22 +1,5 @@
 #!/usr/bin/env bash
 
-# A cancelled run can leave servers behind, so clean up before starting -- but only
-# our own. The previous version killed every valkey-server and every pytest on the
-# host, which is antisocial on a shared machine and fatal when two runs overlap.
-#
-# The match is on the module every server in this suite loads. Matching the
-# test-data path instead would miss the standalone tests, whose servers are started
-# with a relative logfile and a cwd, so their command line never mentions it.
-kill_our_servers() {
-  pkill -9 -f "valkey-server.*libvalkey_timeseries" 2>/dev/null || true
-}
-
-echo "Killing servers left over from a previous run of this suite"
-kill_our_servers
-
-# A cancelled run must not leave servers holding their ports.
-trap kill_our_servers EXIT INT TERM
-
 os_type=$(uname)
 MODULE_EXT=".so"
 if [[ "$os_type" == "Darwin" ]]; then
@@ -30,11 +13,39 @@ else
   exit 1
 fi
 
+BUILD=${BUILD:-debug}
+PROGNAME="${BASH_SOURCE[0]}"
+CWD="$(cd "$(dirname "$PROGNAME")" &>/dev/null && pwd)"
+ROOT=$(cd "$CWD/.." && pwd)
+export MODULE_PATH="$ROOT/target/$BUILD/libvalkey_timeseries${MODULE_EXT}"
+
+# A cancelled run can leave servers behind, so clean up before starting -- but only
+# our own. The previous version killed every valkey-server and every pytest on the
+# host, which is antisocial on a shared machine and fatal when two runs overlap.
+#
+# The match is on this checkout's module path (not just the module's basename),
+# so a concurrent run from a different checkout or worktree is never touched.
+# Matching the test-data path instead would miss the standalone tests, whose
+# servers are started with a relative logfile and a cwd, so their command line
+# never mentions it.
+kill_our_servers() {
+  pkill -9 -f "valkey-server.*${MODULE_PATH}" 2>/dev/null || true
+}
+
+echo "Killing servers left over from a previous run of this suite"
+kill_our_servers
+
+# A cancelled run must not leave servers holding their ports.
+trap kill_our_servers EXIT INT TERM
+
 # Serial unless asked otherwise; see docs/plans/parallel-integration-tests-plan.md.
 PARALLEL_WORKERS="${PARALLEL_WORKERS:-0}"
 
 is_valid_parallel_workers() {
-  [ "$1" = "auto" ] || [ "$1" = "logical" ] || [[ "$1" =~ ^[0-9]+$ ]]
+  # An explicit count must fit within the 100 port bands tests/parallel_ports.py
+  # hands out (MAX_WORKERS); a higher xdist worker index has no port band and
+  # crashes at collection time.
+  [ "$1" = "auto" ] || [ "$1" = "logical" ] || { [[ "$1" =~ ^[0-9]+$ ]] && [ "$1" -le 100 ]; }
 }
 
 PASSTHRU=()
@@ -95,20 +106,13 @@ if [ "$RESOLVED_WORKERS" -gt 1 ]; then
   echo "Running integration tests across $RESOLVED_WORKERS workers"
 fi
 
-BUILD=${BUILD:-debug}
 # If environment variable SERVER_VERSION is not set, default to "unstable"
 if [ -z "$SERVER_VERSION" ]; then
     echo "SERVER_VERSION environment variable is not set. Defaulting to \"unstable\"."
     export SERVER_VERSION="unstable"
 fi
-PROGNAME="${BASH_SOURCE[0]}"
-CWD="$(cd "$(dirname "$PROGNAME")" &>/dev/null && pwd)"
 BINARY_PATH="$CWD/build/binaries/$SERVER_VERSION/valkey-server"
 PORT=${PORT:-6379}
-ROOT=$(cd $CWD/.. && pwd)
-
-export MODULE_PATH="$ROOT/target/$BUILD/libvalkey_timeseries${MODULE_EXT}"
-
 
 REPO_URL="https://github.com/valkey-io/valkey.git"
 

--- a/tests/test_parallel_harness.py
+++ b/tests/test_parallel_harness.py
@@ -1,0 +1,128 @@
+"""Guards for the parallel-execution harness (docs/plans/parallel-integration-tests-plan.md).
+
+None of this starts a server; it checks the invariants that make it safe for several
+pytest-xdist workers to share a machine. They are worth asserting because every one of
+them fails *silently* — as a flaky test somewhere else, hours later — rather than at the
+point of breakage.
+"""
+
+import os
+
+import pytest
+
+# Imported from its own module, not from conftest: several importable modules
+# are named "conftest" during a run.
+from parallel_ports import SafePortTracker
+
+
+def test_framework_port_tracker_is_patched():
+    """The framework's tracker must be replaced, not merely shadowed.
+
+    Test modules do `from valkeytestframework.conftest import resource_port_tracker`,
+    so a fixture defined only in our conftest would be bypassed. The patch in
+    tests/conftest.py rebinds the framework's own module attributes; if a future
+    refactor drops it, every worker goes back to allocating from one shared range.
+    """
+    import valkeytestframework.conftest as fw
+
+    assert fw.PortTracker is SafePortTracker
+
+
+def test_worker_bands_do_not_overlap(monkeypatch):
+    """Two workers must never be offered the same port, bus port included."""
+    bands = []
+    for idx in range(8):
+        monkeypatch.setenv("PYTEST_XDIST_WORKER", f"gw{idx}")
+        tracker = SafePortTracker(f"node-{idx}")
+        start = tracker.band_start
+        bands.append(range(start, start + tracker.band_size))
+
+    for i, first in enumerate(bands):
+        for second in bands[i + 1:]:
+            assert not (
+                first.start < second.stop and second.start < first.stop
+            ), f"client bands overlap: {first} and {second}"
+
+            bus_first = range(
+                first.start + SafePortTracker.CLUSTER_BUS_PORT_OFFSET,
+                first.stop + SafePortTracker.CLUSTER_BUS_PORT_OFFSET,
+            )
+            bus_second = range(
+                second.start + SafePortTracker.CLUSTER_BUS_PORT_OFFSET,
+                second.stop + SafePortTracker.CLUSTER_BUS_PORT_OFFSET,
+            )
+            assert not (bus_first.start < bus_second.stop and bus_second.start < bus_first.stop)
+
+
+def test_client_and_bus_bands_do_not_collide():
+    """The bus band sits above every client port, and both stay out of the
+    ephemeral range (Linux starts at 32768)."""
+    highest_client = SafePortTracker.BASE_PORT + (
+        SafePortTracker.PORTS_PER_WORKER * SafePortTracker.MAX_WORKERS
+    )
+    assert SafePortTracker.CLUSTER_BUS_PORT_OFFSET >= (
+        highest_client - SafePortTracker.BASE_PORT
+    )
+    assert highest_client + SafePortTracker.CLUSTER_BUS_PORT_OFFSET <= 32768
+
+
+def test_allocated_port_is_in_band_and_reserves_bus_port(monkeypatch):
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+    with SafePortTracker("node") as tracker:
+        port = tracker.get_unused_port()
+        assert tracker.band_start <= port < tracker.band_start + tracker.band_size
+        # Both the client port and its cluster-bus partner must be held, or a
+        # cluster test will lose its bus port to another test.
+        assert port in tracker.locked_fds
+        assert port + SafePortTracker.CLUSTER_BUS_PORT_OFFSET in tracker.locked_fds
+
+
+def test_ports_are_not_immediately_reused(monkeypatch):
+    """Consecutive allocations must advance, so a socket still in TIME_WAIT is not
+    handed straight back out."""
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw4")
+    with SafePortTracker("node") as tracker:
+        first = tracker.get_unused_port()
+        second = tracker.get_unused_port()
+    assert first != second
+
+
+def test_lock_files_survive_release(monkeypatch):
+    """Lock files must not be unlinked on release.
+
+    Removing them lets a second process create a new inode at the same path and lock
+    that instead, so the lock excludes nobody. This is the bug in the framework's
+    tracker that the parallel work exists to avoid.
+    """
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw5")
+    with SafePortTracker("node") as tracker:
+        port = tracker.get_unused_port()
+    lock_path = os.path.join(SafePortTracker.LOCKS_DIR, "port_%d.lock" % port)
+    assert os.path.exists(lock_path)
+
+
+def test_serial_run_owns_the_whole_band(monkeypatch):
+    """Without xdist there is nobody to partition against, so a serial run should
+    have at least as much room as it had before this change."""
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    tracker = SafePortTracker("node")
+    assert tracker.band_start == SafePortTracker.BASE_PORT
+    assert tracker.band_size == SafePortTracker.PORTS_PER_WORKER * SafePortTracker.MAX_WORKERS
+
+
+def test_worker_index_beyond_the_bands_is_rejected(monkeypatch):
+    """Better a clear error than two workers quietly sharing a band."""
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", f"gw{SafePortTracker.MAX_WORKERS}")
+    with pytest.raises(RuntimeError, match="exceeds"):
+        SafePortTracker("node")
+
+
+def test_test_dir_is_worker_scoped():
+    """Under xdist, TEST_DIR must name the worker; serially it must not."""
+    from common import TEST_DIR
+
+    worker = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker:
+        assert os.path.basename(os.path.normpath(TEST_DIR)) == worker
+    else:
+        assert os.path.basename(os.path.normpath(TEST_DIR)) == "test-data"

--- a/tests/valkey_timeseries_test_case.py
+++ b/tests/valkey_timeseries_test_case.py
@@ -521,7 +521,17 @@ class ValkeyTimeSeriesClusterTestCase(ValkeyTimeSeriesTestCaseCommon):
                     is_primary=True,
                 )
 
-                replicas = []
+                primary_node = Node(
+                    server=server,
+                    client=client,
+                    logfile=logfile,
+                )
+                # Append the group as soon as the primary is up so the finally
+                # block's cleanup can find (and kill) it even if a later replica
+                # in this group fails to start.
+                rg = ReplicationGroup(primary=primary_node, replicas=[])
+                self.replication_groups.append(rg)
+
                 for _ in range(0, replica_count):
                     # Start the replicas
                     i = i + 1
@@ -535,21 +545,13 @@ class ValkeyTimeSeriesClusterTestCase(ValkeyTimeSeriesTestCaseCommon):
                             is_primary=False,
                         )
                     )
-                    replicas.append(
+                    rg.replicas.append(
                         Node(
                             server=replica_server,
                             client=replica_client,
                             logfile=replica_logfile,
                         )
                     )
-
-                primary_node = Node(
-                    server=server,
-                    client=client,
-                    logfile=logfile,
-                )
-                rg = ReplicationGroup(primary=primary_node, replicas=replicas)
-                self.replication_groups.append(rg)
 
             for rg in self.replication_groups:
                 self.nodes.append(rg.primary)

--- a/tests/valkey_timeseries_test_case.py
+++ b/tests/valkey_timeseries_test_case.py
@@ -180,8 +180,22 @@ class ReplicationGroup:
         for replica in rg.replicas:
             kill_node(replica)
 
+# Cluster formation (MEET plus gossip convergence) is the most load-sensitive wait in
+# the suite: with several workers each starting a 3-node cluster, ten seconds is not
+# always enough on a busy machine. Overridable so a slow runner can be accommodated
+# without editing tests.
+CLUSTER_MEET_TIMEOUT_SECONDS = int(os.environ.get("CLUSTER_MEET_TIMEOUT", "60"))
+
+
 class ValkeyTimeSeriesTestCaseCommon(ValkeyTestCase):
     """Common base class for the various Search test cases"""
+
+    # The framework defaults this to the relative path "test-data", which resolves
+    # against the process cwd and is therefore shared by every worker -- and moves
+    # under the cluster tests, which chdir while starting nodes. TEST_DIR is absolute
+    # and already carries the worker suffix (tests/conftest.py), so tests that build
+    # paths from self.testdir get worker isolation without knowing about it.
+    testdir = TEST_DIR
 
     def resolve_module_path(self) -> str:
         """Resolve and validate the module path used by test servers."""
@@ -439,26 +453,30 @@ class ValkeyTimeSeriesClusterTestCase(ValkeyTimeSeriesTestCaseCommon):
 
         os.makedirs(testdir, exist_ok=True)
         curdir = os.getcwd()
-        os.chdir(testdir)
-        lines = self.get_config_file_lines(testdir, port)
+        # The chdir must be undone even when a node fails to start: the process cwd
+        # is shared by every later test in this worker, and leaving it inside a
+        # torn-down test directory breaks all of them, not just this one.
+        try:
+            os.chdir(testdir)
+            lines = self.get_config_file_lines(testdir, port)
 
-        conf_file = f"{testdir}/valkey_{port}.conf"
-        with open(conf_file, "w+") as f:
-            for line in lines:
-                f.write(f"{line}\n")
-            f.write("\n")
-            f.close()
+            conf_file = f"{testdir}/valkey_{port}.conf"
+            with open(conf_file, "w+") as f:
+                for line in lines:
+                    f.write(f"{line}\n")
+                f.write("\n")
 
-        role = "primary" if is_primary else "replica"
-        logfile = f"{testdir}/logfile-{role}-{port}.log"
-        server, client = self.create_server(
-            testdir=testdir,
-            server_path=server_path,
-            args={"logfile": logfile},
-            port=port,
-            conf_file=conf_file,
-        )
-        os.chdir(curdir)
+            role = "primary" if is_primary else "replica"
+            logfile = f"{testdir}/logfile-{role}-{port}.log"
+            server, client = self.create_server(
+                testdir=testdir,
+                server_path=server_path,
+                args={"logfile": logfile},
+                port=port,
+                conf_file=conf_file,
+            )
+        finally:
+            os.chdir(curdir)
         self.wait_for_logfile(logfile, "Ready to accept connections")
         # Verify each node loaded the exact module artifact requested for this test run.
         self.wait_for_logfile(logfile, f"Module 'ts' loaded from {module_path}")
@@ -467,106 +485,117 @@ class ValkeyTimeSeriesClusterTestCase(ValkeyTimeSeriesTestCaseCommon):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, request):
-        module_path = self.resolve_module_path()
-        replica_count = self.REPLICAS_COUNT
-        # Extract parameters from pytest's parametrize decorator
-        if hasattr(request.node, 'callspec') and 'setup_test' in request.node.callspec.params:
-            param_value = request.node.callspec.params['setup_test']
-            if isinstance(param_value, dict) and 'replica_count' in param_value:
-                replica_count = param_value['replica_count']
-
         self.replication_groups: list[ReplicationGroup] = list()
-        ports = []
-        for i in range(0, self.CLUSTER_SIZE):
-            ports.append(self.get_bind_port())
-            for _ in range(0, replica_count):
-                ports.append(self.get_bind_port())
-
-        test_name = self.normalize_dir_name(request.node.name)
-        testdir_base = f"{TEST_DIR}/{test_name}"
-
-        if os.path.exists(testdir_base):
-            shutil.rmtree(testdir_base)
-
-        for i in range(0, len(ports), replica_count + 1):
-            primary_port = ports[i]
-            server, client, logfile = self.start_server(
-                primary_port,
-                test_name,
-                module_path,
-                True,
-                is_primary=True,
-            )
-
-            replicas = []
-            for _ in range(0, replica_count):
-                # Start the replicas
-                i = i + 1
-                replica_port = ports[i]
-                replica_server, replica_client, replica_logfile = (
-                    self.start_server(
-                        replica_port,
-                        test_name,
-                        module_path,
-                        cluster_enabled=True,
-                        is_primary=False,
-                    )
-                )
-                replicas.append(
-                    Node(
-                        server=replica_server,
-                        client=replica_client,
-                        logfile=replica_logfile,
-                    )
-                )
-
-            primary_node = Node(
-                server=server,
-                client=client,
-                logfile=logfile,
-            )
-            rg = ReplicationGroup(primary=primary_node, replicas=replicas)
-            self.replication_groups.append(rg)
-
         self.nodes: List[Node] = list()
-        for rg in self.replication_groups:
-            self.nodes.append(rg.primary)
-            self.nodes += rg.replicas
+        # Every node started below must be torn down even if setup fails partway:
+        # a half-built cluster otherwise leaves servers holding their ports for the
+        # rest of the session, which strands every later test that lands on them.
+        try:
+            module_path = self.resolve_module_path()
+            replica_count = self.REPLICAS_COUNT
+            # Extract parameters from pytest's parametrize decorator
+            if hasattr(request.node, 'callspec') and 'setup_test' in request.node.callspec.params:
+                param_value = request.node.callspec.params['setup_test']
+                if isinstance(param_value, dict) and 'replica_count' in param_value:
+                    replica_count = param_value['replica_count']
 
-        # Split the slots
-        ranges = self._split_range_pairs(0, 16384, self.CLUSTER_SIZE)
-        node_idx = 0
-        for start, end in ranges:
-            self.add_slots(node_idx, start, end)
-            node_idx = node_idx + 1
+            ports = []
+            for i in range(0, self.CLUSTER_SIZE):
+                ports.append(self.get_bind_port())
+                for _ in range(0, replica_count):
+                    ports.append(self.get_bind_port())
 
-        # Perform cluster meet
-        for node_idx in range(0, self.CLUSTER_SIZE):
-            self.cluster_meet(node_idx, self.CLUSTER_SIZE)
+            test_name = self.normalize_dir_name(request.node.name)
+            testdir_base = f"{TEST_DIR}/{test_name}"
 
-        waiters.wait_for_equal(
-            lambda: self._wait_for_meet(
-                self.CLUSTER_SIZE + (self.CLUSTER_SIZE * replica_count)
-            ),
-            True,
-            timeout=10,
-        )
+            if os.path.exists(testdir_base):
+                shutil.rmtree(testdir_base)
 
-        # Wait for the cluster to be up
-        for rg in self.replication_groups:
-            logging.info(
-                f"Waiting for cluster to change state...{rg.primary.logfile}"
+            for i in range(0, len(ports), replica_count + 1):
+                primary_port = ports[i]
+                server, client, logfile = self.start_server(
+                    primary_port,
+                    test_name,
+                    module_path,
+                    True,
+                    is_primary=True,
+                )
+
+                replicas = []
+                for _ in range(0, replica_count):
+                    # Start the replicas
+                    i = i + 1
+                    replica_port = ports[i]
+                    replica_server, replica_client, replica_logfile = (
+                        self.start_server(
+                            replica_port,
+                            test_name,
+                            module_path,
+                            cluster_enabled=True,
+                            is_primary=False,
+                        )
+                    )
+                    replicas.append(
+                        Node(
+                            server=replica_server,
+                            client=replica_client,
+                            logfile=replica_logfile,
+                        )
+                    )
+
+                primary_node = Node(
+                    server=server,
+                    client=client,
+                    logfile=logfile,
+                )
+                rg = ReplicationGroup(primary=primary_node, replicas=replicas)
+                self.replication_groups.append(rg)
+
+            for rg in self.replication_groups:
+                self.nodes.append(rg.primary)
+                self.nodes += rg.replicas
+
+            # Split the slots
+            ranges = self._split_range_pairs(0, 16384, self.CLUSTER_SIZE)
+            node_idx = 0
+            for start, end in ranges:
+                self.add_slots(node_idx, start, end)
+                node_idx = node_idx + 1
+
+            # Perform cluster meet
+            for node_idx in range(0, self.CLUSTER_SIZE):
+                self.cluster_meet(node_idx, self.CLUSTER_SIZE)
+
+            waiters.wait_for_equal(
+                lambda: self._wait_for_meet(
+                    self.CLUSTER_SIZE + (self.CLUSTER_SIZE * replica_count)
+                ),
+                True,
+                timeout=CLUSTER_MEET_TIMEOUT_SECONDS,
             )
-            self.wait_for_logfile(
-                rg.primary.logfile, "Cluster state changed: ok"
-            )
-            rg.setup_replications_cluster()
-        logging.info("Cluster is up and running!")
-        yield
 
-        # Cleanup
-        for rg in self.replication_groups:
-            ReplicationGroup.cleanup(rg)
+            # Wait for the cluster to be up
+            for rg in self.replication_groups:
+                logging.info(
+                    f"Waiting for cluster to change state...{rg.primary.logfile}"
+                )
+                self.wait_for_logfile(
+                    rg.primary.logfile, "Cluster state changed: ok"
+                )
+                rg.setup_replications_cluster()
+            logging.info("Cluster is up and running!")
+            yield
+        finally:
+            cleanup_error = None
+            for rg in self.replication_groups:
+                try:
+                    ReplicationGroup.cleanup(rg)
+                except Exception as e:  # keep tearing down the remaining groups
+                    logging.error("Error during ReplicationGroup.cleanup: %s", e)
+                    if cleanup_error is None:
+                        cleanup_error = e
+            if cleanup_error is not None:
+                raise cleanup_error
 
     def get_config_file_lines(self, test_dir, port) -> List[str]:
         module_path = self.resolve_module_path()

--- a/uv.lock
+++ b/uv.lock
@@ -12,27 +12,21 @@ wheels = [
 ]
 
 [[package]]
-name = "atomicwrites"
-version = "1.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/c6/53da25344e3e3a9c01095a89f16dbcda021c609ddb42dd6d7c0528236fb2/atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11", size = 14227 }
-
-[[package]]
-name = "attrs"
-version = "25.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815 },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708 },
 ]
 
 [[package]]
@@ -105,21 +99,17 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "6.2.5"
+version = "7.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "atomicwrites", marker = "sys_platform == 'win32'" },
-    { name = "attrs" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
-    { name = "py" },
-    { name = "toml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/24/7d1f2d2537de114bdf1e6875115113ca80091520948d370c964b88070af2/pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89", size = 1118720 }
+sdist = { url = "https://files.pythonhosted.org/packages/38/d4/174f020da50c5afe9f5963ad0fc5b56a4287e3586e3de5b3c8bce9c547b4/pytest-7.4.3.tar.gz", hash = "sha256:d989d136982de4e3b29dabcc838ad581c64e8ed52c11fbe86ddebd9da0818cd5", size = 1356179 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/76/86f886e750b81a4357b6ed606b2bcf0ce6d6c27ad3c09ebf63ed674fc86e/pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134", size = 280654 },
+    { url = "https://files.pythonhosted.org/packages/f3/8c/f16efd81ca8e293b2cc78f111190a79ee539d0d5d36ccd49975cb3beac60/pytest-7.4.3-py3-none-any.whl", hash = "sha256:0d009c083ea859a71b76adf7c1d502e4bc170b80a8ef002da5806527b9591fac", size = 325075 },
 ]
 
 [[package]]
@@ -149,6 +139,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396 },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -175,15 +178,6 @@ wheels = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588 },
-]
-
-[[package]]
 name = "valkey"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -203,6 +197,7 @@ dependencies = [
     { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-html" },
+    { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "sortedcontainers" },
     { name = "valkey" },
@@ -211,8 +206,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "hypothesis" },
-    { name = "pytest", specifier = "==6.2.5" },
+    { name = "pytest", specifier = "==7.4.3" },
     { name = "pytest-html" },
+    { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "pyyaml" },
     { name = "sortedcontainers" },
     { name = "valkey" },


### PR DESCRIPTION
This pull request introduces parallel integration test execution using `pytest-xdist`, with robust isolation for test data and ports to prevent collisions. It also updates documentation and CI to support and describe these changes, and improves argument handling in `build.sh` for easier usage. The most important changes are grouped below.

**Parallel Test Execution and Isolation:**

* Added support for running integration tests in parallel using `pytest-xdist`, with each worker assigned its own port range and `test-data/<worker>` directory to avoid conflicts. This is handled in `build.sh`, `tests/conftest.py`, and `tests/common.py`. [[1]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L35-R100) [[2]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R378-R380) [[3]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823R425-R427) [[4]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L1-R96) [[5]](diffhunk://#diff-53eb316ef7b18ba47acdd955cdaa7ca5467cd5ba6f5cf8ed92c68a421902d120L24-R27)
* Updated `pyproject.toml` to require `pytest-xdist` and bumped `pytest` to 7.4.3 for compatibility.

**User Interface and Documentation:**

* Enhanced `build.sh` to accept `--parallel[=N]`/`-j[=N]` options or the `PARALLEL_WORKERS` environment variable for controlling parallelism, with improved argument parsing and help output. The script defaults to serial execution unless parallelism is requested. [[1]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L5-R19) [[2]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L24-R34) [[3]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L35-R100)
* Updated `AGENTS.md` to document new parallel test options and environment variables, and clarified the behavior of the compatibility and ASAN test suites. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R42-R43) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R56-R64)

**Continuous Integration (CI):**

* Modified `.github/workflows/ci.yml` to run integration tests in parallel using `-n auto --dist=loadscope`, and added comments explaining parallel execution and serial requirements for certain jobs (e.g., ASAN and compatibility). Also updated `actions/checkout` to v5. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL21-R21) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR82-R89) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL97-R103) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL154-R160) [[5]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL180-R186) [[6]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR242-R247)

These changes enable faster, more reliable integration test runs and make it easier for developers to leverage parallelism safely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional parallel integration test execution with configurable worker counts.
  * Added automatic worker-specific test data, logs, and network port allocation to prevent conflicts.

* **Bug Fixes**
  * Improved test cleanup so only processes started by the test suite are terminated.
  * Improved cluster test cleanup and recovery when setup or execution fails.
  * Added configurable cluster startup timeouts.

* **Documentation**
  * Documented parallel test commands, worker configuration, and serial test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->