### PR TITLE
docs: update command documentation

### DIFF
--- a/docs/commands/ts.alter.md
+++ b/docs/commands/ts.alter.md
@@ -1,33 +1,78 @@
 # TS.ALTER
 
-alter a timeseries.
+Update the configuration and labels of an existing time series. `TS.ALTER`
+does not create a series and does not change its storage encoding.
+
+## Syntax
 
 ```
 TS.ALTER key
-  [RETENTION retentionPeriod]
+  [RETENTION duration]
   [CHUNK_SIZE chunkSize]
   [DUPLICATE_POLICY policy]
-  [DEDUPE_INTERVAL duplicateTimediff]
-  [[LABELS [label value ...] | METRIC metricName]
+  [METRIC metric | LABELS labelName labelValue ...]
+  [IGNORE ignoreMaxTimediff ignoreMaxValDiff]
+  [SIGNIFICANT_DIGITS significantDigits | DECIMAL_DIGITS decimalDigits]
 ```
-#### Options
-- **ENCODING**: The encoding to use for the timeseries: `CHIMP`, `GORILLA`, `UNCOMPRESSED`, or
-  `COMPRESSED` (an alias for the configured default compressed encoding). Default is `COMPRESSED`,
-  which resolves to `CHIMP` unless `ts-encoding` says otherwise.
-- **DUPLICATE_POLICY**: The policy to use for duplicate samples. Default is `BLOCK`.
 
-## Required arguments
+## Arguments
 
-<details open><summary><code>key</code></summary>
-is key name for the time series.
-</details>
+- `key` — Existing time-series key to alter.
+- `RETENTION duration` — Retention period in milliseconds. Duration expressions such as `1d` are also accepted; `0` disables retention.
+- `CHUNK_SIZE chunkSize` — Chunk size in bytes for future storage allocation.
+- `DUPLICATE_POLICY policy` — Policy for duplicate timestamps: `BLOCK`, `FIRST`, `LAST`, `MIN`, `MAX`, or `SUM`.
+- `METRIC metric` — Replace the series labels with the labels parsed from a Prometheus-style metric name.
+- `LABELS labelName labelValue ...` — Replace the complete label set. Provide no pairs to clear all labels.
+- `IGNORE ignoreMaxTimediff ignoreMaxValDiff` — Ignore incoming samples within both the time and value thresholds.
+- `SIGNIFICANT_DIGITS significantDigits` — Round values to 1–16 significant digits.
+- `DECIMAL_DIGITS decimalDigits` — Round values to 0–16 decimal places. `0` rounds to whole numbers.
 
-## Optional Arguments
-<details open><summary><code>retentionPeriod</code></summary>
-The period of time for which to keep series samples. Retention can be specified as an integer indication
-the duration as milliseconds, or a duration expression like `3wk`
-</details>
+`SIGNIFICANT_DIGITS` and `DECIMAL_DIGITS` are mutually exclusive. Options
+not included in the command remain unchanged. `ENCODING`, `ON_DUPLICATE`, and
+`DEDUPE_INTERVAL` are not supported by `TS.ALTER`.
 
-<details open><summary><code>chunkSize</code></summary>
-The chunk size for the timeseries, in bytes. Default is `4096`.
-</details>
+Changing `RETENTION` applies the new retention window immediately to existing
+samples. Changing labels updates the label index. Existing samples are not
+otherwise modified.
+
+## Return value
+
+Returns `OK` on success.
+
+## Errors
+
+- `ERR wrong number of arguments` — The key is missing.
+- A key-does-not-exist error — The key does not exist.
+- `WRONGTYPE` — The key exists but is not a time series.
+- `TSDB: invalid duration` — The retention duration cannot be parsed.
+- A chunk-size or rounding error — An option value is outside its valid range.
+- `TSDB: invalid duplicate policy` — The duplicate policy is unknown.
+- A label parsing error — Labels or a metric name are malformed.
+
+## Complexity
+
+O(1), excluding label-index maintenance when labels are changed.
+
+## ACL categories
+
+`@write`, `@fast`, `@timeseries`
+
+## Examples
+
+Change retention and duplicate policy:
+
+```
+TS.ALTER temperature RETENTION 7d DUPLICATE_POLICY LAST
+```
+
+Replace the labels:
+
+```
+TS.ALTER temperature LABELS sensor room1 location kitchen
+```
+
+Clear all labels and configure ignore thresholds:
+
+```
+TS.ALTER temperature LABELS IGNORE 5000 0.1
+```

--- a/docs/commands/ts.alter.md
+++ b/docs/commands/ts.alter.md
@@ -51,11 +51,15 @@ Returns `OK` on success.
 
 ## Complexity
 
-O(1), excluding label-index maintenance when labels are changed.
+O(1), excluding label-index maintenance when labels are changed and the
+retention trim that runs when `RETENTION` is tightened. That trim drops whole
+expired chunks and then rewrites the boundary chunk, so it is O(C + S), where
+C is the number of expired chunks and S is the number of samples in the first
+surviving chunk.
 
 ## ACL categories
 
-`@write`, `@fast`, `@timeseries`
+`@write`, `@timeseries`
 
 ## Examples
 

--- a/docs/commands/ts.decrby.md
+++ b/docs/commands/ts.decrby.md
@@ -1,2 +1,114 @@
 # TS.DECRBY
 
+Decrement the value of the latest sample in a time series, or create a new
+series when the key does not exist.
+
+## Syntax
+
+```
+TS.DECRBY key value
+  [TIMESTAMP timestamp]
+  [RETENTION duration]
+  [DUPLICATE_POLICY policy]
+  [ENCODING <COMPRESSED|UNCOMPRESSED>]
+  [CHUNK_SIZE chunkSize]
+  [METRIC metric | LABELS labelName labelValue ...]
+  [IGNORE ignoreMaxTimediff ignoreMaxValDiff]
+  [SIGNIFICANT_DIGITS significantDigits | DECIMAL_DIGITS decimalDigits]
+```
+
+## Required arguments
+
+| Argument | Description |
+| --- | --- |
+| `key` | Key name for the time series. |
+| `value` | Numeric decrement to apply to the latest sample. Negative values increment it. |
+
+## Optional arguments
+
+| Argument | Description | Default |
+| --- | --- | --- |
+| `TIMESTAMP timestamp` | Timestamp in milliseconds, or `*` for the current time. If omitted, an existing latest sample is updated at its timestamp; on a new series, the current time is used. | Existing latest timestamp or current time |
+| `RETENTION duration` | Retention period in milliseconds. Duration expressions such as `1d` are also accepted. | Module configuration |
+| `DUPLICATE_POLICY policy` | Policy used when creating the series: `BLOCK`, `FIRST`, `LAST`, `MIN`, `MAX`, or `SUM`. | `BLOCK` |
+| `ENCODING <COMPRESSED\|UNCOMPRESSED>` | Storage encoding for a newly created series. | `COMPRESSED` |
+| `CHUNK_SIZE chunkSize` | Chunk size in bytes for a newly created series. | `4096` |
+| `METRIC metric` | Prometheus-style metric name for a newly created series. |—|
+| `LABELS labelName labelValue ...` | Label name-value pairs for a newly created series. |—|
+| `IGNORE ignoreMaxTimediff ignoreMaxValDiff` | Ignore the update when it is within both the time and value thresholds. | No filtering |
+| `SIGNIFICANT_DIGITS significantDigits` | Round values to 1–16 significant digits. | No rounding |
+| `DECIMAL_DIGITS decimalDigits` | Round values to 0–16 decimal places. `0` rounds to whole numbers. | No rounding |
+
+`SIGNIFICANT_DIGITS` and `DECIMAL_DIGITS` are mutually exclusive. Creation
+options are used only when `TS.DECRBY` auto-creates the series; they do not
+alter an existing series.
+
+## Return value
+
+Returns the timestamp of the sample affected by the decrement as an integer.
+
+## Behavior
+
+- If the key does not exist, `TS.DECRBY` creates the series and stores the negative of `value` as its first sample.
+- If the key exists, the decrement is subtracted from its latest sample.
+- An explicit timestamp must be equal to or greater than the latest timestamp. A timestamp equal to the latest sample updates that sample in place; a later timestamp appends a new sample with the decremented value.
+- `TIMESTAMP *` uses the current server time. Without `TIMESTAMP`, an existing series updates its latest timestamp, while a new series uses the current server time.
+- A decrement cannot be applied when the latest sample is `NaN`; `NaN` is also invalid as the decrement value.
+- Retention and compaction rules are applied after a successful update.
+- Keyspace notifications use the `ts.decrby` event.
+
+## Examples
+
+### Basic decrement
+
+Create a series and subtract a value:
+
+```
+TS.DECRBY inventory 10
+```
+
+Decrement the latest value again:
+
+```
+TS.DECRBY inventory 5
+```
+
+If the initial value was `100`, the latest sample now has a value of `85`.
+
+### Decrement at an explicit timestamp
+
+```
+TS.DECRBY counter 25 TIMESTAMP 1609459200000
+TS.DECRBY counter 5 TIMESTAMP 1609459201000
+```
+
+The command returns the timestamp used for the updated or appended sample.
+
+### Create a series with options
+
+```
+TS.DECRBY temperature:room1 1.5 RETENTION 86400000 LABELS sensor_id 1 location living_room
+```
+
+### Apply rounding
+
+```
+TS.DECRBY measurement 1.23456 DECIMAL_DIGITS 2
+```
+
+## Errors
+
+- `ERR wrong number of arguments` — A required argument is missing.
+- `TSDB: invalid increase/decrease value` — The decrement is not a valid number or is `NaN`.
+- `TSDB: invalid timestamp` — The timestamp cannot be parsed.
+- `TSDB: timestamp must be equal to or higher than the maximum existing timestamp` — The timestamp is older than the latest sample.
+- `TSDB: cannot increment/decrement NaN value` — The latest sample is `NaN`.
+- `WRONGTYPE` — The key exists but is not a time series.
+
+## Complexity
+
+O(1) amortized time.
+
+## ACL categories
+
+`@write`, `@fast`, `@timeseries`

--- a/docs/commands/ts.del.md
+++ b/docs/commands/ts.del.md
@@ -1,31 +1,62 @@
-### TS.DEL
+# TS.DEL
 
-#### Syntax
+Delete samples from a time series within an inclusive timestamp range.
+
+## Syntax
 
 ```
 TS.DEL key fromTimestamp toTimestamp
 ```
 
-**TS.DEL** deletes data for a selection of series in a time range.
+## Arguments
 
-### Required Arguments
+- `key` — Existing time-series key.
+- `fromTimestamp` — Start of the range, inclusive, in milliseconds since the Unix epoch.
+- `toTimestamp` — End of the range, inclusive, in milliseconds since the Unix epoch.
 
-- **key**: the key being deleted from.
-- **fromTimestamp**: Start timestamp, inclusive. Optional.
-- **toTimestamp**: End timestamp, inclusive. Optional.
+The timestamp range may use the usual range forms such as `-` and `+`.
+Setting `fromTimestamp` equal to `toTimestamp` deletes only the sample at
+that timestamp, if one exists.
 
-#### Return
+## Behavior
 
-- the number of samples deleted.
+- Deletes every sample whose timestamp is between the two boundaries, including both boundaries.
+- Returns `0` when the range contains no samples; this is not an error.
+- Deletion can span multiple chunks.
+- If the series participates in compaction rules, affected destination series are updated to reflect the deletion.
+- The time-series key itself is retained, even when all its samples are deleted.
+- Keyspace notifications use the `ts.del` event.
 
-#### Error
+## Return value
 
-Return an error reply in the following cases:
+Returns the number of samples deleted as an integer.
 
-TODO
+## Errors
 
-#### Examples
+- `ERR wrong number of arguments` — The key or either timestamp is missing.
+- A key-does-not-exist error — The key does not exist.
+- `WRONGTYPE` — The key exists but is not a time series.
+- `TSDB: invalid timestamp` — A timestamp cannot be parsed.
+- `TSDB: error deleting range` — An internal error occurred while deleting the range.
+
+## Complexity
+
+O(N), where N is the number of samples removed.
+
+## ACL categories
+
+`@write`, `@fast`, `@timeseries`
+
+## Examples
+
+Delete a range of samples, including both endpoints:
 
 ```
 TS.DEL requests:status:200 587396550 1587396550
+```
+
+Delete one sample at timestamp `1609459200000`:
+
+```
+TS.DEL requests:status:200 1609459200000 1609459200000
 ```

--- a/docs/commands/ts.deleterule.md
+++ b/docs/commands/ts.deleterule.md
@@ -1,7 +1,70 @@
 # TS.DELETERULE
 
-Delete a compaction rule.
+Delete the compaction rule between a source and destination time series.
+
+## Syntax
 
 ```
 TS.DELETERULE sourceKey destKey
+```
+
+## Arguments
+
+- `sourceKey` — The source time series that has the compaction rule.
+- `destKey` — The destination time series targeted by the rule.
+
+The source and destination keys must be different. Both keys must already
+exist as time series, and a rule must exist for this exact source and
+destination pair.
+
+## Behavior
+
+- Removes the rule from `sourceKey`.
+- Stops future compaction from `sourceKey` into `destKey`.
+- Clears the source-series metadata from `destKey`.
+- Does not delete `destKey` or any samples already stored in it.
+- When the source has multiple rules, removes only the rule targeting the specified destination.
+
+## Return value
+
+Returns `OK` on success.
+
+## Errors
+
+- `ERR wrong number of arguments` — Either key argument is missing, or an extra argument was provided.
+- `TSDB: compaction rule does not exist` — The source and destination are the same, the destination does not exist, or no rule exists for the specified pair.
+- A missing source key returns a key-does-not-exist error.
+- `WRONGTYPE` — Either key exists but is not a time series.
+- An ACL error is returned when the caller lacks `UPDATE` permission on either key.
+
+## Complexity
+
+O(1).
+
+## ACL categories
+
+`@write`, `@fast`, `@timeseries`
+
+## Example
+
+Create a source and destination series and connect them with a compaction
+rule:
+
+```
+TS.CREATE readings:raw
+TS.CREATE readings:hourly
+TS.CREATERULE readings:raw readings:hourly AGGREGATION avg 1h
+```
+
+Delete the rule while preserving the destination series and its existing
+data:
+
+```
+TS.DELETERULE readings:raw readings:hourly
+```
+
+The destination can be used again in a new rule after deletion:
+
+```
+TS.CREATERULE readings:raw readings:hourly AGGREGATION sum 1h
 ```

--- a/docs/commands/ts.incrby.md
+++ b/docs/commands/ts.incrby.md
@@ -1,2 +1,114 @@
 # TS.INCRBY
 
+Increment the value of the latest sample in a time series, or create a new
+series when the key does not exist.
+
+## Syntax
+
+```
+TS.INCRBY key value
+  [TIMESTAMP timestamp]
+  [RETENTION duration]
+  [DUPLICATE_POLICY policy]
+  [ENCODING <COMPRESSED|UNCOMPRESSED>]
+  [CHUNK_SIZE chunkSize]
+  [METRIC metric | LABELS labelName labelValue ...]
+  [IGNORE ignoreMaxTimediff ignoreMaxValDiff]
+  [SIGNIFICANT_DIGITS significantDigits | DECIMAL_DIGITS decimalDigits]
+```
+
+## Required arguments
+
+| Argument | Description |
+| --- | --- |
+| `key` | Key name for the time series. |
+| `value` | Numeric increment to apply to the latest sample. Negative values decrement it. |
+
+## Optional arguments
+
+| Argument | Description | Default |
+| --- | --- | --- |
+| `TIMESTAMP timestamp` | Timestamp in milliseconds, or `*` for the current time. If omitted, an existing latest sample is updated at its timestamp; on a new series, the current time is used. | Existing latest timestamp or current time |
+| `RETENTION duration` | Retention period in milliseconds. Duration expressions such as `1d` are also accepted. | Module configuration |
+| `DUPLICATE_POLICY policy` | Policy used when creating the series: `BLOCK`, `FIRST`, `LAST`, `MIN`, `MAX`, or `SUM`. | `BLOCK` |
+| `ENCODING <COMPRESSED\|UNCOMPRESSED>` | Storage encoding for a newly created series. | `COMPRESSED` |
+| `CHUNK_SIZE chunkSize` | Chunk size in bytes for a newly created series. | `4096` |
+| `METRIC metric` | Prometheus-style metric name for a newly created series. |—|
+| `LABELS labelName labelValue ...` | Label name-value pairs for a newly created series. |—|
+| `IGNORE ignoreMaxTimediff ignoreMaxValDiff` | Ignore the update when it is within both the time and value thresholds. | No filtering |
+| `SIGNIFICANT_DIGITS significantDigits` | Round values to 1–16 significant digits. | No rounding |
+| `DECIMAL_DIGITS decimalDigits` | Round values to 0–16 decimal places. `0` rounds to whole numbers. | No rounding |
+
+`SIGNIFICANT_DIGITS` and `DECIMAL_DIGITS` are mutually exclusive. Creation
+options are used only when `TS.INCRBY` auto-creates the series; they do not
+alter an existing series.
+
+## Return value
+
+Returns the timestamp of the sample affected by the increment as an integer.
+
+## Behavior
+
+- If the key does not exist, `TS.INCRBY` creates the series and stores `value` as its first sample.
+- If the key exists, the increment is added to its latest sample.
+- An explicit timestamp must be equal to or greater than the latest timestamp. A timestamp equal to the latest sample updates that sample in place; a later timestamp appends a new sample with the accumulated value.
+- `TIMESTAMP *` uses the current server time. Without `TIMESTAMP`, an existing series updates its latest timestamp, while a new series uses the current server time.
+- An increment cannot be applied when the latest sample is `NaN`; `NaN` is also invalid as the increment value.
+- Retention and compaction rules are applied after a successful update.
+- Keyspace notifications use the `ts.incrby` event.
+
+## Examples
+
+### Basic increment
+
+Create a series and add an increment:
+
+```
+TS.INCRBY sensor:requests 10
+```
+
+Increment the latest value again:
+
+```
+TS.INCRBY sensor:requests 5
+```
+
+The latest sample now has a value of `15`.
+
+### Increment at an explicit timestamp
+
+```
+TS.INCRBY counter 25 TIMESTAMP 1609459200000
+TS.INCRBY counter 5 TIMESTAMP 1609459201000
+```
+
+The command returns the timestamp used for the updated or appended sample.
+
+### Create a series with options
+
+```
+TS.INCRBY temperature:room1 1.5 RETENTION 86400000 LABELS sensor_id 1 location living_room
+```
+
+### Apply rounding
+
+```
+TS.INCRBY measurement 1.23456 DECIMAL_DIGITS 2
+```
+
+## Errors
+
+- `ERR wrong number of arguments` — A required argument is missing.
+- `TSDB: invalid increase/decrease value` — The increment is not a valid number or is `NaN`.
+- `TSDB: invalid timestamp` — The timestamp cannot be parsed.
+- `TSDB: timestamp must be equal to or higher than the maximum existing timestamp` — The timestamp is older than the latest sample.
+- `TSDB: cannot increment/decrement NaN value` — The latest sample is `NaN`.
+- `WRONGTYPE` — The key exists but is not a time series.
+
+## Complexity
+
+O(1) amortized time.
+
+## ACL categories
+
+`@write`, `@fast`, `@timeseries`

--- a/docs/commands/ts.queryindex.md
+++ b/docs/commands/ts.queryindex.md
@@ -1,7 +1,123 @@
 # TS.QUERYINDEX
 
-Query the index of time series that match the specified labels.
+Return the keys of time series that match one or more label selectors.
+
+## Syntax
 
 ```
-TS.QUERYINDEX [FILTER_BY_RANGE [NOT] start end] FILTER selector...
+TS.QUERYINDEX
+  [FILTER_BY_RANGE [NOT] start end]
+  selector [selector ...]
 ```
+
+Unlike `TS.MRANGE` and related commands, `TS.QUERYINDEX` does not use a
+`FILTER` keyword. Selectors are passed directly after the command.
+
+## Arguments
+
+### `FILTER_BY_RANGE [NOT] start end`
+
+Restricts the result to indexed series that contain at least one sample in
+the inclusive timestamp range from `start` to `end`.
+
+With `NOT`, the condition is inverted: series with no samples in the range
+are returned. Timestamps are milliseconds since the Unix epoch. Range values
+may use the usual timestamp forms such as `-` and `+` where supported.
+
+### `selector`
+
+One or more label selectors. Multiple selector arguments are combined with
+logical AND. See [filter syntax](../topics/filter-syntax.md) for the complete
+grammar.
+
+Basic selectors include:
+
+```
+label=value
+label!=value
+label=(value1,value2)
+label!=(value1,value2)
+```
+
+Prometheus-style selectors are also supported:
+
+```
+metric_name{label="value",other!="excluded"}
+label=~"regular-expression"
+label!~"regular-expression"
+```
+
+At least one selector in the complete query must contain a positive, bounded
+matcher such as `label=value`, `label=(value1,value2)`, or a non-empty regular
+expression. A query made only from negative or unbounded matchers is rejected.
+
+## Return value
+
+Returns an array of matching time-series key names. The array is empty when
+no series matches. Reply ordering is not part of the command contract.
+
+`TS.QUERYINDEX` returns keys from the label index without reading sample data.
+In clustered deployments, the query is sent to all shards and the matching
+keys are merged into one reply.
+
+## Examples
+
+Create sample series:
+
+```
+TS.CREATE ts:cpu:node1 LABELS name cpu type usage node node1
+TS.CREATE ts:cpu:node2 LABELS name cpu type usage node node2
+TS.CREATE ts:memory:node1 LABELS name memory type usage node node1
+```
+
+Find all CPU series:
+
+```
+TS.QUERYINDEX name=cpu
+```
+
+Find CPU usage series on node 1:
+
+```
+TS.QUERYINDEX name=cpu type=usage node=node1
+```
+
+Match a label with a regular expression:
+
+```
+TS.QUERYINDEX name=~"cpu|memory"
+```
+
+Exclude one value while keeping the query bounded:
+
+```
+TS.QUERYINDEX type=usage node!=node2
+```
+
+Find CPU series that contain data in a time range:
+
+```
+TS.QUERYINDEX FILTER_BY_RANGE 1609459200000 1609545600000 name=cpu
+```
+
+Find CPU-indexed series without data in that range:
+
+```
+TS.QUERYINDEX FILTER_BY_RANGE NOT 1609459200000 1609545600000 name=cpu
+```
+
+## Errors
+
+- `ERR wrong number of arguments` — No selector was provided.
+- `TSDB: please provide at least one matcher` — All selectors are negative or otherwise unbounded.
+- `TSDB: invalid timestamp` — A `FILTER_BY_RANGE` timestamp cannot be parsed.
+- A malformed selector produces a series-selector parsing error.
+
+## Complexity
+
+O(N), where N is the number of matching time series. `FILTER_BY_RANGE` also
+checks the samples of candidate series for data in the requested range.
+
+## ACL categories
+
+`@read`, `@fast`, `@timeseries`

--- a/docs/commands/ts.queryindex.md
+++ b/docs/commands/ts.queryindex.md
@@ -56,7 +56,9 @@ expression. A query made only from negative or unbounded matchers is rejected.
 Returns an array of matching time-series key names. The array is empty when
 no series matches. Reply ordering is not part of the command contract.
 
-`TS.QUERYINDEX` returns keys from the label index without reading sample data.
+Without `FILTER_BY_RANGE`, `TS.QUERYINDEX` answers from the label index alone
+and never reads sample data. With `FILTER_BY_RANGE`, each candidate series is
+opened and the chunks that overlap the range are checked for a sample.
 In clustered deployments, the query is sent to all shards and the matching
 keys are merged into one reply.
 
@@ -68,7 +70,14 @@ Create sample series:
 TS.CREATE ts:cpu:node1 LABELS name cpu type usage node node1
 TS.CREATE ts:cpu:node2 LABELS name cpu type usage node node2
 TS.CREATE ts:memory:node1 LABELS name memory type usage node node1
+TS.ADD ts:cpu:node1 1609462800000 42.5
+TS.ADD ts:cpu:node2 1609372800000 37.0
+TS.ADD ts:memory:node1 1609462800000 8192
 ```
+
+`ts:cpu:node1` and `ts:memory:node1` have a sample inside the range used by
+the `FILTER_BY_RANGE` examples below; `ts:cpu:node2` only has a sample from
+the day before.
 
 Find all CPU series:
 
@@ -115,9 +124,12 @@ TS.QUERYINDEX FILTER_BY_RANGE NOT 1609459200000 1609545600000 name=cpu
 
 ## Complexity
 
-O(N), where N is the number of matching time series. `FILTER_BY_RANGE` also
-checks the samples of candidate series for data in the requested range.
+O(N), where N is the number of time series matching the selectors.
+`FILTER_BY_RANGE` additionally opens each candidate series and decodes the
+chunks that overlap the range until an in-range sample is found, so its cost
+is O(N + ΣCᵢ), where Cᵢ is the number of chunks of candidate series i that
+overlap the range.
 
 ## ACL categories
 
-`@read`, `@fast`, `@timeseries`
+`@read`, `@timeseries`

--- a/src/commands/ts_alter.rs
+++ b/src/commands/ts_alter.rs
@@ -109,6 +109,15 @@ fn update_series(
         has_changed = true;
     }
 
+    // SIGNIFICANT_DIGITS / DECIMAL_DIGITS only affect values written after the
+    // change; samples already stored are left as they are.
+    if let Some(rounding) = options.rounding
+        && Some(rounding) != series.rounding
+    {
+        series.rounding = Some(rounding);
+        has_changed = true;
+    }
+
     // IGNORE and DUPLICATE_POLICY are independent properties: altering one must
     // leave the other as it was.
     if let Some((max_time_delta, max_value_delta)) = options.ignore

--- a/tests/test_ts_alter.py
+++ b/tests/test_ts_alter.py
@@ -170,3 +170,31 @@ class TestTimeSeriesAlter(ValkeyTimeSeriesTestCaseBase):
         # Unknown option
         with pytest.raises(ResponseError):
             self.client.execute_command('TS.ALTER', self.key, 'UNKNOWN_OPTION', 'value')
+
+    def test_alter_rounding(self):
+        """Test altering SIGNIFICANT_DIGITS / DECIMAL_DIGITS"""
+        self.setup_data()
+
+        assert self.client.execute_command('TS.ALTER', self.key, 'SIGNIFICANT_DIGITS', 3) == b'OK'
+        info = self.ts_info(self.key)
+        assert info['rounding'] == [b'significantDigits', 3]
+        # Rounding applies to values written after the change
+        self.client.execute_command('TS.ADD', self.key, 2000, 3.14159)
+        assert self.client.execute_command('TS.GET', self.key) == [2000, b'3.14']
+
+        assert self.client.execute_command('TS.ALTER', self.key, 'DECIMAL_DIGITS', 1) == b'OK'
+        info = self.ts_info(self.key)
+        assert info['rounding'] == [b'decimalDigits', 1]
+        self.client.execute_command('TS.ADD', self.key, 3000, 2.71828)
+        assert self.client.execute_command('TS.GET', self.key) == [3000, b'2.7']
+
+        # An ALTER that does not mention rounding leaves it unchanged
+        assert self.client.execute_command('TS.ALTER', self.key, 'RETENTION', 60000) == b'OK'
+        info = self.ts_info(self.key)
+        assert info['rounding'] == [b'decimalDigits', 1]
+        assert info['retentionTime'] == 60000
+
+        # The two rounding options are mutually exclusive
+        with pytest.raises(ResponseError):
+            self.client.execute_command(
+                'TS.ALTER', self.key, 'SIGNIFICANT_DIGITS', 3, 'DECIMAL_DIGITS', 1)


### PR DESCRIPTION
This pull request provides comprehensive, rewritten documentation for several RedisTimeSeries commands, improving clarity, completeness, and consistency. The changes add detailed syntax, argument descriptions, error lists, return values, behavioral notes, and examples for each command. The updates ensure that users and developers have a much clearer understanding of command behavior and options.

**Major documentation improvements by command:**

**TS.ALTER**
- Expanded the description to clarify that `TS.ALTER` updates configuration and labels but does not create a series or change encoding. Added detailed syntax, argument explanations, error cases, return value, and examples. Deprecated or unsupported options are now clearly documented.

**TS.DECRBY and TS.INCRBY**
- Rewrote both command docs to include full syntax, required and optional argument tables, behavior breakdowns, error lists, return values, and example usage. Both commands now clearly explain auto-creation behavior, timestamp handling, and rounding options. [[1]](diffhunk://#diff-98f2a93edc5ba7b81f7241016cf2d23a295194022e2b4237a00464b8c9bdf03eR3-R114) [[2]](diffhunk://#diff-a0810cb279d03d97a68aa2e8ccb5fe20221bfcc42a1d2ecd17e44afe6fd7cba9R3-R114)

**TS.DEL and TS.DELETERULE**
- TS.DEL: Added a full explanation of arguments, behavior, return value, errors, complexity, and ACL categories, plus examples for deleting ranges and individual samples.
- TS.DELETERULE: Clarified the relationship between source and destination, described behavior when deleting rules, and detailed possible errors and usage scenarios.

**TS.QUERYINDEX**
- Thoroughly documented label selector syntax, the `FILTER_BY_RANGE` option, error cases, and return value. Added multiple realistic examples and clarified the command's role in the context of the label index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `TS.ALTER` now supports applying `SIGNIFICANT_DIGITS` and `DECIMAL_DIGITS` rounding settings to time series.

- **Documentation**
  - Added complete reference documentation for `TS.DECRBY` and `TS.INCRBY`.
  - Expanded `TS.ALTER`, `TS.DEL`, and `TS.DELETERULE` documentation with usage details, behavior, errors, and examples.
  - Clarified `TS.QUERYINDEX` filtering, matching, clustered key handling, complexity, and access requirements.

- **Bug Fixes**
  - Corrected `TS.ALTER` so configured rounding options are applied to subsequent values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->