### PR TITLE
Refactor inline condition syntax for aggregators in time series commands

### DIFF
--- a/docs/commands/ts.createrule.md
+++ b/docs/commands/ts.createrule.md
@@ -4,7 +4,7 @@
 
 ```
 TS.CREATERULE sourceKey destKey 
-AGGREGATION aggregator[(op value)] bucketDuration [alignTimestamp]
+AGGREGATION aggregatorop value bucketDuration [alignTimestamp]
 ```
 
 ## Description

--- a/docs/commands/ts.createrule.md
+++ b/docs/commands/ts.createrule.md
@@ -43,11 +43,11 @@ storage and analysis.
     - `var_s` — Sample variance
     - `rate` — Rate of change per second (handles resets)
 - **bucketDuration**: The duration of each aggregation bucket (e.g., `1h`, `30m`, `5000ms`).
-- **(op value)**: Inline comparison condition attached directly to `aggregator`, e.g. `countif(>100)`.
-  `op` is one of `==`, `!=`, `>=`, `<=`, `<`, `>`, with no spaces inside the parentheses since it is
-  a single argument token. **Required** for `all`, `any`, `countif`, `sumif`, `share`, `none` — it
-  is an error to omit it for these. **Optional** for `count` and `sum`. **Not accepted** by any
-  other aggregator (`avg`, `min`, `max`, ...) — attaching one is an error.
+- **op value**: Inline comparison condition attached directly to `aggregator` with no separator,
+  e.g. `countif>100`. `op` is one of `==`, `!=`, `>=`, `<=`, `<`, `>`; `aggregator` and `op value`
+  together form a single argument token. **Required** for `all`, `any`, `countif`, `sumif`,
+  `share`, `none` — it is an error to omit it for these. **Optional** for `count` and `sum`.
+  **Not accepted** by any other aggregator (`avg`, `min`, `max`, ...) — attaching one is an error.
 - **alignTimestamp** (optional): Align bucket boundaries to a specific timestamp (milliseconds since epoch).
 
 ## Constraints
@@ -70,7 +70,7 @@ Returns `OK` on success.
 - `TSDB: invalid aggregator` — Unsupported aggregation function.
 - `TSDB: invalid bucket duration` — Invalid duration format.
 - `TSDB: circular compaction rule` — Creating this rule would form a cycle.
-- `TSDB: missing condition for aggregator` — `all`/`any`/`countif`/`sumif`/`share`/`none` used without an inline `(op value)` condition.
+- `TSDB: missing condition for aggregator` — `all`/`any`/`countif`/`sumif`/`share`/`none` used without an inline `op value` condition.
 - `TSDB: aggregation type does not support a filter condition` — An inline condition was attached to an aggregator that doesn't accept one.
 
 ## Permissions
@@ -88,7 +88,7 @@ TS.CREATERULE myts:1m myts:1h AGGREGATION avg 1h
 Create a rule that counts only samples greater than 100:
 
 ```
-TS.CREATERULE temperature:raw temperature:hourly AGGREGATION countif(>100) 1h
+TS.CREATERULE temperature:raw temperature:hourly AGGREGATION countif>100 1h
 ```
 
 Create a rule with bucket alignment to midnight UTC:

--- a/docs/commands/ts.mrange.md
+++ b/docs/commands/ts.mrange.md
@@ -150,7 +150,7 @@ ALIGN 1609459200000 AGGREGATION sum 5m
 - Cannot use `start` align with `-` range start timestamp
 - Cannot use `end` align with `+` range end timestamp
 
-### AGGREGATION aggregator[(op value)][,aggregator[(op value)]...] bucketDuration
+### AGGREGATION aggregatorop value[,aggregatorop value...] bucketDuration
 
 Aggregate samples into time buckets using the specified aggregator(s) and bucket size. A
 comma-separated list of up to 16 distinct aggregators produces one row per bucket containing the

--- a/docs/commands/ts.mrange.md
+++ b/docs/commands/ts.mrange.md
@@ -187,11 +187,11 @@ AGGREGATION avg 1h
 AGGREGATION sum 5m
 ```
 
-#### Inline condition: aggregator(op value)
+#### Inline condition: aggregatorop value
 
 `all`, `any`, `countif`, `sumif`, `share`, and `none` **require** an inline comparison condition —
-`aggregator(op value)`, e.g. `countif(>5)` — with no spaces inside the parentheses since it is a
-single argument token; omitting it is an error. `count` and `sum` accept the same form
+`aggregatorop value`, e.g. `countif>5` — with no separator since `aggregator` and its condition
+form a single argument token; omitting it is an error. `count` and `sum` accept the same form
 *optionally*, to count/sum only matching samples. Any other aggregator (`avg`, `max`, ...) does
 not accept a condition; attaching one is an error.
 
@@ -200,13 +200,13 @@ not accept a condition; attaching one is an error.
 **Example:**
 
 ```
-AGGREGATION share(>20.0) 1h
+AGGREGATION share>20.0 1h
 ```
 
 Different elements of the `aggregator` list can filter on different conditions:
 
 ```
-AGGREGATION countif(>5),sumif(<=2),avg 1h
+AGGREGATION countif>5,sumif<=2,avg 1h
 ```
 
 #### BUCKETTIMESTAMP bt
@@ -249,7 +249,7 @@ GROUPBY region REDUCE sum
 
 Supports all aggregators except `rate` (e.g., `avg`, `sum`, `count`, `max`, `min`, etc.)
 
-#### Inline condition: reducer(op value)
+#### Inline condition: reducerop value
 
 Same inline condition syntax as `AGGREGATION` (see above): required for `countif`/`sumif`/`share`/
 `all`/`any`/`none`, optional for `count`/`sum`, and disallowed for other reducers.
@@ -257,7 +257,7 @@ Same inline condition syntax as `AGGREGATION` (see above): required for `countif
 **Example:**
 
 ```
-GROUPBY region REDUCE countif(>20.0)
+GROUPBY region REDUCE countif>20.0
 ```
 
 ### EXCLUDEEMPTY
@@ -390,7 +390,7 @@ O(n×m×k) where:
 ### Query with aggregation condition and empty buckets
 
 ```bash
-127.0.0.1:6379> TS.MRANGE - + AGGREGATION countif(>23.0) 1h EMPTY FILTER sensor_id=12
+127.0.0.1:6379> TS.MRANGE - + AGGREGATION countif>23.0 1h EMPTY FILTER sensor_id=12
 1) 1) "temperature:sensor:12"
    2) (empty array)
    3) 1) 1) (integer) 1609459200000

--- a/docs/commands/ts.nrange.md
+++ b/docs/commands/ts.nrange.md
@@ -78,7 +78,7 @@ inside the argument. A key contributes one value per aggregator it names, and it
 together in the reply in that order.
 
 A [filtered aggregator](./ts.range.md#filtered-aggregators) (`countif`, `sumif`, `all`, `any`,
-`none`, `share`) **requires** an inline condition — `aggregator(op value)`, e.g. `countif(>5)` — and
+`none`, `share`) **requires** an inline condition — `aggregatorop value`, e.g. `countif>5` — and
 `count`/`sum` accept the same form optionally. Conditions are per aggregator, so different keys (and
 different aggregators for one key) can use different ones.
 </details>
@@ -181,7 +181,7 @@ Each timestamp's values are a single flat list — `{sensor}:3`'s `avg`, then it
 Count each key's samples above its own threshold, per minute:
 
 ```
-127.0.0.1:6379> TS.NRANGE 2 {app}:errors {app}:latency - + AGGREGATION countif(>0) countif(>250) 60000
+127.0.0.1:6379> TS.NRANGE 2 {app}:errors {app}:latency - + AGGREGATION countif>0 countif>250 60000
 ```
 
 ### Latest rows only

--- a/docs/commands/ts.range.md
+++ b/docs/commands/ts.range.md
@@ -10,7 +10,7 @@ TS.RANGE key fromTimestamp toTimestamp
   [FILTER_BY_TS timestamp ...]
   [FILTER_BY_VALUE min max]
   [COUNT count]
-  [[ALIGN align] AGGREGATION aggregator[(op value)][,aggregator[(op value)]...] bucketDuration [BUCKETTIMESTAMP bt] [EMPTY]]
+  [[ALIGN align] AGGREGATION aggregatorop value[,aggregatorop value...] bucketDuration [BUCKETTIMESTAMP bt] [EMPTY]]
 ```
 
 ---
@@ -49,7 +49,7 @@ Include only samples with values in `[min, max]`. Both bounds are inclusive. App
 Limit output to the first `count` samples or buckets. When used with aggregation, limits bucket
 count (not samples per bucket).
 </details>
-<details open><summary><code>AGGREGATION aggregator[(op value)][,aggregator[(op value)]...] bucketDuration</code></summary>
+<details open><summary><code>AGGREGATION aggregatorop value[,aggregatorop value...] bucketDuration</code></summary>
 Aggregate raw samples into fixed-size time buckets. See [Aggregators](#aggregators) for supported aggregation functions.
 
 `aggregator` may be a comma-separated list of up to 16 distinct aggregators (e.g. `avg,max,count`).
@@ -273,5 +273,4 @@ TS.RANGE cpu:utilization 1609459200000 1609545600000 AGGREGATION countif>90,sumi
 - `TS.MRANGE` — Query multiple time series at once
 - `TS.GET` — Get the latest sample only
 - `TS.ADD` — Add samples to a time series
-
 

--- a/docs/commands/ts.range.md
+++ b/docs/commands/ts.range.md
@@ -59,12 +59,12 @@ aggregator, in the order specified. With a single aggregator the output shape is
 (`[timestamp, value]`).
 
 A [filtered aggregator](#filtered-aggregators) (`countif`, `sumif`, `all`, `any`, `none`, `share`)
-**requires** an inline condition — `aggregator(op value)`, e.g. `countif(>5)` — with no spaces
-inside the parentheses since it is a single argument token; omitting it is an error. `count` and
-`sum` optionally accept the same inline form to filter which samples they count/sum. Any other
+**requires** an inline condition — `aggregatorop value`, e.g. `countif>5` — with no separator
+since `aggregator` and its condition form a single argument token; omitting it is an error. `count`
+and `sum` optionally accept the same inline form to filter which samples they count/sum. Any other
 aggregator (`avg`, `max`, ...) does not accept a condition at all; attaching one is an error.
 Different elements in the same list can use different conditions, e.g. `AGGREGATION
-countif(>5),sumif(<=2),avg 60000` counts samples over 5, sums samples at or under 2, and averages
+countif>5,sumif<=2,avg 60000` counts samples over 5, sums samples at or under 2, and averages
 everything — three independent conditions in a single clause.
 </details>
 <details open><summary><code>ALIGN align</code></summary> 
@@ -84,10 +84,10 @@ Control bucket alignment:
 </details>
 ### Aggregation
 
-- **`AGGREGATION aggregator[(op value)][,aggregator[(op value)]...] bucketDuration`** — Aggregate raw samples into fixed-size time buckets
+- **`AGGREGATION aggregator[op value][,aggregator[op value]...] bucketDuration`** — Aggregate raw samples into fixed-size time buckets
   - **`aggregator`** — Aggregation function(s) to apply (see [Aggregators](#aggregators)); a
     comma-separated list produces one output column per aggregator, in the order specified
-  - **`(op value)`** — Inline comparison condition for a filtered aggregator, e.g. `countif(>5)`.
+  - **`op value`** — Inline comparison condition for a filtered aggregator, e.g. `countif>5`.
     `op` is one of `>`, `<`, `>=`, `<=`, `==`, `!=`; `value` is the number to compare against.
     Only samples satisfying the condition are included in that aggregator's computation.
   - **`bucketDuration`** — Bucket size in milliseconds (must be positive)
@@ -127,7 +127,7 @@ Control bucket alignment:
 
 ### Filtered Aggregators
 
-> These require an inline `(op value)` condition, e.g. `countif(>5)`; omitting it is an error.
+> These require an inline `op value` condition, e.g. `countif>5`; omitting it is an error.
 
 | Aggregator | Description                                           | Empty Bucket Value |
 |------------|-------------------------------------------------------|--------------------|
@@ -138,7 +138,7 @@ Control bucket alignment:
 | `any`      | `1.0` if any sample matches, `0.0` otherwise          | `NaN`              |
 | `none`     | `1.0` if no samples match, `0.0` otherwise            | `NaN`              |
 
-`count` and `sum` also accept an *optional* inline condition (`count(>5)`, `sum(<=2)`) to count or
+`count` and `sum` also accept an *optional* inline condition (`count>5`, `sum<=2`) to count or
 sum only matching samples; without one they operate over every sample in the bucket as usual.
 
 ---
@@ -234,7 +234,7 @@ TS.RANGE metrics 1609459200000 1609545600000
 Count samples over 90 and sum samples at or under 10, per hour, in one scan:
 
 ```
-TS.RANGE cpu:utilization 1609459200000 1609545600000 AGGREGATION countif(>90),sumif(<=10) 3600000
+TS.RANGE cpu:utilization 1609459200000 1609545600000 AGGREGATION countif>90,sumif<=10 3600000
 ```
 
 ---

--- a/docs/commands/ts.read.md
+++ b/docs/commands/ts.read.md
@@ -184,7 +184,7 @@ Take a page at a time:
 ```
 
 Alert when more than 5% of requests in a one-minute window take longer than 500 ms. A
-[`TS.CREATERULE`](./ts.createrule.md) with `share(>500)` down-samples the raw latency values to
+[`TS.CREATERULE`](./ts.createrule.md) with `share>500` down-samples the raw latency values to
 one fraction per minute; a worker then tails that compacted series, and `CONDITION` does the
 threshold test on the server so the worker is woken only by a breach:
 
@@ -193,11 +193,11 @@ threshold test on the server so the worker is woken only by a breach:
 OK
 > TS.CREATE api:latency:over_500ms:1m
 OK
-> TS.CREATERULE api:latency:raw api:latency:over_500ms:1m AGGREGATION share(>500) 1m 0
+> TS.CREATERULE api:latency:raw api:latency:over_500ms:1m AGGREGATION share>500 1m 0
 OK
 ```
 
-Block until the condition is met. `share(>500)` returns a fraction from `0.0` to `1.0`, so `0.05` represents 5%. 
+Block until the condition is met. `share>500` returns a fraction from `0.0` to `1.0`, so `0.05` represents 5%. 
 ```
 > TS.READ api:latency:over_500ms:1m $ BLOCK 60000 1 CONDITION > 0.05
 ```

--- a/docs/commands/ts.revrange.md
+++ b/docs/commands/ts.revrange.md
@@ -14,7 +14,7 @@ TS.REVRANGE key fromTimestamp toTimestamp
   [FILTER_BY_VALUE min max]
   [COUNT count]
   [
-      [ALIGN align] AGGREGATION aggregator[(operator value)][,aggregator[(operator value)]...] bucketDuration [BUCKETTIMESTAMP bt] [EMPTY]
+      [ALIGN align] AGGREGATION aggregatoroperatorvalue[,aggregatoroperatorvalue...] bucketDuration [BUCKETTIMESTAMP bt] [EMPTY]
   ]
 ```
 
@@ -61,13 +61,13 @@ TS.REVRANGE key fromTimestamp toTimestamp
 
 | Option            | Arguments                   | Description                                                                                                               |
 |-------------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| `AGGREGATION`     | `aggregator[operator value][,aggregator[operator value]...] bucketDuration` | Downsample into fixed time buckets of size `bucketDuration` and apply each `aggregator` per bucket. A comma-separated list (up to 16 distinct aggregators) yields one value per aggregator per bucket, in the order specified. |
+| `AGGREGATION`     | `aggregatoroperatorvalue[,aggregatoroperatorvalue...] bucketDuration` | Downsample into fixed time buckets of size `bucketDuration` and apply each `aggregator` per bucket. A comma-separated list (up to 16 distinct aggregators) yields one value per aggregator per bucket, in the order specified. |
 | `ALIGN`           | `align`                     | Bucket alignment anchor. May appear before `AGGREGATION` (`ALIGN … AGGREGATION …`) or after it (`AGGREGATION … ALIGN …`). |
 | `BUCKETTIMESTAMP` | `bt`                        | Controls the timestamp emitted for each bucket. Default: `start`.                                                         |
 | `EMPTY`           | (none)                      | Include empty buckets (buckets with no samples).                                                                          |
 
 Each element of the `aggregator` list carries its own inline condition —
-`aggregatoroperator value`, e.g. `countif>5` — with no separator since `aggregator` and its
+`aggregatoroperatorvalue`, e.g. `countif>5` — with no separator since `aggregator` and its
 condition form a single argument token. `countif`, `sumif`, `share`, and `all`/`any`/`none`
 **require** one; omitting it is an error. `count` and `sum` accept one *optionally*, to count/sum
 only matching samples. Any other aggregator (`avg`, `max`, ...) does not accept a condition;
@@ -111,8 +111,8 @@ Supported `aggregator` values for `AGGREGATION`:
 | `increase` | Counter increase over the bucket (handles counter resets).                                             |
 | `rate`     | Counter rate per second over the bucket window (`increase / window_seconds`).                          |
 | `irate`    | Instantaneous per-second rate from the last two samples in the bucket/window (handles counter resets). |
-| `countif`  | Count of samples matching the inline `(operator value)` condition.                                     |
-| `sumif`    | Sum of sample values matching the inline `(operator value)` condition.                                 |
+| `countif`  | Count of samples matching the inline `operatorvalue` condition.                                         |
+| `sumif`    | Sum of sample values matching the inline `operatorvalue` condition.                                   |
 | `share`    | Fraction of samples matching the condition (range `[0..1]`), or empty when no samples.                 |
 | `all`      | `1.0` if all samples match the condition, else `0.0`.                                                  |
 | `any`      | `1.0` if any sample matches the condition, else `0.0`.                                                  |

--- a/docs/commands/ts.revrange.md
+++ b/docs/commands/ts.revrange.md
@@ -61,18 +61,18 @@ TS.REVRANGE key fromTimestamp toTimestamp
 
 | Option            | Arguments                   | Description                                                                                                               |
 |-------------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| `AGGREGATION`     | `aggregator[(operator value)][,aggregator[(operator value)]...] bucketDuration` | Downsample into fixed time buckets of size `bucketDuration` and apply each `aggregator` per bucket. A comma-separated list (up to 16 distinct aggregators) yields one value per aggregator per bucket, in the order specified. |
+| `AGGREGATION`     | `aggregator[operator value][,aggregator[operator value]...] bucketDuration` | Downsample into fixed time buckets of size `bucketDuration` and apply each `aggregator` per bucket. A comma-separated list (up to 16 distinct aggregators) yields one value per aggregator per bucket, in the order specified. |
 | `ALIGN`           | `align`                     | Bucket alignment anchor. May appear before `AGGREGATION` (`ALIGN … AGGREGATION …`) or after it (`AGGREGATION … ALIGN …`). |
 | `BUCKETTIMESTAMP` | `bt`                        | Controls the timestamp emitted for each bucket. Default: `start`.                                                         |
 | `EMPTY`           | (none)                      | Include empty buckets (buckets with no samples).                                                                          |
 
 Each element of the `aggregator` list carries its own inline condition —
-`aggregator(operator value)`, e.g. `countif(>5)` — with no spaces inside the parentheses since it
-is a single argument token. `countif`, `sumif`, `share`, and `all`/`any`/`none` **require** one;
-omitting it is an error. `count` and `sum` accept one *optionally*, to count/sum only matching
-samples. Any other aggregator (`avg`, `max`, ...) does not accept a condition; attaching one is an
-error. Different elements in the same list can use different conditions, e.g.
-`AGGREGATION countif(>5),sumif(<=2) 60000`.
+`aggregatoroperator value`, e.g. `countif>5` — with no separator since `aggregator` and its
+condition form a single argument token. `countif`, `sumif`, `share`, and `all`/`any`/`none`
+**require** one; omitting it is an error. `count` and `sum` accept one *optionally*, to count/sum
+only matching samples. Any other aggregator (`avg`, `max`, ...) does not accept a condition;
+attaching one is an error. Different elements in the same list can use different conditions, e.g.
+`AGGREGATION countif>5,sumif<=2 60000`.
 
 ##### `bucketDuration` format
 
@@ -175,7 +175,7 @@ TS.REVRANGE temperature:office 1700000000000 1700003600000 AGGREGATION max 60000
 Return `1.0` for each 5-minute bucket where any sample exceeds 0.9:
 
 ```plain text
-TS.REVRANGE cpu:utilization 1700000000000 1700003600000 AGGREGATION any(>0.9) 300000
+TS.REVRANGE cpu:utilization 1700000000000 1700003600000 AGGREGATION any>0.9 300000
 ```
 
 ---

--- a/src/commands/command_parser.rs
+++ b/src/commands/command_parser.rs
@@ -588,29 +588,26 @@ pub fn parse_label_value_pairs(
 }
 
 /// An `AGGREGATION` list element paired with its optional inline condition,
-/// e.g. the `(CountIf, Some(>5))` parsed from `countif(>5)`.
+/// e.g. the `(CountIf, Some(>5))` parsed from `countif>5`.
 type AggregationListElement = (AggregationType, Option<ValueComparisonFilter>);
 
-/// Split an aggregator token into its bare name and optional parenthesized
-/// inline-condition substring, e.g. `countif(>5)` -> (`"countif"`, `Some(">5")`),
-/// `avg` -> (`"avg"`, `None`).
+/// Split an aggregator token into its bare name and optional inline-condition
+/// substring, e.g. `countif>=5` -> (`"countif"`, `Some(">=5")`); a name with no
+/// condition at all (`avg`) yields `None`. No aggregator name contains `<`,
+/// `>`, `=`, or `!`, so the first such character unambiguously marks where the
+/// name ends.
 pub(super) fn split_aggregator_condition(part: &str) -> ValkeyResult<(&str, Option<&str>)> {
-    match part.find('(') {
+    match part.find(['<', '>', '=', '!']) {
         Some(0) => Err(ValkeyError::Str(error_consts::INVALID_AGGREGATION_LIST)),
-        Some(open) => {
-            if !part.ends_with(')') {
-                return Err(ValkeyError::Str(error_consts::INVALID_AGGREGATION_LIST));
-            }
-            Ok((&part[..open], Some(&part[open + 1..part.len() - 1])))
-        }
+        Some(op) => Ok((&part[..op], Some(&part[op..]))),
         None => Ok((part, None)),
     }
 }
 
-/// Split the parenthesized suffix of an inline condition (e.g. `>5`,
-/// `<=2.5`) into its operator and value substring. Two-character operators
-/// are tried before one-character ones so `>=`/`<=` aren't parsed as a
-/// truncated `>`/`<` followed by a malformed value.
+/// Split the suffix of an inline condition (e.g. `>5`, `<=2.5`) into its
+/// operator and value substring. Two-character operators are tried before
+/// one-character ones so `>=`/`<=` aren't parsed as a truncated `>`/`<`
+/// followed by a malformed value.
 fn split_condition_operator(cond_str: &str) -> Option<(ComparisonOperator, &str)> {
     [2usize, 1usize].into_iter().find_map(|len| {
         let prefix = cond_str.get(..len)?;
@@ -619,8 +616,8 @@ fn split_condition_operator(cond_str: &str) -> Option<(ComparisonOperator, &str)
     })
 }
 
-/// Parse the parenthesized suffix of an inline per-aggregator condition,
-/// e.g. `>5` or `<=2.5` (the part between the parens in `countif(>5)`).
+/// Parse the suffix of an inline per-aggregator condition, e.g. `>5` or
+/// `<=2.5` (the part following the name in `countif>5`).
 pub(super) fn parse_inline_condition(cond_str: &str) -> ValkeyResult<ValueComparisonFilter> {
     let (operator, value_str) = split_condition_operator(cond_str).ok_or(ValkeyError::Str(
         error_consts::INVALID_AGGREGATION_CONDITION,
@@ -638,7 +635,7 @@ pub(super) fn parse_inline_condition(cond_str: &str) -> ValkeyResult<ValueCompar
 
 /// Parse one element of a comma-separated `AGGREGATION` list: either a bare
 /// aggregator name (`avg`) or one carrying its own inline condition
-/// (`countif(>5)`). The inline form is the only way to attach a condition to
+/// (`countif>5`). The inline form is the only way to attach a condition to
 /// an aggregator; each element in the list can use a different one. Whether
 /// the condition is required, optional, or disallowed for a given aggregator
 /// is enforced later by [`AggregatorConfig::new`].
@@ -651,7 +648,7 @@ fn parse_aggregation_list_element(part: &str) -> ValkeyResult<AggregationListEle
 
 /// Parse the comma-separated aggregator list of an AGGREGATION clause, e.g.
 /// `avg`, `avg,max,count`, or with inline per-aggregator conditions,
-/// `countif(>5),sumif(<=2)`. Order is preserved (it defines the output
+/// `countif>5,sumif<=2`. Order is preserved (it defines the output
 /// column order), duplicate aggregator *types* are rejected regardless of any
 /// inline condition, and the list is capped at [`MAX_AGGREGATIONS`].
 fn parse_aggregation_list(agg_str: &str) -> ValkeyResult<SmallVec<[AggregationListElement; 2]>> {
@@ -734,7 +731,7 @@ fn parse_aggregation_modifiers(
 }
 
 /// Build the per-aggregator configs of an AGGREGATION clause from the parsed
-/// list elements. Each element's inline condition (`countif(>5)`, parsed by
+/// list elements. Each element's inline condition (`countif>5`, parsed by
 /// [`parse_aggregation_list_element`]) is passed straight through to
 /// [`AggregatorConfig::new`], which rejects a condition-requiring aggregator
 /// left without one and a condition attached to an aggregator that doesn't
@@ -1089,7 +1086,7 @@ fn parse_numkeys_and_keys(args: &mut CommandArgIterator) -> ValkeyResult<Vec<Val
 /// by the single `bucketDuration` and modifiers that every key shares.
 ///
 /// Each list is the same comma-separated form TS.RANGE accepts (`avg`, `min,max`,
-/// `countif(>5)`), so a key contributes one output column per aggregator it names.
+/// `countif>5`), so a key contributes one output column per aggregator it names.
 fn parse_nrange_aggregation_options(
     args: &mut CommandArgIterator,
     key_count: usize,
@@ -1170,7 +1167,7 @@ fn parse_align_for_nrange_aggregation(
 ///   [FILTER_BY_VALUE min max]
 ///   [COUNT count]
 ///   [[ALIGN align] AGGREGATION aggregators [aggregators ...] bucketDuration
-///     [BUCKETTIMESTAMP bt] [EMPTY]]
+///   [BUCKETTIMESTAMP bt] [EMPTY]]
 pub(super) fn parse_nrange_options(args: &mut CommandArgIterator) -> ValkeyResult<NRangeOptions> {
     const NRANGE_OPTION_ARGS: [CommandArgToken; 7] = [
         CommandArgToken::Align,
@@ -2001,7 +1998,7 @@ mod tests {
     #[test]
     fn test_inline_aggregation_condition() {
         // each element carries its own condition
-        let list = parse_aggregation_list("countif(>5),sumif(<=2.5)").unwrap();
+        let list = parse_aggregation_list("countif>5,sumif<=2.5").unwrap();
         assert_eq!(list[0].0, AggregationType::CountIf);
         let cond = list[0].1.unwrap();
         assert_eq!(cond.operator, ComparisonOperator::GreaterThan);
@@ -2012,7 +2009,7 @@ mod tests {
         assert_eq!(cond.value, 2.5);
 
         // mixed: inline condition alongside a plain (uncontitional) element
-        let list = parse_aggregation_list("countif(>5),avg").unwrap();
+        let list = parse_aggregation_list("countif>5,avg").unwrap();
         assert!(list[0].1.is_some());
         assert!(list[1].1.is_none());
 
@@ -2025,25 +2022,23 @@ mod tests {
             ("==5", ComparisonOperator::Equal),
             ("!=5", ComparisonOperator::NotEqual),
         ] {
-            let list = parse_aggregation_list(&format!("countif({text})")).unwrap();
+            let list = parse_aggregation_list(&format!("countif{text}")).unwrap();
             assert_eq!(list[0].1.unwrap().operator, expected, "operator {text}");
         }
 
         // negative and fractional values
-        let list = parse_aggregation_list("sumif(<-3.5)").unwrap();
+        let list = parse_aggregation_list("sumif<-3.5").unwrap();
         assert_eq!(list[0].1.unwrap().value, -3.5);
     }
 
     #[test]
     fn test_inline_aggregation_condition_errors() {
-        assert!(parse_aggregation_list("countif(>5").is_err()); // missing ')'
-        assert!(parse_aggregation_list("(>5)").is_err()); // empty aggregator name
-        assert!(parse_aggregation_list("countif()").is_err()); // empty condition
-        assert!(parse_aggregation_list("countif(5)").is_err()); // missing operator
-        assert!(parse_aggregation_list("countif(>bogus)").is_err()); // bad value
-        assert!(parse_aggregation_list("bogus(>5)").is_err()); // unknown aggregator
+        assert!(parse_aggregation_list(">5").is_err()); // empty aggregator name
+        assert!(parse_aggregation_list("countif5").is_err()); // no operator char -> unknown aggregator name
+        assert!(parse_aggregation_list("countif>bogus").is_err()); // bad value
+        assert!(parse_aggregation_list("bogus>5").is_err()); // unknown aggregator
         // duplicate detection ignores inline condition differences
-        let err = parse_aggregation_list("countif(>5),countif(<10)").unwrap_err();
+        let err = parse_aggregation_list("countif>5,countif<10").unwrap_err();
         assert!(err.to_string().contains("duplicate aggregation 'countif'"));
     }
 
@@ -2051,7 +2046,7 @@ mod tests {
     fn test_condition_distribution() {
         // each filter-capable element carries its own inline condition
         let configs =
-            build_aggregator_configs(parse_aggregation_list("countif(>5),avg,sum(>5)").unwrap())
+            build_aggregator_configs(parse_aggregation_list("countif>5,avg,sum>5").unwrap())
                 .unwrap();
         assert_eq!(configs.len(), 3);
         assert!(configs[0].filter().is_some()); // countif
@@ -2071,7 +2066,7 @@ mod tests {
 
     #[test]
     fn test_inline_condition_on_non_filterable_aggregator_is_an_error() {
-        let elements = parse_aggregation_list("avg(>5)").unwrap();
+        let elements = parse_aggregation_list("avg>5").unwrap();
         let err = build_aggregator_configs(elements).unwrap_err();
         assert!(err.to_string().contains("does not support a filter"));
     }

--- a/tests/compat/test_compat_multi_aggregation.py
+++ b/tests/compat/test_compat_multi_aggregation.py
@@ -549,13 +549,13 @@ class TestDivergences:
         with pytest.raises(ResponseError):
             diff.subject.execute_command(*args)
 
-    @pytest.mark.parametrize("aggregators", ["countif(>15),avg", "avg,rate"])
+    @pytest.mark.parametrize("aggregators", ["countif>15,avg", "avg,rate"])
     def test_extension_list_elements_are_a_superset(self, diff, range_cmd, aggregators):
         """DIV-0038: our list-element grammar accepts names and an inline
-        `name(condition)` form that RTS has no vocabulary for.
+        `nameop value` condition form that RTS has no vocabulary for.
 
-        `rate` is not an RTS aggregator, and the parenthesized per-element
-        condition (`countif(>15)`) has no RTS equivalent — both answer "Unknown
+        `rate` is not an RTS aggregator, and the inline per-element condition
+        (`countif>15`) has no RTS equivalent — both answer "Unknown
         aggregation type". An accepted-input superset, so per-engine.
         """
         mk_populated(diff, "ma:ext", MULTI_SAMPLES)

--- a/tests/test_ts_createrule.py
+++ b/tests/test_ts_createrule.py
@@ -125,7 +125,7 @@ class TestTSCreateRule(ValkeyTimeSeriesTestCaseBase):
 
             result = self.client.execute_command(
                 "TS.CREATERULE", source_key, key,
-                "AGGREGATION", f"{agg}(<100)", "60000"
+                "AGGREGATION", f"{agg}<100", "60000"
             )
 
             assert result == b"OK"
@@ -142,7 +142,7 @@ class TestTSCreateRule(ValkeyTimeSeriesTestCaseBase):
 
     def test_create_rule_missing_required_condition(self):
         """Filtered aggregators (countif, sumif, all, any, none, share) require
-        an inline (op value) condition; omitting it is an error."""
+        an inline op value condition; omitting it is an error."""
         source_key = "test:source_missing_cond"
         dest_key = "test:dest_missing_cond"
 
@@ -157,7 +157,7 @@ class TestTSCreateRule(ValkeyTimeSeriesTestCaseBase):
 
     def test_create_rule_disallowed_condition(self):
         """Aggregators that don't support conditions (e.g. avg) must not
-        carry an inline (op value)."""
+        carry an inline op value."""
         source_key = "test:source_bad_cond"
         dest_key = "test:dest_bad_cond"
 
@@ -167,7 +167,7 @@ class TestTSCreateRule(ValkeyTimeSeriesTestCaseBase):
         with pytest.raises(ResponseError, match="TSDB: aggregation type does not support a filter condition"):
             self.client.execute_command(
                 "TS.CREATERULE", source_key, dest_key,
-                "AGGREGATION", "avg(>5)", "60000"
+                "AGGREGATION", "avg>5", "60000"
             )
 
     def test_disallow_replace_existing(self):

--- a/tests/test_ts_mrange.py
+++ b/tests/test_ts_mrange.py
@@ -139,15 +139,15 @@ class TestTimeSeriesMRange(ValkeyTimeSeriesTestCaseBase):
             assert val > 40  # Sum of two temp sensors should be > 40
 
     def test_mrange_groupby_reduce_with_inline_condition(self):
-        """GROUPBY/REDUCE reducers take the same inline (op value) condition
-        syntax as AGGREGATION, e.g. REDUCE countif(>5)."""
+        """GROUPBY/REDUCE reducers take the same inline op value condition
+        syntax as AGGREGATION, e.g. REDUCE countif>5."""
         self.setup_data()
 
         result = self.client.execute_command(
             'TS.MRANGE', self.start_ts, self.start_ts + 100,
             'FILTER', 'sensor=temp',
             'GROUPBY', 'sensor',
-            'REDUCE', 'countif(>0)')
+            'REDUCE', 'countif>0')
 
         assert len(result) == 1
         for ts, val in result[0][2]:
@@ -168,7 +168,7 @@ class TestTimeSeriesMRange(ValkeyTimeSeriesTestCaseBase):
             self.client.execute_command(
                 'TS.MRANGE', self.start_ts, self.start_ts + 100,
                 'FILTER', 'sensor=temp',
-                'GROUPBY', 'sensor', 'REDUCE', 'avg(>0)')
+                'GROUPBY', 'sensor', 'REDUCE', 'avg>0')
 
     def test_mrange_empty(self):
 

--- a/tests/test_ts_multi_aggregation.py
+++ b/tests/test_ts_multi_aggregation.py
@@ -79,8 +79,8 @@ class TestTimeSeriesMultiAggregation(ValkeyTimeSeriesTestCaseBase):
 
         result = self.client.execute_command(
             'TS.RANGE', 'ts1', '-', '+',
-            'AGGREGATION', 'countif(>15),avg', 1000)
-        # bucket [1000,2000): countif(>15)=1 (30), avg=20
+            'AGGREGATION', 'countif>15,avg', 1000)
+        # bucket [1000,2000): countif>15=1 (30), avg=20
         assert result[0] == [1000, b'1', b'20']
 
     def test_multi_aggregation_errors(self):
@@ -106,7 +106,7 @@ class TestTimeSeriesMultiAggregation(ValkeyTimeSeriesTestCaseBase):
         with pytest.raises(ResponseError, match='does not support a filter'):
             self.client.execute_command(
                 'TS.RANGE', 'ts1', '-', '+',
-                'AGGREGATION', 'avg(>5),max', 1000)
+                'AGGREGATION', 'avg>5,max', 1000)
 
     def test_mrange_multi_aggregation(self):
         self.setup_mrange_data()

--- a/tests/test_ts_nrange.py
+++ b/tests/test_ts_nrange.py
@@ -188,7 +188,7 @@ class TestTimeSeriesNRange(ValkeyTimeSeriesTestCaseBase):
         self.client.execute_command('TS.MADD', 'b', 1000, 4, 'b', 1100, 6, 'b', 2000, 2)
 
         result = self.client.execute_command(
-            'TS.NRANGE', 2, 'a', 'b', '-', '+', 'AGGREGATION', 'countif(>5)', 'range', 1000)
+            'TS.NRANGE', 2, 'a', 'b', '-', '+', 'AGGREGATION', 'countif>5', 'range', 1000)
 
         assert rows(result) == [
             (1000, [1.0, 2.0]),

--- a/tests/test_ts_range.py
+++ b/tests/test_ts_range.py
@@ -636,7 +636,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'all_true', 0, 5000,
             'ALIGN', 0,
-            'AGGREGATION', 'ALL(>=1)', 5000,
+            'AGGREGATION', 'ALL>=1', 5000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -658,7 +658,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'all_has_zero', 0, 5000,
             'ALIGN', 0,
-            'AGGREGATION', 'ALL(!=0)', 5000,
+            'AGGREGATION', 'ALL!=0', 5000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -681,7 +681,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'all_multi_bucket', 0, 6000,
             'ALIGN', 0,
-            'AGGREGATION', 'ALL(<500)', 2000,
+            'AGGREGATION', 'ALL<500', 2000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -705,7 +705,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'any_true', 0, 5000,
             'ALIGN', 0,
-            'AGGREGATION', 'ANY(>=1)', 5000,
+            'AGGREGATION', 'ANY>=1', 5000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -727,7 +727,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'any_false', 0, 5000,
             'ALIGN', 0,
-            'AGGREGATION', 'ANY(!=0)', 5000,
+            'AGGREGATION', 'ANY!=0', 5000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -753,7 +753,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'any_multi_bucket', 0, 6000,
             'ALIGN', 0,
-            'AGGREGATION', 'ANY(>0)', 2000,
+            'AGGREGATION', 'ANY>0', 2000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -777,7 +777,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'sumif_all', 0, 4000,
             'ALIGN', 0,
-            'AGGREGATION', 'SUM(>0)', 4000,
+            'AGGREGATION', 'SUM>0', 4000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -798,7 +798,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'sumif_none', 0, 4000,
             'ALIGN', 0,
-            'AGGREGATION', 'SUMIF(>10)', 4000,
+            'AGGREGATION', 'SUMIF>10', 4000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -820,7 +820,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'sumif_mixed', 0, 5000,
             'ALIGN', 0,
-            'AGGREGATION', 'SUM(>5)', 5000,
+            'AGGREGATION', 'SUM>5', 5000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -848,7 +848,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'sumif_multi', 0, 6000,
             'ALIGN', 0,
-            'AGGREGATION', 'SUM(>=5)', 2000,
+            'AGGREGATION', 'SUM>=5', 2000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -872,7 +872,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'countif_all', 0, 4000,
             'ALIGN', 0,
-            'AGGREGATION', 'COUNTIF(>0)', 4000,
+            'AGGREGATION', 'COUNTIF>0', 4000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -893,7 +893,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'countif_none', 0, 4000,
             'ALIGN', 0,
-            'AGGREGATION', 'COUNT(>10)', 4000,
+            'AGGREGATION', 'COUNT>10', 4000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -915,7 +915,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'countif_mixed', 0, 5000,
             'ALIGN', 0,
-            'AGGREGATION', 'COUNT(<=5)', 5000,
+            'AGGREGATION', 'COUNT<=5', 5000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -944,7 +944,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'countif_multi', 0, 6000,
             'ALIGN', 0,
-            'AGGREGATION', 'COUNTIF(>=5)', 2000,
+            'AGGREGATION', 'COUNTIF>=5', 2000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -967,21 +967,21 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         # Test equality
         result_eq = self.client.execute_command(
             'TS.RANGE', 'countif_ops', 0, 4000,
-            'AGGREGATION', 'COUNTIF(==5)', 4000
+            'AGGREGATION', 'COUNTIF==5', 4000
         )
         assert float(result_eq[0][1]) == pytest.approx(2.0)
 
         # Test not equal
         result_neq = self.client.execute_command(
             'TS.RANGE', 'countif_ops', 0, 4000,
-            'AGGREGATION', 'COUNTIF(!=5)', 4000
+            'AGGREGATION', 'COUNTIF!=5', 4000
         )
         assert float(result_neq[0][1]) == pytest.approx(1.0)
 
         # Test less than
         result_lt = self.client.execute_command(
             'TS.RANGE', 'countif_ops', 0, 4000,
-            'AGGREGATION', 'COUNTIF(<10)', 4000
+            'AGGREGATION', 'COUNTIF<10', 4000
         )
         assert float(result_lt[0][1]) == pytest.approx(2.0)
 
@@ -1067,7 +1067,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'none_true', 0, 5000,
             'ALIGN', 0,
-            'AGGREGATION', 'NONE(>0)', 5000,
+            'AGGREGATION', 'NONE>0', 5000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -1089,7 +1089,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'none_false', 0, 5000,
             'ALIGN', 0,
-            'AGGREGATION', 'NONE(>=1)', 5000,
+            'AGGREGATION', 'NONE>=1', 5000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -1115,7 +1115,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'none_multi_bucket', 0, 6000,
             'ALIGN', 0,
-            'AGGREGATION', 'NONE(>0)', 2000,
+            'AGGREGATION', 'NONE>0', 2000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -1139,7 +1139,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'share_all', 0, 5000,
             'ALIGN', 0,
-            'AGGREGATION', 'SHARE(>0)', 5000,
+            'AGGREGATION', 'SHARE>0', 5000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -1160,7 +1160,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'share_none', 0, 5000,
             'ALIGN', 0,
-            'AGGREGATION', 'SHARE(!=0)', 5000,
+            'AGGREGATION', 'SHARE!=0', 5000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -1182,7 +1182,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'share_mixed', 0, 5000,
             'ALIGN', 0,
-            'AGGREGATION', 'SHARE(>0)', 5000,
+            'AGGREGATION', 'SHARE>0', 5000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -1208,7 +1208,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         result = self.client.execute_command(
             'TS.RANGE', 'share_multi_bucket', 0, 6000,
             'ALIGN', 0,
-            'AGGREGATION', 'SHARE(>0)', 2000,
+            'AGGREGATION', 'SHARE>0', 2000,
             'BUCKETTIMESTAMP', 'START'
         )
 
@@ -1483,7 +1483,7 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
             self.client.execute_command('TS.RANGE', 'ts1', '-', '+', 'FILTER_BY_VALUE', 1000, 'b')
 
     def test_aggregation_condition_errors(self):
-        """Filtered aggregators require an inline (op value) condition;
+        """Filtered aggregators require an inline op value condition;
         non-filtered aggregators must not be given one."""
         self.client.execute_command('TS.CREATE', 'ts1')
         self.client.execute_command('TS.ADD', 'ts1', 1000, 10.0)
@@ -1498,10 +1498,10 @@ class TestTimeSeriesRange(ValkeyTimeSeriesTestCaseBase):
         for agg in ['avg', 'min', 'max', 'first', 'last', 'range', 'std.p']:
             with pytest.raises(ResponseError, match="TSDB: aggregation type does not support a filter condition"):
                 self.client.execute_command(
-                    'TS.RANGE', 'ts1', '-', '+', 'AGGREGATION', f'{agg}(>5)', 1000)
+                    'TS.RANGE', 'ts1', '-', '+', 'AGGREGATION', f'{agg}>5', 1000)
 
         # count/sum accept an inline condition optionally
         for agg in ['count', 'sum']:
             result = self.client.execute_command(
-                'TS.RANGE', 'ts1', '-', '+', 'AGGREGATION', f'{agg}(>5)', 1000)
+                'TS.RANGE', 'ts1', '-', '+', 'AGGREGATION', f'{agg}>5', 1000)
             assert len(result) == 1

--- a/tests/test_ts_read.py
+++ b/tests/test_ts_read.py
@@ -962,7 +962,7 @@ class TestTsReadConditionValidation(TsReadTestBase):
         """A fused `CONDITION >500` is an invalid operator, not wrong-arity.
 
         `TS.READ` has no reason to accept the fused spelling the inline per-aggregator form uses
-        (`countif(>5)`), which exists only because an aggregator name and its condition must share
+        (`countif>5`), which exists only because an aggregator name and its condition must share
         one token. A spaced clause matches every other TS.READ option.
         """
         self.seed("k", [100])


### PR DESCRIPTION
- Updated documentation and command implementations to change the inline condition syntax for aggregators from `aggregator(op value)` to `aggregatorop value`.
- Adjusted tests to reflect the new syntax, ensuring compatibility with the updated command structure.
- This change affects commands such as `TS.CREATERULE`, `TS.MRANGE`, `TS.NRANGE`, `TS.RANGE`, and `TS.READ`, among others.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated time-series command documentation to use inline aggregation conditions, such as `countif>5`, instead of parenthesized syntax like `countif(>5)`.
  - Revised examples, argument descriptions, and error guidance across range, rule, and read commands.

- **Bug Fixes**
  - Updated command parsing to recognize inline operator-and-value conditions for aggregations and grouped reductions.

- **Tests**
  - Updated compatibility and time-series tests to validate the new inline condition syntax and related error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->